### PR TITLE
ci: move publish credentials to organization secrets

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -4,7 +4,7 @@ name: Publish Android
 # tag (vX.Y.Z) is pushed, but only if the artifact actually changed. The artifact
 # is pure Kotlin, so this needs no emulator and no Swift toolchain: it runs
 # `mise run publish-android`, driven by the runner's Android SDK and a mise JDK.
-# Credentials come from the `maven-central` GitHub Environment secrets.
+# Credentials come from Desert-Ant-Labs organization secrets.
 #
 # Release model: `mise run set-version X.Y.Z` bumps every artifact's version (so
 # they stay current), you commit and push `vX.Y.Z`, and each publish workflow
@@ -13,11 +13,19 @@ name: Publish Android
 # nothing but version lines republishes nothing. Published versions may skip
 # (an unchanged artifact keeps its last published version until it next changes).
 #
-# Environment `maven-central` secrets (set with `gh secret set --env maven-central`):
+# Organization secrets (set once for the whole org with
+# `gh secret set <NAME> --org Desert-Ant-Labs --repos desert-ant-core,shapes,emo,redact`),
+# so every SDK repo publishes with the same credentials and there is one place
+# to rotate them:
 #   MAVEN_CENTRAL_USERNAME          Central portal token username
 #   MAVEN_CENTRAL_PASSWORD          Central portal token password
 #   SIGNING_IN_MEMORY_KEY           ASCII-armored GPG private key (multiline)
 #   SIGNING_IN_MEMORY_KEY_PASSWORD  passphrase for that key
+#
+# The `maven-central` environment below holds no secrets; it is kept only as an
+# optional approval gate (add required reviewers to it to gate releases) and for
+# deployment history. Never add a secret to it - environment secrets shadow
+# organization ones.
 
 on:
   push:

--- a/.github/workflows/publish-gradle-plugin.yml
+++ b/.github/workflows/publish-gradle-plugin.yml
@@ -3,7 +3,10 @@ name: Publish Gradle plugin
 # Publish the ai.desertant model-SDK Gradle plugin to Maven Central when a
 # release tag (vX.Y.Z) is pushed, but only if it actually changed. Pure JVM (no
 # Android SDK), so it just runs `mise run publish-plugin`. Credentials come from
-# the `maven-central` GitHub Environment secrets.
+# the Desert-Ant-Labs organization secrets (MAVEN_CENTRAL_* / SIGNING_IN_MEMORY_*).
+# The `maven-central` environment below holds no secrets; it is kept only as an
+# optional approval gate. Never add a secret to it - environment secrets shadow
+# organization ones.
 #
 # Same publish-on-change model as the other artifacts: `mise run set-version`
 # bumps every version, the tag names the release, and this publishes only when

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,8 +2,8 @@ name: Publish npm
 
 # Publish the @desert-ant-labs/core npm package when a release tag (vX.Y.Z) is
 # pushed, but only if the package actually changed. Pure JS, no build step, so it
-# just runs `mise run publish-npm`. The token comes from the `npm` GitHub
-# Environment secret.
+# just runs `mise run publish-npm`. The token comes from the Desert-Ant-Labs
+# organization secrets.
 #
 # Release model: `mise run set-version X.Y.Z` bumps every artifact's version (so
 # they stay current), you commit and push `vX.Y.Z`, and each publish workflow
@@ -12,8 +12,15 @@ name: Publish npm
 # nothing but version lines republishes nothing. Published versions may skip
 # (an unchanged artifact keeps its last published version until it next changes).
 #
-# Environment `npm` secret (set with `gh secret set --env npm`):
+# Organization secret (set once for the whole org with
+# `gh secret set NPM_TOKEN --org Desert-Ant-Labs --repos desert-ant-core,shapes,emo,redact`),
+# so every SDK repo publishes with the same credential and there is one place to
+# rotate it:
 #   NPM_TOKEN  npm automation token with publish rights on @desert-ant-labs
