### PR TITLE
ci: gate publish workflows on tag == artifact version (not dir-diff)

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,22 +1,24 @@
 name: Publish Android
 
 # Publish the ai.desertant:core Android artifact to Maven Central when a release
-# tag (vX.Y.Z) is pushed AND the artifact sources (kotlin/) changed since the
-# previous tag. The artifact is pure Kotlin, so this needs no emulator and no
-# Swift toolchain: it runs `mise run publish-android`, driven by the runner's
-# Android SDK and a mise-provided JDK. Credentials come from the `maven-central`
-# GitHub Environment secrets (see below), mapped to the ORG_GRADLE_PROJECT_*
-# properties the Gradle publish reads.
+# tag (vX.Y.Z) whose version matches the artifact is pushed. The artifact is pure
+# Kotlin, so this needs no emulator and no Swift toolchain: it runs
+# `mise run publish-android`, driven by the runner's Android SDK and a mise JDK.
+# Credentials come from the `maven-central` GitHub Environment secrets.
+#
+# Gating: the repo's `v*` tags are shared by the SwiftPM package and the two core
+# artifacts, which version independently. This workflow publishes only when the
+# tag version equals the Android artifact version (single-sourced in
+# kotlin/build.gradle.kts); a tag that bumps only the npm package or the SwiftPM
+# package leaves kotlin/build.gradle.kts untouched and is skipped here. Bump with
+# `mise run set-version X.Y.Z` (or edit kotlin/build.gradle.kts for an
+# Android-only release), commit, then tag vX.Y.Z.
 #
 # Environment `maven-central` secrets (set with `gh secret set --env maven-central`):
 #   MAVEN_CENTRAL_USERNAME          Central portal token username
 #   MAVEN_CENTRAL_PASSWORD          Central portal token password
 #   SIGNING_IN_MEMORY_KEY           ASCII-armored GPG private key (multiline)
 #   SIGNING_IN_MEMORY_KEY_PASSWORD  passphrase for that key
-#
-# The published version is single-sourced in kotlin/build.gradle.kts; the tag
-# must match it (the verify step fails otherwise), so a tag never ships a stale
-# artifact. Bump with `mise run set-version X.Y.Z`, commit, then tag vX.Y.Z.
 
 on:
   push:
@@ -31,41 +33,32 @@ permissions:
   contents: read
 
 jobs:
-  detect:
-    name: kotlin/ changed since previous tag?
+  gate:
+    name: tag matches the Android artifact version?
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.diff.outputs.changed }}
+      publish: ${{ steps.v.outputs.publish }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # full history + tags, to diff against the previous tag
 
-      - id: diff
+      - id: v
         shell: bash
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          # The most recent tag strictly before this one, by history.
-          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
-          if [ -z "$PREV" ]; then
-            echo "no previous tag; treating as an Android change."
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "diffing ${PREV}..${TAG} for kotlin/ changes"
-          if git diff --name-only "$PREV" "$TAG" -- kotlin/ | grep -q .; then
-            echo "kotlin/ changed since ${PREV}; will publish."
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+          VERSION=$(sed -n 's/^version = "\(.*\)"$/\1/p' kotlin/build.gradle.kts)
+          [ -n "$VERSION" ] || { echo "no version in kotlin/build.gradle.kts" >&2; exit 1; }
+          if [ "${GITHUB_REF_NAME#v}" = "$VERSION" ]; then
+            echo "tag ${GITHUB_REF_NAME} matches ai.desertant:core ${VERSION}; will publish."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
           else
-            echo "no kotlin/ changes since ${PREV}; skipping publish."
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "tag ${GITHUB_REF_NAME} != ai.desertant:core ${VERSION}; skipping (not an Android release)."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
 
   publish:
     name: Publish ai.desertant:core to Maven Central
-    needs: detect
-    if: needs.detect.outputs.changed == 'true'
+    needs: gate
+    if: needs.gate.outputs.publish == 'true'
     runs-on: ubuntu-latest
     environment: maven-central
     steps:
@@ -78,18 +71,6 @@ jobs:
         uses: jdx/mise-action@v2
         with:
           install: false
-
-      # The tag must match the single-sourced artifact version.
-      - name: Verify tag matches artifact version
-        shell: bash
-        run: |
-          set -euo pipefail
-          VERSION="$(mise run check-version)"
-          [ "${GITHUB_REF_NAME#v}" = "$VERSION" ] || {
-            echo "tag ${GITHUB_REF_NAME} != kotlin/build.gradle.kts version ${VERSION}" >&2
-            exit 1
-          }
-          echo "publishing ai.desertant:core:${VERSION}"
 
       - name: Publish to Maven Central
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,17 +1,20 @@
 name: Publish npm
 
-# Publish the @desert-ant-labs/core npm package to npm when a release tag
-# (vX.Y.Z) is pushed AND the package sources (js/) changed since the previous
-# tag. Mirrors publish-android.yml: pure JS, no build step, so it just runs the
-# tests then `mise run publish-npm`. The token comes from the `npm` GitHub
-# Environment secret.
+# Publish the @desert-ant-labs/core npm package when a release tag (vX.Y.Z) whose
+# version matches the package is pushed. Pure JS, no build step, so it just runs
+# `mise run publish-npm`. The token comes from the `npm` GitHub Environment
+# secret.
+#
+# Gating: the repo's `v*` tags are shared by the SwiftPM package and the two core
+# artifacts, which version independently. This workflow publishes only when the
+# tag version equals the npm package version (single-sourced in js/package.json);
+# a tag that bumps only the Android artifact or the SwiftPM package leaves
+# js/package.json untouched and is skipped here. Bump with
+# `mise run set-version X.Y.Z` (or edit js/package.json for an npm-only release),
+# commit, then tag vX.Y.Z.
 #
 # Environment `npm` secret (set with `gh secret set --env npm`):
 #   NPM_TOKEN  npm automation token with publish rights on @desert-ant-labs
-#
-# The published version is single-sourced in js/package.json; the tag must match
-# it (the verify step fails otherwise). Bump with `mise run set-version X.Y.Z`
-# (which also bumps the Android artifact), commit, then tag vX.Y.Z.
 
 on:
   push:
@@ -26,40 +29,32 @@ permissions:
   contents: read
 
 jobs:
-  detect:
-    name: js/ changed since previous tag?
+  gate:
+    name: tag matches the npm package version?
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.diff.outputs.changed }}
+      publish: ${{ steps.v.outputs.publish }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # full history + tags, to diff against the previous tag
 
-      - id: diff
+      - id: v
         shell: bash
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
-          if [ -z "$PREV" ]; then
-            echo "no previous tag; treating as a js change."
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "diffing ${PREV}..${TAG} for js/ changes"
-          if git diff --name-only "$PREV" "$TAG" -- js/ | grep -q .; then
-            echo "js/ changed since ${PREV}; will publish."
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+          VERSION=$(sed -n 's/^  "version": "\([^"]*\)",$/\1/p' js/package.json)
+          [ -n "$VERSION" ] || { echo "no version in js/package.json" >&2; exit 1; }
+          if [ "${GITHUB_REF_NAME#v}" = "$VERSION" ]; then
+            echo "tag ${GITHUB_REF_NAME} matches @desert-ant-labs/core ${VERSION}; will publish."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
           else
-            echo "no js/ changes since ${PREV}; skipping publish."
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "tag ${GITHUB_REF_NAME} != @desert-ant-labs/core ${VERSION}; skipping (not an npm release)."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
 
   publish:
     name: Publish @desert-ant-labs/core to npm
-    needs: detect
-    if: needs.detect.outputs.changed == 'true'
+    needs: gate
+    if: needs.gate.outputs.publish == 'true'
     runs-on: ubuntu-latest
     environment: npm
     steps:
@@ -70,17 +65,6 @@ jobs:
         uses: jdx/mise-action@v2
         with:
           install: false
-
-      - name: Verify tag matches package version
-        shell: bash
-        run: |
-          set -euo pipefail
-          VERSION="$(mise run check-version-npm)"
-          [ "${GITHUB_REF_NAME#v}" = "$VERSION" ] || {
-            echo "tag ${GITHUB_REF_NAME} != js/package.json version ${VERSION}" >&2
-            exit 1
-          }
-          echo "publishing @desert-ant-labs/core@${VERSION}"
 
       - name: Publish to npm
         env:

--- a/README.md
+++ b/README.md
@@ -214,34 +214,39 @@ testing consumers). The version is single-sourced in `kotlin/build.gradle.kts`
 The repo ships two published sibling artifacts alongside the SwiftPM package:
 the `ai.desertant:core` Android library (`kotlin/`) and the
 `@desert-ant-labs/core` npm package (`js/`, the shared JavaScript runtime the
-model node packages build on). Both are versioned in lockstep with the SwiftPM
-package and released the same way: tag-driven.
+model node packages build on). Each versions independently, and releases are
+tag-driven: a `vX.Y.Z` tag publishes exactly the artifacts whose version equals
+`X.Y.Z`.
 
