### PR TITLE
sdk-build: drop the release-highlights mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.4.0")
+    implementation("ai.desertant:core:0.4.1")
 }
 ```
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.4.0"
+version = "0.4.1"
 
 android {
     namespace = "ai.desertant.core"

--- a/sdk-build/README.md
+++ b/sdk-build/README.md
@@ -34,9 +34,6 @@ tools = { node = "22" }
 run = "npm test"
 ```
 
-An optional `RELEASE_HIGHLIGHTS.md` at the repo root is appended to the
-`publish-swift` GitHub release notes.
-
 ## What the catalog owns
 
 `build`, `build-swift`, `build-android`, `build-web`, `node-natives`,

--- a/sdk-build/model-sdk.toml
+++ b/sdk-build/model-sdk.toml
@@ -23,7 +23,6 @@
 #
 # The release version is single-sourced from packages/<model>-node/package.json;
 # the two Gradle module versions must match it (the publish tasks verify).
-# publish-swift appends an optional RELEASE_HIGHLIGHTS.md from the repo root.
 
 # ---------------------------------------------------------------- build
 
@@ -327,10 +326,6 @@ cat > "$notes" <<EOF
 - Android bundled model resources: ai.desertant:{{ vars.model }}-tflite-resources:$VERSION
 - npm: @desert-ant-labs/{{ vars.model }}@$VERSION
 EOF
-# Optional per-repo marketing bullets.
-if [ -f RELEASE_HIGHLIGHTS.md ]; then
-    { echo; echo "## Highlights"; echo; cat RELEASE_HIGHLIGHTS.md; } >> "$notes"
-fi
 
 if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
     echo "release exists: https://github.com/$REPO/releases/tag/$TAG"


### PR DESCRIPTION
Removes the `RELEASE_HIGHLIGHTS.md` block from the catalog's `publish-swift` (and the README/comment mentions). Release notes are just the Packages section now. Bumps to 0.4.1; the model repos will repin their `includes` to `v0.4.1` and drop their `RELEASE_HIGHLIGHTS.md` files.