+#
+# The `npm` environment below holds no secrets; it is kept only as an optional
+# approval gate and for deployment history. Never add a secret to it -
+# environment secrets shadow organization ones.
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -226,19 +226,35 @@ mise run set-version 0.3.2   # bumps kotlin/build.gradle.kts, js/package.json, R
 git tag v0.3.2 && git push origin v0.3.2
 ```
 
-Two workflows react to the tag, each independent, and each publishes its artifact
-only if it actually changed:
+Three workflows react to the tag, each independent, and each publishes its
+artifact only if it actually changed:
 
 - `Publish Android` (`.github/workflows/publish-android.yml`) runs
   `mise run publish-android` when the tag matches the `kotlin/build.gradle.kts`
-  version **and** `kotlin/` changed since the previous tag. Credentials: the
-  `maven-central` GitHub Environment secrets (`MAVEN_CENTRAL_USERNAME`,
-  `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`,
-  `SIGNING_IN_MEMORY_KEY_PASSWORD`).
+  version **and** `kotlin/` changed since the previous tag.
 - `Publish npm` (`.github/workflows/publish-npm.yml`) runs `mise run publish-npm`
   when the tag matches the `js/package.json` version **and** `js/` changed since
-  the previous tag. Credentials: the `npm` GitHub Environment secret
-  (`NPM_TOKEN`).
+  the previous tag.
+- `Publish Gradle plugin` (`.github/workflows/publish-gradle-plugin.yml`) runs
+  `mise run publish-plugin` when the tag matches the
+  `gradle-plugin/build.gradle.kts` version **and** `gradle-plugin/` changed since
+  the previous tag.
+
+Credentials are **Desert-Ant-Labs organization secrets**, shared by every SDK
+repo so there is a single place to rotate them: `MAVEN_CENTRAL_USERNAME`,
+`MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`,
+`SIGNING_IN_MEMORY_KEY_PASSWORD`, and `NPM_TOKEN`. They are scoped to the
+publishing repos:
+
+```bash
+gh secret set MAVEN_CENTRAL_USERNAME --org Desert-Ant-Labs \
+    --repos desert-ant-core,shapes,emo,redact
+```
+
+The `maven-central` and `npm` environments hold **no** secrets; they are kept
+only as optional approval gates (add required reviewers to gate a release) and
+for deployment history. Do not add secrets to them - environment secrets shadow
+organization ones.
 
 A **pure version bump does not count as a change**, so a blanket `set-version`
 that touches nothing but version lines republishes nothing. An artifact that did


### PR DESCRIPTION
Moves the Maven Central + npm credentials from desert-ant-core's `maven-central`/`npm` **Environments** to **Desert-Ant-Labs organization secrets**.

## What changed
- **Org secrets created** (scoped `SELECTED` to the publishing repos: `desert-ant-core, shapes, emo, redact`): `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`, `SIGNING_IN_MEMORY_KEY_PASSWORD`, `NPM_TOKEN`.
- **Deleted from core's environments** - both environments now hold zero secrets.
- **Workflows**: no logic change needed (`secrets.*` resolves environment → repo → org, so removing the env secrets lets the org ones through). Comments updated to document the org as the source, plus a warning never to re-add secrets to the environments since **environment secrets shadow organization ones**.
- **Environments kept** as optional approval gates (add required reviewers to gate a release) and for deployment history. Say the word if you'd rather I delete them outright.
- **README**: documents the org secrets + scoping command, and fixes a stale line that said "Two workflows react to the tag" (there are three since the Gradle plugin landed).

## Why scoped rather than org-wide
The org has ~50 repos; these are publish credentials (Central token + GPG key + npm token). `SELECTED` keeps the blast radius to the four repos that actually publish. Easy to widen - just add repos to the `--repos` list.

## Verification
Ran a temporary branch-triggered workflow that reads the secrets through the same `environment:` path the publish jobs use:
```
maven: success   MAVEN_CENTRAL_USERNAME (6 bytes), MAVEN_CENTRAL_PASSWORD (33),
                 SIGNING_IN_MEMORY_KEY (877, PGP armor OK), ..._PASSWORD (32)
npm:   success   NPM_TOKEN (40 bytes), npm_ prefix OK
```
The armor/prefix assertions are exactly the checks that would have caught the earlier dict-repr corruption. Temp workflow and branch have been deleted.

## Follow-up now unblocked
shapes/emo/redact have org access, so they can get the same tag-driven publish workflows instead of publishing manually from a dev machine's `mise.local.toml`.