### PR TITLE
ci: publish only on real change (set-version bumps all, tag, skip unchanged)

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,18 +1,17 @@
 name: Publish Android
 
 # Publish the ai.desertant:core Android artifact to Maven Central when a release
-# tag (vX.Y.Z) whose version matches the artifact is pushed. The artifact is pure
-# Kotlin, so this needs no emulator and no Swift toolchain: it runs
+# tag (vX.Y.Z) is pushed, but only if the artifact actually changed. The artifact
+# is pure Kotlin, so this needs no emulator and no Swift toolchain: it runs
 # `mise run publish-android`, driven by the runner's Android SDK and a mise JDK.
 # Credentials come from the `maven-central` GitHub Environment secrets.
 #
-# Gating: the repo's `v*` tags are shared by the SwiftPM package and the two core
-# artifacts, which version independently. This workflow publishes only when the
-# tag version equals the Android artifact version (single-sourced in
-# kotlin/build.gradle.kts); a tag that bumps only the npm package or the SwiftPM
-# package leaves kotlin/build.gradle.kts untouched and is skipped here. Bump with
-# `mise run set-version X.Y.Z` (or edit kotlin/build.gradle.kts for an
-# Android-only release), commit, then tag vX.Y.Z.
+# Release model: `mise run set-version X.Y.Z` bumps every artifact's version (so
+# they stay current), you commit and push `vX.Y.Z`, and each publish workflow
+# ships only the artifact whose content changed since the previous tag. A pure
+# version bump does not count as a change, so a blanket set-version that touches
+# nothing but version lines republishes nothing. Published versions may skip
+# (an unchanged artifact keeps its last published version until it next changes).
 #
 # Environment `maven-central` secrets (set with `gh secret set --env maven-central`):
 #   MAVEN_CENTRAL_USERNAME          Central portal token username
@@ -34,26 +33,56 @@ permissions:
 
 jobs:
   gate:
-    name: tag matches the Android artifact version?
+    name: should this tag publish the Android artifact?
     runs-on: ubuntu-latest
     outputs:
