### PR TITLE
Bump to 0.4.2 (release the Gradle plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.4.1")
+    implementation("ai.desertant:core:0.4.2")
 }
 ```
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.4.1"
+version = "0.4.2"
 
 android {
     namespace = "ai.desertant.core"


### PR DESCRIPTION
Aligns kotlin/js to 0.4.2 (the plugin is already 0.4.2). Tagging `v0.4.2` publishes the Gradle plugin; Android/npm skip (only version-bumped).