### PR TITLE
Move model-SDK catalog to sdk-build/, pin by semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.3.0")
+    implementation("ai.desertant:core:0.4.0")
 }
 ```
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.3.0"
+version = "0.4.0"
 
 android {
     namespace = "ai.desertant.core"

--- a/sdk-build/README.md
+++ b/sdk-build/README.md
@@ -21,7 +21,7 @@ tflite_files = "emo.tflite emo_meta.json emo_tokenizer.bin"  # staged into the A
 DAL_GPU = ""                # non-empty ships the LiteRT GPU accelerator siblings
 
 [task_config]
-includes = ["git::https://github.com/Desert-Ant-Labs/desert-ant-core.git//mise-tasks/model-sdk.toml?ref=model-sdk-v1"]
+includes = ["git::https://github.com/Desert-Ant-Labs/desert-ant-core.git//sdk-build/model-sdk.toml?ref=v0.4.0"]
 
 # Test harnesses differ per model, so the test aggregate + web/node tests stay
 # local. test-swift and test-android come from the catalog.
@@ -53,9 +53,11 @@ coordinates.
 
 ## Versioning
 
-Pinned by the `model-sdk-vN` tag (a dedicated tag namespace, separate from the
-`vX.Y.Z` artifact releases so it never triggers the publish/release workflows).
-Change the catalog, tag `model-sdk-vN+1`, and bump each model repo's `includes`
-ref. Included tasks shadow same-named local tasks, so keep the catalog fully
+The catalog rides desert-ant-core's own `vX.Y.Z` release tags: pin `includes` to
+a semver tag. It lives in `sdk-build/` (not `mise-tasks/`) so mise does not
+auto-load it into desert-ant-core's own task set. Change the catalog, cut a new
+core release (a version-only bump publishes nothing, since the publish gates
+skip unchanged artifacts), and bump each model repo's `includes` ref to the new
+tag. Included tasks shadow same-named local tasks, so keep the catalog fully
 parameterized; for a genuinely model-specific need, define a distinctly-named
 local task or branch on a var/`DAL_*` env inside the shared task.

--- a/sdk-build/model-sdk.toml
+++ b/sdk-build/model-sdk.toml
@@ -14,7 +14,7 @@
 #   DAL_GPU = ""                # non-empty ships the LiteRT GPU accelerator siblings
 #
 #   [task_config]
-#   includes = ["git::https://github.com/Desert-Ant-Labs/desert-ant-core.git//mise-tasks/model-sdk.toml?ref=vX.Y.Z"]
+#   includes = ["git::https://github.com/Desert-Ant-Labs/desert-ant-core.git//sdk-build/model-sdk.toml?ref=v0.4.0"]
 #
 # The tasks derive every model-specific name from `model`/`product`. Test tasks
 # (test, test-node, test-web, test-android-firebase) stay in the model repo,


### PR DESCRIPTION
Two fixes to the shared build catalog:

1. **Move `mise-tasks/` → `sdk-build/`.** A top-level `mise-tasks/` directory is **auto-loaded by mise as tasks**, so in desert-ant-core itself the catalog's templated tasks (which need `vars.model`) shadowed core's own tasks and broke `mise run set-version` here. `sdk-build/` is a normal directory mise doesn't auto-load; the model repos include it by explicit path.
2. **Pin by a semantic version tag** (the catalog rides desert-ant-core's `vX.Y.Z` releases) instead of the ad-hoc `model-sdk-vN` tag. Deleted `model-sdk-v1`.

Bumps the repo to **0.4.0**. Tagging `v0.4.0` after merge is what the model repos pin their `includes` to; the publish gates skip (kotlin/js only version-bumped, so nothing republishes).