-      publish: ${{ steps.v.outputs.publish }}
+      publish: ${{ steps.g.outputs.publish }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags, to diff against the previous tag
 
-      - id: v
+      - id: g
         shell: bash
         run: |
           set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
           VERSION=$(sed -n 's/^version = "\(.*\)"$/\1/p' kotlin/build.gradle.kts)
           [ -n "$VERSION" ] || { echo "no version in kotlin/build.gradle.kts" >&2; exit 1; }
-          if [ "${GITHUB_REF_NAME#v}" = "$VERSION" ]; then
-            echo "tag ${GITHUB_REF_NAME} matches ai.desertant:core ${VERSION}; will publish."
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag ${GITHUB_REF_NAME} != ai.desertant:core ${VERSION}; skipping (not an Android release)."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
+
+          # The tag must name this artifact's version (set-version bumps it).
+          if [ "${TAG#v}" != "$VERSION" ]; then
+            echo "tag ${TAG} != ai.desertant:core ${VERSION}; skipping (not this artifact's release)."
+            echo "publish=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
+
+          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+          if [ -z "$PREV" ]; then
+            echo "no previous tag; publishing ${VERSION}."
+            echo "publish=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          # Publish only if kotlin/ actually changed since the previous tag,
+          # counting a pure version bump in build.gradle.kts as no change (so a
+          # blanket set-version that only touches version lines republishes
+          # nothing). Any other changed file - including binaries - counts.
+          files=$(git diff --name-only "$PREV" "$TAG" -- kotlin/)
+          if [ -z "$files" ]; then
+            publish=false
+          elif [ "$files" = "kotlin/build.gradle.kts" ]; then
+            body=$(git diff "$PREV" "$TAG" -- kotlin/build.gradle.kts \
+              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]version = "' || true)
+            [ -n "$body" ] && publish=true || publish=false
+          else
+            publish=true
+          fi
+
+          if [ "$publish" = true ]; then
+            echo "kotlin/ changed since ${PREV}; publishing ${VERSION}."
+          else
+            echo "kotlin/ unchanged since ${PREV} (only the version bump, if any); skipping."
+          fi
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish ai.desertant:core to Maven Central

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,17 +1,16 @@
 name: Publish npm
 
-# Publish the @desert-ant-labs/core npm package when a release tag (vX.Y.Z) whose
-# version matches the package is pushed. Pure JS, no build step, so it just runs
-# `mise run publish-npm`. The token comes from the `npm` GitHub Environment
-# secret.
+# Publish the @desert-ant-labs/core npm package when a release tag (vX.Y.Z) is
+# pushed, but only if the package actually changed. Pure JS, no build step, so it
+# just runs `mise run publish-npm`. The token comes from the `npm` GitHub
+# Environment secret.
 #
-# Gating: the repo's `v*` tags are shared by the SwiftPM package and the two core
-# artifacts, which version independently. This workflow publishes only when the
-# tag version equals the npm package version (single-sourced in js/package.json);
-# a tag that bumps only the Android artifact or the SwiftPM package leaves
-# js/package.json untouched and is skipped here. Bump with
-# `mise run set-version X.Y.Z` (or edit js/package.json for an npm-only release),
-# commit, then tag vX.Y.Z.
+# Release model: `mise run set-version X.Y.Z` bumps every artifact's version (so
+# they stay current), you commit and push `vX.Y.Z`, and each publish workflow
+# ships only the artifact whose content changed since the previous tag. A pure
+# version bump does not count as a change, so a blanket set-version that touches
+# nothing but version lines republishes nothing. Published versions may skip
+# (an unchanged artifact keeps its last published version until it next changes).
 #
 # Environment `npm` secret (set with `gh secret set --env npm`):
 #   NPM_TOKEN  npm automation token with publish rights on @desert-ant-labs
@@ -30,26 +29,56 @@ permissions:
 
 jobs:
   gate:
-    name: tag matches the npm package version?
+    name: should this tag publish the npm package?
     runs-on: ubuntu-latest
     outputs:
-      publish: ${{ steps.v.outputs.publish }}
+      publish: ${{ steps.g.outputs.publish }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags, to diff against the previous tag
 
-      - id: v
+      - id: g
         shell: bash
         run: |
           set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
           VERSION=$(sed -n 's/^  "version": "\([^"]*\)",$/\1/p' js/package.json)
           [ -n "$VERSION" ] || { echo "no version in js/package.json" >&2; exit 1; }
-          if [ "${GITHUB_REF_NAME#v}" = "$VERSION" ]; then
-            echo "tag ${GITHUB_REF_NAME} matches @desert-ant-labs/core ${VERSION}; will publish."
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag ${GITHUB_REF_NAME} != @desert-ant-labs/core ${VERSION}; skipping (not an npm release)."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
+
+          # The tag must name this artifact's version (set-version bumps it).
+          if [ "${TAG#v}" != "$VERSION" ]; then
+            echo "tag ${TAG} != @desert-ant-labs/core ${VERSION}; skipping (not this artifact's release)."
+            echo "publish=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
+
+          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+          if [ -z "$PREV" ]; then
+            echo "no previous tag; publishing ${VERSION}."
+            echo "publish=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          # Publish only if js/ actually changed since the previous tag, counting
+          # a pure version bump in package.json as no change (so a blanket
+          # set-version that only touches version lines republishes nothing). Any
+          # other changed file - including binaries - counts.
+          files=$(git diff --name-only "$PREV" "$TAG" -- js/)
+          if [ -z "$files" ]; then
+            publish=false
+          elif [ "$files" = "js/package.json" ]; then
+            body=$(git diff "$PREV" "$TAG" -- js/package.json \
+              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]  "version": "' || true)
+            [ -n "$body" ] && publish=true || publish=false
+          else
+            publish=true
+          fi
+
+          if [ "$publish" = true ]; then
+            echo "js/ changed since ${PREV}; publishing ${VERSION}."
+          else
+            echo "js/ unchanged since ${PREV} (only the version bump, if any); skipping."
+          fi
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish @desert-ant-labs/core to npm

--- a/README.md
+++ b/README.md
@@ -214,11 +214,11 @@ testing consumers). The version is single-sourced in `kotlin/build.gradle.kts`
 The repo ships two published sibling artifacts alongside the SwiftPM package:
 the `ai.desertant:core` Android library (`kotlin/`) and the
 `@desert-ant-labs/core` npm package (`js/`, the shared JavaScript runtime the
-model node packages build on). Each versions independently, and releases are
-tag-driven: a `vX.Y.Z` tag publishes exactly the artifacts whose version equals
-`X.Y.Z`.
+model node packages build on). Releases are tag-driven and publish only what
+changed.
 
