### PR TITLE
Add @desert-ant-labs/core npm package (shared JS runtime for the model SDKs)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,88 @@
+name: Publish npm
+
+# Publish the @desert-ant-labs/core npm package to npm when a release tag
+# (vX.Y.Z) is pushed AND the package sources (js/) changed since the previous
+# tag. Mirrors publish-android.yml: pure JS, no build step, so it just runs the
+# tests then `mise run publish-npm`. The token comes from the `npm` GitHub
+# Environment secret.
+#
+# Environment `npm` secret (set with `gh secret set --env npm`):
+#   NPM_TOKEN  npm automation token with publish rights on @desert-ant-labs
+#
+# The published version is single-sourced in js/package.json; the tag must match
+# it (the verify step fails otherwise). Bump with `mise run set-version X.Y.Z`
+# (which also bumps the Android artifact), commit, then tag vX.Y.Z.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: publish-npm-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: js/ changed since previous tag?
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags, to diff against the previous tag
+
+      - id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+          if [ -z "$PREV" ]; then
+            echo "no previous tag; treating as a js change."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "diffing ${PREV}..${TAG} for js/ changes"
+          if git diff --name-only "$PREV" "$TAG" -- js/ | grep -q .; then
+            echo "js/ changed since ${PREV}; will publish."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no js/ changes since ${PREV}; skipping publish."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    name: Publish @desert-ant-labs/core to npm
+    needs: detect
+    if: needs.detect.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v4
+
+      # Just the mise binary; the publish-npm task pulls Node on demand.
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(mise run check-version-npm)"
+          [ "${GITHUB_REF_NAME#v}" = "$VERSION" ] || {
+            echo "tag ${GITHUB_REF_NAME} != js/package.json version ${VERSION}" >&2
+            exit 1
+          }
+          echo "publishing @desert-ant-labs/core@${VERSION}"
+
+      - name: Publish to npm
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: mise run publish-npm

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ kotlin/local.properties
 *.xcodeproj
 Package.resolved
 Vendor/
+js/node_modules/
+js/LICENSE.md

--- a/README.md
+++ b/README.md
@@ -211,25 +211,40 @@ testing consumers). The version is single-sourced in `kotlin/build.gradle.kts`
 
 ### Releasing
 
-Releases are tag-driven. Bump the version, commit to `main`, then push a
-matching `vX.Y.Z` tag:
+The repo ships two published sibling artifacts alongside the SwiftPM package:
+the `ai.desertant:core` Android library (`kotlin/`) and the
+`@desert-ant-labs/core` npm package (`js/`, the shared JavaScript runtime the
+model node packages build on). Both are versioned in lockstep with the SwiftPM
+package and released the same way: tag-driven.
+
+Bump the versions, commit to `main`, then push a matching `vX.Y.Z` tag:
 
 ```bash
-mise run set-version 0.3.1   # updates kotlin/build.gradle.kts (+ this README)
+mise run set-version 0.3.1   # bumps kotlin/build.gradle.kts, js/package.json, README
 # commit and merge to main
 git tag v0.3.1 && git push origin v0.3.1
 ```
 
