### PR TITLE
js: remove unused loadNative defaultModelDirectory helper (core 0.3.1)

### DIFF
--- a/js/node.d.ts
+++ b/js/node.d.ts
@@ -12,7 +12,6 @@ export interface NativeCore {
   version: string;
   nativeDir: () => string;
   defaultCacheRoot: () => string;
-  defaultModelDirectory: (cacheRoot: string) => string;
 }
 
 export function loadNative(options: {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/js/src/native.js
+++ b/js/src/native.js
@@ -36,8 +36,7 @@ const coreFile = (name) => ({ linux: `lib${name}.so`, darwin: `lib${name}.dylib`
  * @param {string[]} [o.targets] supported target keys for the error hint
  * @returns {{ lib: Record<string,any>, koffi: any, callAsync: Function,
  *   decodeResult: (ptr:any)=>FfiReader, version: string,
- *   nativeDir: ()=>string, defaultModelDirectory: (cacheRoot:string)=>string,
- *   defaultCacheRoot: ()=>string }}
+ *   nativeDir: ()=>string, defaultCacheRoot: ()=>string }}
  */
 export function loadNative({ here, packageName, coreName, symbols, targets }) {
   const version = JSON.parse(fs.readFileSync(path.join(here, "package.json"), "utf8")).version;
@@ -94,14 +93,10 @@ export function loadNative({ here, packageName, coreName, symbols, targets }) {
     return path.join(os.homedir(), ".cache");
   }
 
-  // Versioned per-host cache folder: <cacheRoot>/@desert-ant-labs/<pkg>/<ver>/<host>.
-  // The npm package ships no model, so the Node entry always supplies a concrete
-  // directory (an explicit one, or this) rather than letting the Swift core try
-  // SwiftPM resource bundles that are not part of the npm package.
-  const short = packageName.replace(/^@[^/]+\//, "");
-  function defaultModelDirectory(cacheRoot) {
-    return path.join(cacheRoot, "@desert-ant-labs", short, version, `${process.platform}-${process.arch}`);
-  }
+  // The single managed cache layout - <cacheRoot>/desert-ant-models/<repo>/<revision>
+  // - is owned by desert-ant-core's Swift ModelStore. The Node entry passes
+  // cacheRoot (defaultCacheRoot below) and a null directory, so there is no
+  // JS-side model-path computation.
 
   return {
     get koffi() {
@@ -113,6 +108,5 @@ export function loadNative({ here, packageName, coreName, symbols, targets }) {
     version,
     nativeDir,
     defaultCacheRoot,
-    defaultModelDirectory,
   };
 }


### PR DESCRIPTION
Follow-up to normalizing the model cache. The cache layout is owned by the Swift `ModelStore` (`<cacheRoot>/desert-ant-models/<repo>/<revision>`) and the three node packages now pass a `null` directory, so `loadNative`'s JS `defaultModelDirectory` helper - which encoded a *different*, now-abandoned layout (`@desert-ant-labs/<pkg>/<version>/<host>`) - is unused and a footgun for any future SDK that might reach for it.

## Changes (js/ only)
- Remove `defaultModelDirectory` from `js/src/native.js` and `js/node.d.ts`.
- Bump `js/package.json` to **0.3.1**.

No published node package references it (the SDK node packages call `defaultCacheRoot` + pass `null`), so this is a safe removal.

## Release
npm-only: the Android artifact is unchanged and stays **0.3.0** (`kotlin/` untouched). Tagging `v0.3.1` publishes `@desert-ant-labs/core@0.3.1` via `publish-npm.yml` and the Android workflow skips (no `kotlin/` change). Core JS tests pass (11/11).