-For a unified release, bump both, commit to `main`, then push a matching tag:
+Bump the version whenever you like (it sets every artifact, so their versions
+stay current and aligned), commit to `main`, then push a matching `vX.Y.Z` tag:
 
 ```bash
 mise run set-version 0.3.2   # bumps kotlin/build.gradle.kts, js/package.json, README
@@ -226,27 +226,29 @@ mise run set-version 0.3.2   # bumps kotlin/build.gradle.kts, js/package.json, R
 git tag v0.3.2 && git push origin v0.3.2
 ```
 
-For an artifact-only release, bump just that one (edit `js/package.json` or
-`kotlin/build.gradle.kts`) and tag its version.
-
-Two workflows react to the tag, each independent:
+Two workflows react to the tag, each independent, and each publishes its artifact
+only if it actually changed:
 
 - `Publish Android` (`.github/workflows/publish-android.yml`) runs
-  `mise run publish-android` when the tag version equals
-  `kotlin/build.gradle.kts`'s. Credentials: the `maven-central` GitHub
-  Environment secrets (`MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`,
-  `SIGNING_IN_MEMORY_KEY`, `SIGNING_IN_MEMORY_KEY_PASSWORD`).
+  `mise run publish-android` when the tag matches the `kotlin/build.gradle.kts`
+  version **and** `kotlin/` changed since the previous tag. Credentials: the
+  `maven-central` GitHub Environment secrets (`MAVEN_CENTRAL_USERNAME`,
+  `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`,
+  `SIGNING_IN_MEMORY_KEY_PASSWORD`).
 - `Publish npm` (`.github/workflows/publish-npm.yml`) runs `mise run publish-npm`
-  when the tag version equals `js/package.json`'s. Credentials: the `npm` GitHub
-  Environment secret (`NPM_TOKEN`).
+  when the tag matches the `js/package.json` version **and** `js/` changed since
+  the previous tag. Credentials: the `npm` GitHub Environment secret
+  (`NPM_TOKEN`).
 
-So the tag version selects which artifacts release: an artifact whose version
-doesn't match the tag is skipped (a Swift-only tag skips both; an npm-only bump
-tags only the npm release). npm and Maven Central versions are immutable, so a
-given version never republishes. No local secrets are needed to cut a release.
-To publish by hand instead, run `mise run publish-android` / `mise run
-publish-npm` with the credentials exported (for example via a gitignored
-`mise.local.toml`).
+A **pure version bump does not count as a change**, so a blanket `set-version`
+that touches nothing but version lines republishes nothing. An artifact that did
+not change is simply skipped and keeps its last published version, so **published
+versions may skip** (e.g. the Android artifact can go from `0.3.0` straight to
+`0.3.3` while the npm package publishes the in-between versions). npm and Maven
+Central versions are immutable, so a given version never republishes. No local
+secrets are needed to cut a release. To publish by hand instead, run
+`mise run publish-android` / `mise run publish-npm` with the credentials
+exported (for example via a gitignored `mise.local.toml`).
 
 The JavaScript runtime is documented in [`js/README.md`](js/README.md); build
 and test it locally with `mise run test-js`.


### PR DESCRIPTION
Makes the release model match how you want to work: **bump the version any time with `mise run set-version X.Y.Z` (it bumps every artifact so versions stay current), tag `vX.Y.Z`, and each workflow publishes only the artifact that actually changed.**

## Gate logic
Each publish workflow now runs iff:
1. the tag version equals that artifact's own version (`kotlin/build.gradle.kts` / `js/package.json`), **and**
2. that artifact's directory changed since the previous tag - where a **pure version-line bump does not count as a change**.

So a blanket `set-version` that only rewrites version lines republishes nothing; a real code change does. An unchanged artifact is skipped and keeps its last published version, so **published versions may skip** (e.g. Android `0.3.0` → `0.3.3` while npm ships the in-between versions) - which you confirmed is fine.

## Why this replaces the previous gate
The earlier "tag == version" gate would republish an unchanged artifact whenever `set-version` bumped it. The even-earlier "dir changed since previous tag" gate tripped on the `v0.3.0` baseline (which predates `kotlin/`/`js/`). This version ignores a version-only delta and only compares consecutive release tags, so it's both correct and robust.

## Validated
Ran the exact detection locally against the repo:
- version-only bump → **skip**
- version + build/dependency change → **publish**
- version + source change → **publish**
- no change → **skip**
(for both `kotlin/build.gradle.kts` and `js/package.json` indentation). README's Releasing section updated.