-The `Publish Android` workflow (`.github/workflows/publish-android.yml`) then
-runs `mise run publish-android` for you, but only when `kotlin/` actually
-changed since the previous tag (a Swift-only release skips it, and Maven Central
-versions are immutable so a version never republishes). It first checks that the
-tag matches the `kotlin/build.gradle.kts` version. Credentials come from the
-`maven-central` GitHub Environment secrets (`MAVEN_CENTRAL_USERNAME`,
-`MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`,
-`SIGNING_IN_MEMORY_KEY_PASSWORD`), so no local secrets are needed to cut a
-release. To publish by hand instead, run `mise run publish-android` with those
-values exported (for example via a gitignored `mise.local.toml`).
+Two workflows react to the tag, each independent:
+
+- `Publish Android` (`.github/workflows/publish-android.yml`) runs
+  `mise run publish-android` when `kotlin/` changed since the previous tag.
+  Credentials: the `maven-central` GitHub Environment secrets
+  (`MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`,
+  `SIGNING_IN_MEMORY_KEY_PASSWORD`).
+- `Publish npm` (`.github/workflows/publish-npm.yml`) runs `mise run publish-npm`
+  when `js/` changed since the previous tag. Credentials: the `npm` GitHub
+  Environment secret (`NPM_TOKEN`).
+
+Each job only publishes when its own directory actually changed (a Swift-only
+release skips both; both npm and Maven Central versions are immutable so nothing
+ever republishes), and each first checks the tag matches its artifact version.
+No local secrets are needed to cut a release. To publish by hand instead, run
+`mise run publish-android` / `mise run publish-npm` with the credentials
+exported (for example via a gitignored `mise.local.toml`).
+
+The JavaScript runtime is documented in [`js/README.md`](js/README.md); build
+and test it locally with `mise run test-js`.
 
 ## Android wiring
 

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,43 @@
+# @desert-ant-labs/core
+
+Shared JavaScript runtime for [Desert Ant Labs](https://desertant.com) on-device
+model SDKs. The per-model node packages (`@desert-ant-labs/shapes`,
+`@desert-ant-labs/emo`, `@desert-ant-labs/redact`, ...) build their browser and
+Node entries on these model-agnostic pieces, so each model ships only its own
+decode + public API.
+
+Not meant to be used directly; it is the common core the model packages depend
+on.
+
+## What it provides
+
+Browser-safe entry (`@desert-ant-labs/core`, no `node:*`):
+
+- `installLiteRtHost(...)` - installs the LiteRT.js host the wasm core drives
+  through `globalThis[hostGlobal]`: named-tensor `createSession` / `run` with the
+  correct dtype marshalling and LiteRT.js manual memory management.
+- `loadLiteRt(...)` / `assertBrowserRuntime(...)` - load `@litertjs/core` once
+  per process (with an install hint) and guard against running the wasm runtime
+  in plain Node.
+- `fetchModelFrom(baseUrl, files)` - the self-hosted (`modelBaseUrl`) opt-out.
+- `browserSetup` / `browserWasmDir` / `browserReadModelSource` /
+  `browserCacheRoot` - the browser half of a model's `#platform` seam.
+- `FfiReader` - big-endian cursor over the length-prefixed FFIBuffer payload the
+  native core returns (the JS counterpart of Kotlin's `FfiReader`).
+
+Node entry (`@desert-ant-labs/core/node`, uses `node:*` + koffi):
+
+- `loadNative({ here, packageName, coreName, symbols })` - resolves the prebuilt
+  Swift core under `native/<platform>-<arch>`, loads the LiteRT runtime first,
+  binds the model's C ABI with koffi, and returns `callAsync` + `decodeResult` +
+  cache-path helpers.
+- `nodeSetup` / `nodeWasmDir` / `nodeReadModelSource` / `nodeCacheRoot` - the
+  Node half of the `#platform` seam.
+
+`@litertjs/core` and `koffi` are optional peer dependencies: the browser path
+needs `@litertjs/core`, the native Node path needs `koffi`, and neither is
+required just to import the package.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0).

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -1,0 +1,53 @@
+// Type declarations for the browser-safe entry of @desert-ant-labs/core.
+
+/** A named tensor exchanged with the wasm core / LiteRT.js host. */
+export interface HostTensor {
+  data: Uint8Array;
+  dims: number[];
+  type: "int32" | "float32" | "uint8" | string;
+}
+
+/** Big-endian cursor over the length-prefixed FFIBuffer payload the native core
+ *  returns (the JS counterpart of Kotlin's FfiReader and Swift's FFIWriter). */
+export class FfiReader {
+  constructor(bytes: Uint8Array);
+  u32(): number;
+  i32(): number;
+  f64(): number;
+  bytes(n: number): Uint8Array;
+  str(): string;
+  readonly offset: number;
+  readonly remaining: number;
+}
+
+export function loadLiteRt(options: {
+  litert?: any;
+  wasmDir?: string;
+  defaultWasmDir: () => Promise<string>;
+  packageName: string;
+}): Promise<any>;
+
+export function assertBrowserRuntime(options: { packageName: string; litert?: any }): void;
+
+export function installLiteRtHost(options: {
+  hostGlobal: string;
+  accelerator?: "wasm" | "webgpu" | string;
+  loadAndCompile: (data: Uint8Array, opts: { accelerator: string }) => Promise<any>;
+  Tensor: new (data: any, dims: number[]) => any;
+  readModelSource: (source: any) => Promise<any>;
+}): { setModel: (model: any) => void };
+
+export function fetchModelFrom(
+  baseUrl: string,
+  files: { meta: string; model: string },
+): Promise<{ metaJSON: string; modelBytes: Uint8Array }>;
+
+export function browserSetup(options: {
+  hostGlobal: string;
+  exportsGlobal: string;
+  init: () => Promise<{ init: (arg: object) => Promise<unknown> }>;
+}): Promise<any>;
+
+export function browserWasmDir(): Promise<string>;
+export function browserReadModelSource(source: any): Promise<any>;
+export function browserCacheRoot(): Promise<string>;

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,16 @@
+// @desert-ant-labs/core: shared JavaScript runtime for Desert Ant Labs on-device
+// model SDKs. This entry is browser-safe (no `node:*`): the LiteRT.js host and
+// session contract, the LiteRT loader/guards, the self-hosted-model fetch
+// helper, the browser platform seam, and the FFI reader. The node-only native
+// loader and node platform seam live in the "./node" subpath.
+export { FfiReader } from "./src/ffi.js";
+export {
+  loadLiteRt,
+  assertBrowserRuntime,
+  installLiteRtHost,
+  fetchModelFrom,
+  browserSetup,
+  browserWasmDir,
+  browserReadModelSource,
+  browserCacheRoot,
+} from "./src/litert.js";

--- a/js/node.d.ts
+++ b/js/node.d.ts
@@ -1,0 +1,35 @@
+// Type declarations for the node-only entry of @desert-ant-labs/core/node.
+import { FfiReader } from "./index.js";
+export { FfiReader };
+
+export interface NativeCore {
+  koffi: any;
+  /** Lazily loads + binds the native library on first property access. */
+  lib: Record<string, any>;
+  callAsync: (fn: any, ...args: any[]) => Promise<any>;
+  /** Decode a result pointer into a reader positioned at the payload start. */
+  decodeResult: (ptr: any) => FfiReader;
+  version: string;
+  nativeDir: () => string;
+  defaultCacheRoot: () => string;
+  defaultModelDirectory: (cacheRoot: string) => string;
+}
+
+export function loadNative(options: {
+  here: string;
+  packageName: string;
+  coreName: string;
+  symbols: Record<string, string>;
+  targets?: string[];
+}): NativeCore;
+
+export function nodeSetup(options: {
+  hostGlobal: string;
+  exportsGlobal: string;
+  instantiate: () => Promise<{ instantiate: Function }>;
+  nodePlatform: () => Promise<{ defaultNodeSetup: Function }>;
+}): Promise<any>;
+
+export function nodeWasmDir(): Promise<string>;
+export function nodeReadModelSource(source: any): Promise<any>;
+export function nodeCacheRoot(): Promise<string>;

--- a/js/node.js
+++ b/js/node.js
@@ -1,0 +1,12 @@
+// @desert-ant-labs/core/node: the node-only pieces for a model package's native
+// server-side entry. The native koffi loader (loadNative, callAsync,
+// decodeResult) plus the node half of the platform seam. Importing this pulls in
+// `node:*`, so browser bundles must import from "@desert-ant-labs/core" instead.
+export { loadNative } from "./src/native.js";
+export {
+  nodeSetup,
+  nodeWasmDir,
+  nodeReadModelSource,
+  nodeCacheRoot,
+} from "./src/platform-node.js";
+export { FfiReader } from "./src/ffi.js";

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@desert-ant-labs/core",
+  "version": "0.3.0",
+  "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
+  "type": "module",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "homepage": "https://github.com/Desert-Ant-Labs/desert-ant-core",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Desert-Ant-Labs/desert-ant-core.git",
+    "directory": "js"
+  },
+  "keywords": [
+    "on-device",
+    "litert",
+    "wasm",
+    "koffi",
+    "ffi",
+    "isomorphic",
+    "desert-ant-labs"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./index.js",
+  "browser": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./node": {
+      "types": "./node.d.ts",
+      "default": "./node.js"
+    }
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "node.js",
+    "node.d.ts",
+    "src",
+    "LICENSE.md",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "peerDependencies": {
+    "@litertjs/core": ">=2.1.0",
+    "koffi": ">=2.9.0"
+  },
+  "peerDependenciesMeta": {
+    "@litertjs/core": {
+      "optional": true
+    },
+    "koffi": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@litertjs/core": "^2.5.2"
+  }
+}

