### PR TITLE
ci: widen publish org secrets to all repos

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -13,10 +13,10 @@ name: Publish Android
 # nothing but version lines republishes nothing. Published versions may skip
 # (an unchanged artifact keeps its last published version until it next changes).
 #
-# Organization secrets (set once for the whole org with
-# `gh secret set <NAME> --org Desert-Ant-Labs --repos desert-ant-core,shapes,emo,redact`),
-# so every SDK repo publishes with the same credentials and there is one place
-# to rotate them:
+# Organization secrets, visibility `all` (set once for the whole org with
+# `gh secret set <NAME> --org Desert-Ant-Labs --visibility all`), so every SDK
+# repo - including new model SDKs, with no per-repo setup - publishes with the
+# same credentials and there is one place to rotate them:
 #   MAVEN_CENTRAL_USERNAME          Central portal token username
 #   MAVEN_CENTRAL_PASSWORD          Central portal token password
 #   SIGNING_IN_MEMORY_KEY           ASCII-armored GPG private key (multiline)

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -12,10 +12,10 @@ name: Publish npm
 # nothing but version lines republishes nothing. Published versions may skip
 # (an unchanged artifact keeps its last published version until it next changes).
 #
-# Organization secret (set once for the whole org with
-# `gh secret set NPM_TOKEN --org Desert-Ant-Labs --repos desert-ant-core,shapes,emo,redact`),
-# so every SDK repo publishes with the same credential and there is one place to
-# rotate it:
+# Organization secret, visibility `all` (set once for the whole org with
+# `gh secret set NPM_TOKEN --org Desert-Ant-Labs --visibility all`), so every SDK
+# repo - including new model SDKs, with no per-repo setup - publishes with the
+# same credential and there is one place to rotate it:
 #   NPM_TOKEN  npm automation token with publish rights on @desert-ant-labs
 #
 # The `npm` environment below holds no secrets; it is kept only as an optional

--- a/README.md
+++ b/README.md
@@ -243,13 +243,18 @@ artifact only if it actually changed:
 Credentials are **Desert-Ant-Labs organization secrets**, shared by every SDK
 repo so there is a single place to rotate them: `MAVEN_CENTRAL_USERNAME`,
 `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`,
-`SIGNING_IN_MEMORY_KEY_PASSWORD`, and `NPM_TOKEN`. They are scoped to the
-publishing repos:
+`SIGNING_IN_MEMORY_KEY_PASSWORD`, and `NPM_TOKEN`. They use visibility `all`, so
+a **new model SDK repo publishes with no secret setup at all** - it just needs
+the publish workflows:
 
 ```bash
-gh secret set MAVEN_CENTRAL_USERNAME --org Desert-Ant-Labs \
-    --repos desert-ant-core,shapes,emo,redact
+gh secret set MAVEN_CENTRAL_USERNAME --org Desert-Ant-Labs --visibility all
 ```
+
+Note that GitHub has no "public repositories only" scope (visibility is `all`,
+`private`, or `selected`), so `all` also exposes these to the org's private
+repos. Any workflow in any org repo can therefore read the publish credentials;
+they are not readable from fork pull requests. Rotate via the same command.
 
 The `maven-central` and `npm` environments hold **no** secrets; they are kept
 only as optional approval gates (add required reviewers to gate a release) and


### PR DESCRIPTION
Switches the five publish org secrets from `SELECTED` to **`ALL`** so new model SDK repos publish with **zero secret setup** - they only need the publish workflows.

## Changed
- Org secrets `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_IN_MEMORY_KEY`, `SIGNING_IN_MEMORY_KEY_PASSWORD`, `NPM_TOKEN` → visibility `all` (values unchanged and re-verified: 878-byte PGP-armored key, `npm_` token).
- Workflow comments + README updated: rotation is now `gh secret set <NAME> --org Desert-Ant-Labs --visibility all`.

## One thing worth knowing
GitHub has **no "public repositories only" scope** - visibility is `all`, `private`, or `selected`. So `all` also exposes these to the org's private repos (the training repos, etc.), not just the public SDKs. In practice that means any workflow in any org repo can read the publish credentials. They are *not* exposed to pull requests from forks, so the realistic exposure is someone with write access to any org repo. Documented in the README.

If you'd rather bound that, the alternative is keeping `selected` and adding each new SDK repo when it's created (one command per repo) - happy to switch back.