-Bump the versions, commit to `main`, then push a matching `vX.Y.Z` tag:
+For a unified release, bump both, commit to `main`, then push a matching tag:
 
 ```bash
-mise run set-version 0.3.1   # bumps kotlin/build.gradle.kts, js/package.json, README
+mise run set-version 0.3.2   # bumps kotlin/build.gradle.kts, js/package.json, README
 # commit and merge to main
-git tag v0.3.1 && git push origin v0.3.1
+git tag v0.3.2 && git push origin v0.3.2
 ```
+
+For an artifact-only release, bump just that one (edit `js/package.json` or
+`kotlin/build.gradle.kts`) and tag its version.
 
 Two workflows react to the tag, each independent:
 
 - `Publish Android` (`.github/workflows/publish-android.yml`) runs
-  `mise run publish-android` when `kotlin/` changed since the previous tag.
-  Credentials: the `maven-central` GitHub Environment secrets
-  (`MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`,
-  `SIGNING_IN_MEMORY_KEY_PASSWORD`).
+  `mise run publish-android` when the tag version equals
+  `kotlin/build.gradle.kts`'s. Credentials: the `maven-central` GitHub
+  Environment secrets (`MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`,
+  `SIGNING_IN_MEMORY_KEY`, `SIGNING_IN_MEMORY_KEY_PASSWORD`).
 - `Publish npm` (`.github/workflows/publish-npm.yml`) runs `mise run publish-npm`
-  when `js/` changed since the previous tag. Credentials: the `npm` GitHub
+  when the tag version equals `js/package.json`'s. Credentials: the `npm` GitHub
   Environment secret (`NPM_TOKEN`).
 
-Each job only publishes when its own directory actually changed (a Swift-only
-release skips both; both npm and Maven Central versions are immutable so nothing
-ever republishes), and each first checks the tag matches its artifact version.
-No local secrets are needed to cut a release. To publish by hand instead, run
-`mise run publish-android` / `mise run publish-npm` with the credentials
-exported (for example via a gitignored `mise.local.toml`).
+So the tag version selects which artifacts release: an artifact whose version
+doesn't match the tag is skipped (a Swift-only tag skips both; an npm-only bump
+tags only the npm release). npm and Maven Central versions are immutable, so a
+given version never republishes. No local secrets are needed to cut a release.
+To publish by hand instead, run `mise run publish-android` / `mise run
+publish-npm` with the credentials exported (for example via a gitignored
+`mise.local.toml`).
 
 The JavaScript runtime is documented in [`js/README.md`](js/README.md); build
 and test it locally with `mise run test-js`.


### PR DESCRIPTION
Fixes the noisy failure the v0.3.1 (npm-only) release produced: the `Publish Android` workflow ran and failed.

## Root cause
The old gate was "did `kotlin/` / `js/` change since the previous tag?". But the repo's `v*` tags are shared with the SwiftPM releases, and the baseline tag `v0.3.0` **predates** the `kotlin/` and `js/` directories. So "kotlin/ changed since v0.3.0" was trivially true, the Android publish job ran on the npm-only `v0.3.1` tag, and its version check then correctly refused to publish 0.3.0 under a v0.3.1 tag - failing loudly (red run), though nothing was actually published.

## Fix
Gate each workflow on **the tag version equalling that artifact's own version** (`kotlin/build.gradle.kts` for Android, `js/package.json` for npm). A mismatched artifact **skips quietly** instead of failing. This is:
- robust against old baseline tags (no diff against history),
- aligned with the independent-versioning model: the tag version selects which artifacts release,
- still safe: npm/Maven Central versions are immutable, so nothing republishes.

npm-only bump → tag its version → only npm publishes. Unified `set-version` bump → both match the tag → both publish. README's Releasing section updated to match.

(The v0.3.1 npm release itself succeeded and `@desert-ant-labs/core@0.3.1` is live; this only fixes the gating so future tags don't produce a spurious Android failure.)