--- a/js/src/ffi.js
+++ b/js/src/ffi.js
@@ -1,0 +1,57 @@
+// FfiReader: a big-endian cursor over the length-prefixed typed buffer the
+// native core returns. It is the JavaScript counterpart of Kotlin's FfiReader
+// and the Swift `FFIWriter`/`FFIBuffer` format in desert-ant-core: values are
+// big-endian, doubles are IEEE-754, and strings are a uint32 byte length
+// followed by UTF-8. A model reads its own payload schema off this cursor.
+//
+// Uses DataView (not node Buffer), so it works unchanged in the browser too;
+// the per-model node package uses it via `decodeResult` (native.js), which
+// strips the outer uint32 length prefix and hands back a reader over the body.
+export class FfiReader {
+  constructor(bytes) {
+    this._bytes = bytes;
+    this._view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    this._o = 0;
+  }
+
+  u32() {
+    const v = this._view.getUint32(this._o, false);
+    this._o += 4;
+    return v;
+  }
+
+  i32() {
+    const v = this._view.getInt32(this._o, false);
+    this._o += 4;
+    return v;
+  }
+
+  f64() {
+    const v = this._view.getFloat64(this._o, false);
+    this._o += 8;
+    return v;
+  }
+
+  /** Read `n` raw bytes (a view into the underlying buffer; copy if retaining). */
+  bytes(n) {
+    const v = this._bytes.subarray(this._o, this._o + n);
+    this._o += n;
+    return v;
+  }
+
+  /** Read a uint32-length-prefixed UTF-8 string. */
+  str() {
+    const n = this.u32();
+    const s = new TextDecoder().decode(this._bytes.subarray(this._o, this._o + n));
+    this._o += n;
+    return s;
+  }
+
+  get offset() {
+    return this._o;
+  }
+
+  get remaining() {
+    return this._bytes.length - this._o;
+  }
+}

--- a/js/src/litert.js
+++ b/js/src/litert.js
@@ -1,0 +1,196 @@
+// The shared browser/WebAssembly runtime for the model node packages: it owns
+// the @litertjs/core (LiteRT.js) session behind the generic tensor contract the
+// wasm core (JSInferenceSession) calls, loads LiteRT.js once per process, and
+// carries the browser half of the platform seam. A model package supplies only
+// its host-global name, its dist entry points, and its self-hosted file names.
+//
+// Browser-safe: no `node:*` imports. The node-only native path lives in
+// node.js.
+
+// @litertjs/core is loaded once per process; its Wasm runtime initializes a
+// single time. `loadLiteRt` memoizes both the module import and the runtime
+// load across every model in the process (LiteRT.js is itself a singleton).
+let liteRtReady;
+
+async function importLiteRt(packageName) {
+  try {
+    return await import("@litertjs/core");
+  } catch (cause) {
+    // Only surface the install hint when @litertjs/core is genuinely absent;
+    // rethrow anything else (a real error from inside LiteRT.js) unchanged.
+    const missing =
+      cause?.code === "ERR_MODULE_NOT_FOUND" ||
+      cause?.code === "MODULE_NOT_FOUND" ||
+      String(cause?.message ?? "").includes("@litertjs/core");
+    if (!missing) throw cause;
+    throw new Error(
+      `${packageName} browser runtime requires @litertjs/core. ` +
+        `Install it with: npm i ${packageName} @litertjs/core. ` +
+        `If you already bundle LiteRT.js yourself, pass it to load({ litert }). ` +
+        `(In Node, import the package normally to use the native server-side build instead.)`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Load @litertjs/core and ensure its Wasm runtime is initialized (once per
+ * process). Returns the LiteRT.js module ({ loadAndCompile, Tensor, ... }).
+ *
+ * @param {object} o
+ * @param {any} [o.litert] caller-injected module (tests/custom builds)
+ * @param {string} [o.wasmDir] explicit runtime directory (overrides default)
+ * @param {() => Promise<string>} o.defaultWasmDir where LiteRT.js loads its wasm
+ * @param {string} o.packageName consumer package name for the install hint
+ */
+export async function loadLiteRt({ litert, wasmDir, defaultWasmDir, packageName }) {
+  const lrt = litert ?? (await importLiteRt(packageName));
+  liteRtReady ??= lrt.loadLiteRt(wasmDir ?? (await defaultWasmDir()));
+  await liteRtReady;
+  return lrt;
+}
+
+/**
+ * LiteRT.js loads its Wasm runtime through the DOM (a <script> tag) or a Web
+ * Worker (importScripts); it has no plain-Node loader. So the default (wasm)
+ * build can be imported during SSR but cannot run inference in Node. Detect that
+ * up front and point at the native server build instead of failing deep inside
+ * LiteRT.js with a cryptic `document is not defined`.
+ */
+export function assertBrowserRuntime({ packageName, litert }) {
+  if (litert) return; // caller injected a working module; trust it
+  const hasDom = typeof document !== "undefined";
+  const hasWorker = typeof importScripts === "function";
+  if (hasDom || hasWorker) return;
+  throw new Error(
+    `${packageName}: the default import runs the browser WebAssembly runtime ` +
+      `(LiteRT.js), which needs a browser/Worker environment and can't ` +
+      `initialize in plain Node. For server-side inference import the native ` +
+      `build instead: import from "${packageName}/native". (The default import ` +
+      `is still safe to bundle for server-side rendering; only calling load() ` +
+      `in Node needs the native build.)`,
+  );
+}
+
+/**
+ * Install the LiteRT.js host the wasm core (JSInferenceSession) drives through
+ * `globalThis[hostGlobal]`. Both sides exchange named tensors as
+ * `{ name: { data: Uint8Array, dims: number[], type } }`; LiteRT.js infers each
+ * dtype from the typed array. Uses LiteRT.js manual memory management: results
+ * and any GPU->wasm copies are deleted along with the input tensors made here.
+ *
+ * Returns `{ setModel }` so the caller's `modelBaseUrl` opt-out can compile the
+ * model directly and hand it to the same `run` closure.
+ *
+ * @param {object} o
+ * @param {string} o.hostGlobal e.g. "__ShapesHost"
+ * @param {string} o.accelerator "wasm" (default) or "webgpu"
+ * @param {(data: Uint8Array, opts: object) => Promise<any>} o.loadAndCompile
+ * @param {new (data: any, dims: number[]) => any} o.Tensor
+ * @param {(source: any) => Promise<any>} o.readModelSource path (node) -> bytes
+ */
+export function installLiteRtHost({ hostGlobal, accelerator = "wasm", loadAndCompile, Tensor, readModelSource }) {
+  let model;
+
+  const typedArray = (t) => {
+    const bytes = t.data.slice(); // own, aligned buffer
+    switch (t.type) {
+      case "int32":
+        return new Int32Array(bytes.buffer);
+      case "float32":
+        return new Float32Array(bytes.buffer);
+      case "uint8":
+        return new Uint8Array(bytes.buffer);
+      default:
+        throw new Error(`unsupported tensor type: ${t.type}`);
+    }
+  };
+
+  globalThis[hostGlobal] = {
+    // modelSource is the cached file path (node) or the model bytes (browser).
+    createSession: async (modelSource) => {
+      const modelData = await readModelSource(modelSource);
+      model = await loadAndCompile(modelData, { accelerator });
+    },
+    run: async (inputs) => {
+      const feeds = {};
+      const made = [];
+      for (const [name, t] of Object.entries(inputs)) {
+        const tensor = new Tensor(typedArray(t), Array.from(t.dims));
+        feeds[name] = tensor;
+        made.push(tensor);
+      }
+      const results = await model.run(feeds);
+      const outputs = {};
+      const toDelete = [...made];
+      for (const [name, out] of Object.entries(results)) {
+        const host = accelerator === "wasm" ? out : await out.moveTo("wasm");
+        const arr = host.toTypedArray();
+        outputs[name] = {
+          data: new Uint8Array(arr.buffer.slice(arr.byteOffset, arr.byteOffset + arr.byteLength)),
+          dims: Array.from(host.type.layout.dimensions),
+          type: host.type.dtype,
+        };
+        toDelete.push(out);
+        if (host !== out) toDelete.push(host);
+      }
+      for (const t of toDelete) t.delete();
+      return outputs;
+    },
+  };
+
+  return {
+    setModel: (m) => {
+      model = m;
+    },
+  };
+}
+
+/**
+ * Fetch self-hosted model files from a base URL (the `modelBaseUrl` opt-out).
+ * Accepts absolute URLs and root-relative paths (e.g. "/assets/shapes/").
+ *
+ * @param {string} baseUrl
+ * @param {{ meta: string, model: string }} files file names under baseUrl,
+ *   e.g. { meta: "shapes_meta.json", model: "shapes.tflite" }
+ * @returns {Promise<{ metaJSON: string, modelBytes: Uint8Array }>}
+ */
+export async function fetchModelFrom(baseUrl, files) {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const [meta, model] = await Promise.all([
+    fetch(`${base}${files.meta}`).then((r) => r.text()),
+    fetch(`${base}${files.model}`).then((r) => r.arrayBuffer()),
+  ]);
+  return { metaJSON: meta, modelBytes: new Uint8Array(model) };
+}
+
+// ------------------------------------------------------------- browser seam
+//
+// The browser half of a model package's `#platform` import. A model's
+// platform-browser.js is a thin wrapper around these.
+
+/** Instantiate the wasm core and return its exports global. `init` imports the
+ *  model's own ./dist/index.js. */
+export async function browserSetup({ hostGlobal, exportsGlobal, init }) {
+  globalThis[hostGlobal] ??= {};
+  const { init: initCore } = await init();
+  await initCore({});
+  return globalThis[exportsGlobal];
+}
+
+/** Where LiteRT.js loads its Wasm runtime from in the browser: the jsDelivr
+ *  mirror of the @litertjs/core package's wasm/ directory. */
+export async function browserWasmDir() {
+  return "https://cdn.jsdelivr.net/npm/@litertjs/core/wasm/";
+}
+
+/** In the browser the model "source" is already the model bytes. */
+export async function browserReadModelSource(source) {
+  return source;
+}
+
+/** No managed on-disk cache in the browser; the runtime caches (Cache API /
+ *  IndexedDB) with an empty base. */
+export async function browserCacheRoot() {
+  return "";
+}

--- a/js/src/native.js
+++ b/js/src/native.js
@@ -1,0 +1,118 @@
+// The shared server-side native loader for the model node packages: it resolves
+// the per-host prebuilt Swift core under native/<platform>-<arch>, loads the
+// LiteRT runtime first (so the core's DT_NEEDED resolves in-process), binds the
+// model's C ABI with koffi, and runs blocking calls on a libuv worker thread.
+//
+// Node-only (uses node:*, koffi). Browser code never imports this file.
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { FfiReader } from "./ffi.js";
+
+const require = createRequire(import.meta.url);
+
+// koffi is loaded lazily (only when a native library is actually loaded), so
+// loadNative()/nativeDir() work in environments without the optional koffi peer.
+let _koffi;
+function koffiModule() {
+  return (_koffi ??= require("koffi"));
+}
+
+// The LiteRT runtime is the same across models; the core library name is the
+// model's (e.g. "ShapesNode" -> libShapesNode.so / .dylib / ShapesNode.dll).
+const RUNTIME = { linux: "libLiteRt.so", darwin: "libLiteRt.dylib", win32: "LiteRt.dll" };
+const coreFile = (name) => ({ linux: `lib${name}.so`, darwin: `lib${name}.dylib`, win32: `${name}.dll` });
+
+/**
+ * Load and bind the prebuilt native core for this host.
+ *
+ * @param {object} o
+ * @param {string} o.here directory of the model's node.js (import.meta dir)
+ * @param {string} o.packageName consumer package (for error messages)
+ * @param {string} o.coreName C core base name, e.g. "ShapesNode"
+ * @param {Record<string,string>} o.symbols koffi prototypes keyed by a friendly
+ *   name, e.g. { create: "void* shapes_create(const char*, const char*)", ... }
+ * @param {string[]} [o.targets] supported target keys for the error hint
+ * @returns {{ lib: Record<string,any>, koffi: any, callAsync: Function,
+ *   decodeResult: (ptr:any)=>FfiReader, version: string,
+ *   nativeDir: ()=>string, defaultModelDirectory: (cacheRoot:string)=>string,
+ *   defaultCacheRoot: ()=>string }}
+ */
+export function loadNative({ here, packageName, coreName, symbols, targets }) {
+  const version = JSON.parse(fs.readFileSync(path.join(here, "package.json"), "utf8")).version;
+  const supported = (targets ?? ["linux-x64", "linux-arm64", "darwin-arm64"]).join(", ");
+
+  function nativeDir() {
+    const key = `${process.platform}-${process.arch}`;
+    const dir = path.join(here, "native", key);
+    if (!fs.existsSync(dir)) {
+      throw new Error(
+        `${packageName}: no prebuilt native for ${key}. ` +
+          `Supported server-side targets: ${supported}. ` +
+          `Use the Swift package or a browser on this platform.`,
+      );
+    }
+    return dir;
+  }
+
+  const CORE = coreFile(coreName);
+  let lib;
+  function loadLib() {
+    if (lib) return lib;
+    const koffi = koffiModule();
+    const dir = nativeDir();
+    // Load the LiteRT runtime first so the core's DT_NEEDED resolves in-process.
+    const runtime = RUNTIME[process.platform];
+    if (runtime && fs.existsSync(path.join(dir, runtime))) koffi.load(path.join(dir, runtime));
+    const core = koffi.load(path.join(dir, CORE[process.platform] || CORE.linux));
+    lib = {};
+    for (const [name, proto] of Object.entries(symbols)) lib[name] = core.func(proto);
+    return lib;
+  }
+
+  // Run a blocking native function on a libuv worker thread (koffi async) so the
+  // Node event loop stays free during download and inference.
+  function callAsync(fn, ...args) {
+    return new Promise((resolve, reject) => {
+      fn.async(...args, (err, res) => (err ? reject(err) : resolve(res)));
+    });
+  }
+
+  // Decode a native result pointer: a big-endian uint32 length prefix, then the
+  // FFIBuffer payload. Returns a reader positioned at the payload start; the
+  // caller frees the pointer (e.g. via the core's *_string_free).
+  function decodeResult(ptr) {
+    const koffi = koffiModule();
+    const head = Uint8Array.from(koffi.decode(ptr, koffi.array("uint8", 4)));
+    const len = new DataView(head.buffer).getUint32(0, false);
+    const full = Uint8Array.from(koffi.decode(ptr, koffi.array("uint8", 4 + len)));
+    return new FfiReader(full.subarray(4));
+  }
+
+  function defaultCacheRoot() {
+    return path.join(os.homedir(), ".cache");
+  }
+
+  // Versioned per-host cache folder: <cacheRoot>/@desert-ant-labs/<pkg>/<ver>/<host>.
+  // The npm package ships no model, so the Node entry always supplies a concrete
+  // directory (an explicit one, or this) rather than letting the Swift core try
+  // SwiftPM resource bundles that are not part of the npm package.
+  const short = packageName.replace(/^@[^/]+\//, "");
+  function defaultModelDirectory(cacheRoot) {
+    return path.join(cacheRoot, "@desert-ant-labs", short, version, `${process.platform}-${process.arch}`);
+  }
+
+  return {
+    get koffi() {
+      return koffiModule();
+    },
+    lib: new Proxy({}, { get: (_t, prop) => loadLib()[prop] }),
+    callAsync,
+    decodeResult,
+    version,
+    nativeDir,
+    defaultCacheRoot,
+    defaultModelDirectory,
+  };
+}

--- a/js/src/platform-node.js
+++ b/js/src/platform-node.js
@@ -1,0 +1,77 @@
+// The node half of a model package's `#platform` import, for the universal
+// WebAssembly entry running server-side (e.g. the Client-Component SSR pass a
+// framework renders in Node). Every node-only import lives here so the browser
+// bundle never sees `node:*`. A model's platform-node.js is a thin wrapper
+// around these.
+//
+// Node-only (uses node:*).
+
+/**
+ * Instantiate the wasm core under Node (WASI shim) and return its exports.
+ * Gives the Swift ModelStore node's fs through the shared `__DalNodeFS` seam
+ * (no `require` under the WASI shim); the download/verify/cache logic stays in
+ * Swift.
+ *
+ * @param {object} o
+ * @param {string} o.hostGlobal e.g. "__ShapesHost"
+ * @param {string} o.exportsGlobal e.g. "__ShapesExports"
+ * @param {() => Promise<{ instantiate: Function }>} o.instantiate imports the
+ *   model's own ./dist/instantiate.js
+ * @param {() => Promise<{ defaultNodeSetup: Function }>} o.nodePlatform imports
+ *   the model's own ./dist/platforms/node.js
+ */
+export async function nodeSetup({ hostGlobal, exportsGlobal, instantiate, nodePlatform }) {
+  globalThis[hostGlobal] ??= {};
+  const { instantiate: inst } = await instantiate();
+  const fsmod = await import("node:fs");
+  globalThis.__DalNodeFS = {
+    existsSync: fsmod.existsSync,
+    statSync: fsmod.statSync,
+    // Copy into an exact-length Uint8Array: node returns pooled Buffers for
+    // small files whose .buffer is the whole shared pool, which JavaScriptKit
+    // would over-read when marshalling into wasm memory.
+    readFileSync: (p) => new Uint8Array(fsmod.readFileSync(p)),
+    writeFileSync: fsmod.writeFileSync,
+    mkdirSync: fsmod.mkdirSync,
+    renameSync: fsmod.renameSync,
+    unlinkSync: fsmod.unlinkSync,
+  };
+  const { defaultNodeSetup } = await nodePlatform();
+  await inst(await defaultNodeSetup({}));
+  return globalThis[exportsGlobal];
+}
+
+/**
+ * Serve LiteRT.js's own Wasm runtime straight from the installed @litertjs/core
+ * package. Layout: <root>/dist/index.js and <root>/wasm/. Walk up from the
+ * resolved entry to the package root, then point at wasm/.
+ */
+export async function nodeWasmDir() {
+  const { createRequire } = await import("node:module");
+  const { pathToFileURL } = await import("node:url");
+  const path = await import("node:path");
+  const fs = await import("node:fs");
+  const require = createRequire(import.meta.url);
+  let dir = path.dirname(require.resolve("@litertjs/core"));
+  for (let i = 0; i < 4 && !fs.existsSync(path.join(dir, "wasm")); i++) {
+    dir = path.dirname(dir);
+  }
+  return pathToFileURL(path.join(dir, "wasm") + "/").href;
+}
+
+/** The wasm host hands createSession a cached file path under Node; read it into
+ *  an owned Uint8Array before compiling. */
+export async function nodeReadModelSource(source) {
+  if (typeof source === "string") {
+    const fs = await import("node:fs");
+    return new Uint8Array(fs.readFileSync(source));
+  }
+  return source;
+}
+
+/** Base for the managed nested cache under Node: ~/.cache. */
+export async function nodeCacheRoot() {
+  const os = await import("node:os");
+  const path = await import("node:path");
+  return path.join(os.homedir(), ".cache");
+}

--- a/js/test/entries.test.mjs
+++ b/js/test/entries.test.mjs
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+test("browser-safe entry exports the expected surface", async () => {
+  const core = await import("../index.js");
+  for (const name of [
+    "FfiReader",
+    "loadLiteRt",
+    "assertBrowserRuntime",
+    "installLiteRtHost",
+    "fetchModelFrom",
+    "browserSetup",
+    "browserWasmDir",
+    "browserReadModelSource",
+    "browserCacheRoot",
+  ]) {
+    assert.equal(typeof core[name], "function", `exports ${name}`);
+  }
+});
+
+test("node entry exports the native loader + node seam", async () => {
+  const node = await import("../node.js");
+  for (const name of ["loadNative", "nodeSetup", "nodeWasmDir", "nodeReadModelSource", "nodeCacheRoot", "FfiReader"]) {
+    assert.equal(typeof node[name], "function", `exports ${name}`);
+  }
+});
+
+test("loadNative reports a friendly error for an unsupported host", async () => {
+  const { loadNative } = await import("../node.js");
+  const core = loadNative({
+    here: new URL("..", import.meta.url).pathname, // package dir (has package.json, no native/)
+    packageName: "@desert-ant-labs/shapes",
+    coreName: "ShapesNode",
+    symbols: { create: "void* shapes_create(const char*, const char*)" },
+  });
+  assert.throws(() => core.nativeDir(), /no prebuilt native for .*Supported server-side targets/s);
+});

--- a/js/test/ffi.test.mjs
+++ b/js/test/ffi.test.mjs
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FfiReader } from "../src/ffi.js";
+
+// Build a big-endian buffer the way the Swift FFIWriter / Kotlin FfiReader do.
+function buildPayload() {
+  const parts = [];
+  const u32 = (v) => { const b = Buffer.alloc(4); b.writeUInt32BE(v >>> 0); parts.push(b); };
+  const i32 = (v) => { const b = Buffer.alloc(4); b.writeInt32BE(v); parts.push(b); };
+  const f64 = (v) => { const b = Buffer.alloc(8); b.writeDoubleBE(v); parts.push(b); };
+  const str = (s) => { const u = Buffer.from(s, "utf8"); u32(u.length); parts.push(u); };
+  return { u32, i32, f64, str, done: () => new Uint8Array(Buffer.concat(parts)) };
+}
+
+test("FfiReader reads u32/i32/f64/str big-endian in order", () => {
+  const b = buildPayload();
+  b.u32(5);
+  b.f64(3.5);
+  b.i32(-7);
+  b.str("héllo");        // multi-byte UTF-8
+  b.u32(0xdeadbeef);
+  const r = new FfiReader(b.done());
+  assert.equal(r.u32(), 5);
+  assert.equal(r.f64(), 3.5);
+  assert.equal(r.i32(), -7);
+  assert.equal(r.str(), "héllo");
+  assert.equal(r.u32(), 0xdeadbeef);
+  assert.equal(r.remaining, 0);
+});
+
+test("FfiReader mirrors a shapes-style line payload", () => {
+  // present(1), kind line(1), from(x,y), to(x,y)
+  const b = buildPayload();
+  b.u32(1);
+  b.u32(1);
+  b.f64(1); b.f64(2);
+  b.f64(3); b.f64(4);
+  const r = new FfiReader(b.done());
+  assert.equal(r.u32(), 1);          // present
+  assert.equal(r.u32(), 1);          // line
+  assert.deepEqual([r.f64(), r.f64()], [1, 2]);
+  assert.deepEqual([r.f64(), r.f64()], [3, 4]);
+});
+
+test("FfiReader.bytes returns a view and advances", () => {
+  const src = new Uint8Array([10, 20, 30, 40, 50]);
+  const r = new FfiReader(src);
+  assert.deepEqual(Array.from(r.bytes(3)), [10, 20, 30]);
+  assert.equal(r.offset, 3);
+  assert.deepEqual(Array.from(r.bytes(2)), [40, 50]);
+});

--- a/js/test/litert.test.mjs
+++ b/js/test/litert.test.mjs
@@ -1,0 +1,112 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  installLiteRtHost,
+  loadLiteRt,
+  assertBrowserRuntime,
+  fetchModelFrom,
+} from "../src/litert.js";
+
+// A fake LiteRT.js: records compiled models and tensor lifecycle so we can
+// assert the host marshals I/O and frees every tensor (LiteRT.js is manual).
+function fakeLiteRt() {
+  const deleted = [];
+  class Tensor {
+    constructor(data, dims) { this.data = data; this.dims = dims; this.deleted = false; }
+    delete() { this.deleted = true; deleted.push(this); }
+  }
+  function makeOutput(name, floats) {
+    const arr = Float32Array.from(floats);
+    return {
+      deleted: false,
+      toTypedArray: () => arr,
+      type: { dtype: "float32", layout: { dimensions: [floats.length] } },
+      moveTo: async () => makeOutput(name, floats),
+      delete() { this.deleted = true; deleted.push(this); },
+    };
+  }
+  const loadAndCompile = async (bytes) => ({
+    bytes,
+    run: async (feeds) => {
+      // echo: return one output "probs" = [sum of first input's data length]
+      const first = Object.values(feeds)[0];
+      return { probs: makeOutput("probs", [first.data.length]) };
+    },
+  });
+  return { Tensor, loadAndCompile, deleted, loadLiteRt: async () => {} };
+}
+
+test("installLiteRtHost creates a session and marshals + frees tensors", async () => {
+  const lrt = fakeLiteRt();
+  installLiteRtHost({
+    hostGlobal: "__TestHost",
+    accelerator: "wasm",
+    loadAndCompile: lrt.loadAndCompile,
+    Tensor: lrt.Tensor,
+    readModelSource: async (s) => s, // bytes already
+  });
+  const host = globalThis.__TestHost;
+  await host.createSession(new Uint8Array([1, 2, 3]));
+
+  const input = { features: { data: new Uint8Array(new Float32Array([1, 2]).buffer), dims: [1, 2], type: "float32" } };
+  const out = await host.run(input);
+
+  assert.ok(out.probs, "returns named output");
+  assert.equal(out.probs.type, "float32");
+  assert.deepEqual(out.probs.dims, [1]);
+  // Every tensor made (input) and produced (output) must be deleted.
+  assert.ok(lrt.deleted.length >= 2, `all tensors freed (got ${lrt.deleted.length})`);
+  assert.ok(lrt.deleted.every((t) => t.deleted), "each freed tensor marked deleted");
+  delete globalThis.__TestHost;
+});
+
+test("installLiteRtHost setModel lets the modelBaseUrl path share run()", async () => {
+  const lrt = fakeLiteRt();
+  const { setModel } = installLiteRtHost({
+    hostGlobal: "__TestHost2",
+    loadAndCompile: lrt.loadAndCompile,
+    Tensor: lrt.Tensor,
+    readModelSource: async (s) => s,
+  });
+  setModel(await lrt.loadAndCompile(new Uint8Array([9])));
+  const out = await globalThis.__TestHost2.run({
+    x: { data: new Uint8Array(new Float32Array([1]).buffer), dims: [1], type: "float32" },
+  });
+  assert.ok(out.probs);
+  delete globalThis.__TestHost2;
+});
+
+test("loadLiteRt uses the injected module and initializes the runtime once", async () => {
+  let loads = 0;
+  const lrt = { loadAndCompile: async () => {}, Tensor: class {}, loadLiteRt: async () => { loads++; } };
+  const mod = await loadLiteRt({ litert: lrt, defaultWasmDir: async () => "wasm/", packageName: "@x/y" });
+  assert.equal(mod, lrt);
+  await loadLiteRt({ litert: lrt, defaultWasmDir: async () => "wasm/", packageName: "@x/y" });
+  assert.equal(loads, 1, "runtime load is memoized across calls");
+});
+
+test("assertBrowserRuntime throws in plain Node, passes with injected litert", () => {
+  assert.throws(() => assertBrowserRuntime({ packageName: "@desert-ant-labs/shapes" }), /native build/);
+  assert.doesNotThrow(() => assertBrowserRuntime({ packageName: "@x/y", litert: {} }));
+});
+
+test("fetchModelFrom fetches the configured file names and normalizes the base", async () => {
+  const seen = [];
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    seen.push(url);
+    if (url.endsWith(".json")) return { text: async () => '{"ok":true}' };
+    return { arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer };
+  };
+  try {
+    const { metaJSON, modelBytes } = await fetchModelFrom("/assets/shapes", {
+      meta: "shapes_meta.json",
+      model: "shapes.tflite",
+    });
+    assert.equal(metaJSON, '{"ok":true}');
+    assert.deepEqual(Array.from(modelBytes), [1, 2, 3]);
+    assert.deepEqual(seen.sort(), ["/assets/shapes/shapes.tflite", "/assets/shapes/shapes_meta.json"]);
+  } finally {
+    globalThis.fetch = orig;
+  }
+});

--- a/mise.toml
+++ b/mise.toml
@@ -313,8 +313,9 @@ echo "$v"
 """
 
 [tasks.set-version]
-description = "Set the ai.desertant:core artifact version (kotlin/build.gradle.kts + README snippet)"
+description = "Set the desert-ant-core artifact versions (ai.desertant:core + @desert-ant-labs/core + README)"
 dir = "{{ config_root }}"
+tools = { node = "22" }
 shell = "bash -c"
 usage = '''
 arg "<version>" help="Release version (X.Y.Z)"
@@ -323,8 +324,60 @@ run = """
 set -euo pipefail
 VERSION="${usage_version:?version arg required}"
 echo "$VERSION" | grep -Eq '^[0-9]+\\.[0-9]+\\.[0-9]+$' || { echo "error: version must be X.Y.Z, got '$VERSION'" >&2; exit 1; }
+# Android artifact version (single-sourced in the Gradle build).
 sed -i.bak 's/^version = ".*"$/version = "'"$VERSION"'"/' kotlin/build.gradle.kts && rm -f kotlin/build.gradle.kts.bak
+# npm package version (npm keeps package.json + any lockfile in sync).
+( cd js && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null )
 # The Maven coordinate in the README install snippet, if present.
 sed -i.bak -E 's|(ai\\.desertant:core:)[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|g' README.md && rm -f README.md.bak
-echo "version set to $VERSION"
+echo "version set to $VERSION (kotlin/build.gradle.kts, js/package.json, README)"
+"""
+
+# ---------------------------------------------------------------- npm artifact
+#
+# `@desert-ant-labs/core` (js/) is the shared JavaScript runtime the per-model
+# node packages build on (LiteRT.js host, koffi native loader, FFI reader). Pure
+# JS, no build step. Version single-sourced in js/package.json (mise run
+# set-version keeps it aligned with the Android artifact).
+
+[tasks.test-js]
+description = "Run the @desert-ant-labs/core JS test suite (js/)"
+dir = "{{ config_root }}/js"
+tools = { node = "22" }
+run = "node --test test/*.test.mjs"
+
+# Print the single-sourced npm version (from js/package.json).
+[tasks.check-version-npm]
+hide = true
+dir = "{{ config_root }}"
+shell = "bash -c"
+run = """
+set -euo pipefail
+v=$(sed -n 's/^  "version": "\\([^"]*\\)",$/\\1/p' js/package.json)
+[ -n "$v" ] || { echo "error: no version in js/package.json" >&2; exit 1; }
+echo "$v"
+"""
+
+[tasks.publish-npm]
+description = "Publish @desert-ant-labs/core to npm"
+dir = "{{ config_root }}/js"
+depends = ["check-version-npm", "test-js"]
+tools = { node = "22" }
+shell = "bash -c"
+run = """
+set -euo pipefail
+# The npm tarball must carry the license (package.json: SEE LICENSE IN LICENSE.md).
+cp ../LICENSE.md LICENSE.md
+# Auth: NPM_TOKEN from mise.local.toml (or a CI env), else an interactive
+# `npm login`. The token goes through a throwaway userconfig so normal npm
+# commands and checked-in files never carry auth.
+if [ -n "${NPM_TOKEN:-}" ]; then
+    npmrc=$(mktemp)
+    trap 'rm -f "$npmrc"' EXIT
+    echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$npmrc"
+    npm publish --access public --userconfig "$npmrc"
+else
+    npm publish --access public
+fi
+echo "published: @desert-ant-labs/core@$(mise run check-version-npm)"
 """


### PR DESCRIPTION
The JavaScript counterpart to the `ai.desertant:core` Android artifact. Extracts the model-agnostic runtime the per-model node packages (shapes/emo/redact) duplicate today, so each keeps only its own decode + public API. Step 2 of the shared-core extraction.

## `js/` = `@desert-ant-labs/core` (pure JS, no build step)
- **src/litert.js** (browser-safe): `installLiteRtHost` (the LiteRT.js host the wasm core drives: named-tensor `createSession`/`run` with dtype marshalling and LiteRT.js manual memory management), `loadLiteRt` + `assertBrowserRuntime`, `fetchModelFrom` (the `modelBaseUrl` opt-out), and the browser `#platform` seam.
- **src/native.js** (`@desert-ant-labs/core/node`): `loadNative` (resolve `native/<platform>-<arch>`, load LiteRT first, bind the model C ABI with koffi, lazily), `callAsync`, `decodeResult`. koffi is a lazy optional peer.
- **src/platform-node.js**: the Node `#platform` seam.
- **src/ffi.js**: `FfiReader`, a big-endian DataView cursor over the length-prefixed FFIBuffer payload (JS counterpart of Kotlin's `FfiReader`).
- Browser-safe `index.js` (no `node:*`) and node-only `node.js` entries + `.d.ts`.
- **test/**: 11 `node --test` cases (FfiReader byte format, LiteRT host tensor marshalling + free with a fake `@litertjs/core`, loader memoization, browser-runtime guard, `fetchModelFrom`, entry surfaces). All green.

## Release infra (mirrors the Android artifact, equally easy to update)
- mise tasks `test-js`, `check-version-npm`, `publish-npm`; `set-version` now bumps `js/package.json` alongside the Gradle version, keeping the two core artifacts aligned.
- **.github/workflows/publish-npm.yml**: on a `vX.Y.Z` tag, publish to npm when `js/` changed since the previous tag, after verifying tag == package version. Token from the `npm` GitHub Environment secret (`NPM_TOKEN`).
- README documents both sibling artifacts and the shared tag-driven release.

## Behavior-preserving
The LiteRT host, `callAsync`, and native loader are byte-identical across shapes/emo/redact today (modulo model name + C signatures), so this is a faithful extraction.

## Follow-up
Wiring the three node packages onto this (thin `node.js`/`browser.js`/`platform-*.js` that import core) is a separate PR per repo, after `@desert-ant-labs/core` is on npm - same pattern as the Android SDK PRs.