### PR TITLE
ci: add the shared model-SDK release workflow

### DIFF
--- a/.github/workflows/model-sdk-release.yml
+++ b/.github/workflows/model-sdk-release.yml
@@ -1,0 +1,322 @@
+name: Model SDK release
+
+# The shared, tag-driven release pipeline for every Desert Ant model SDK
+# (shapes, emo, redact, ...). Each SDK repo has an ~8-line caller workflow:
+#
+#   name: Release
+#   on:
+#     push:
+#       tags: ["v*"]
+#     workflow_dispatch:          # dry-run the build paths without publishing
+#   jobs:
+#     release:
+#       uses: Desert-Ant-Labs/desert-ant-core/.github/workflows/model-sdk-release.yml@vX.Y.Z
+#       secrets: inherit
+#
+# A reusable workflow checks out the *caller's* repo at the triggering ref, so
+# this file operates on the SDK that called it while living in one place. The
+# model id is the repo name (matching `rootProject.name` and the mise catalog's
+# `vars.model`); override with the `model` input if a repo is ever named
+# differently.
+#
+# Publish-on-change, matching desert-ant-core's own release model: the tag names
+# the release, and each artifact ships only if its sources changed since the
+# previous tag - a pure version bump does not count. Published versions may skip.
+#
+#   SwiftPM  the tag itself is the release, so a GitHub Release is always created
+#   Android  ai.desertant:<model> (+ :<model>-tflite-resources) -> Maven Central
+#   npm      @desert-ant-labs/<model> -> npm, with prebuilt natives for
+#            linux-x64, linux-arm64, and darwin-arm64 built in a matrix
+#
+# Credentials are Desert-Ant-Labs organization secrets (visibility `all`), so a
+# new SDK repo needs no secret setup - only the caller workflow above.
+#
+# The Linux natives build on ubuntu-22.04 (glibc 2.35) on purpose: the published
+# libs must run on Ubuntu 22.04+/Debian 12+, not just the build host.
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: "Model id (defaults to the repository name)"
+        type: string
+        required: false
+        default: ""
+      dry_run:
+        description: "Run the gates and builds but skip every publish"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write # create the GitHub Release
+
+jobs:
+  gate:
+    name: what should this tag publish?
+    runs-on: ubuntu-latest
+    outputs:
+      model: ${{ steps.g.outputs.model }}
+      version: ${{ steps.g.outputs.version }}
+      android: ${{ steps.g.outputs.android }}
+      npm: ${{ steps.g.outputs.npm }}
+      dry: ${{ steps.g.outputs.dry }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags, to diff against the previous tag
+
+      - id: g
+        shell: bash
+        run: |
+          set -euo pipefail
+          MODEL="${{ inputs.model }}"
+          [ -n "$MODEL" ] || MODEL="${GITHUB_REPOSITORY##*/}"
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+
+          # The release version is single-sourced from the npm package; the two
+          # Gradle modules must match it (the mise check-version task verifies).
+          VERSION=$(sed -n 's/^  "version": "\([^"]*\)",$/\1/p' "packages/$MODEL-node/package.json")
+          [ -n "$VERSION" ] || { echo "no version in packages/$MODEL-node/package.json" >&2; exit 1; }
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # A manual run is always a dry run over both build paths, so the heavy
+          # cross-compiles can be exercised without cutting a release.
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "manual run: dry-running both build paths at $VERSION"
+            { echo "android=true"; echo "npm=true"; echo "dry=true"; } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "dry=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+
+          TAG="${GITHUB_REF_NAME}"
+          if [ "${TAG#v}" != "$VERSION" ]; then
+            echo "tag ${TAG} != $MODEL ${VERSION}; publishing nothing." >&2
+            { echo "android=false"; echo "npm=false"; } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+          if [ -z "$PREV" ]; then
+            echo "no previous tag; publishing everything."
+            { echo "android=true"; echo "npm=true"; } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A path counts as changed if any file under it changed, ignoring
+          # version-only edits to the manifests `mise run set-version` rewrites.
+          changed() { # $@ = paths
+            local files
+            files=$(git diff --name-only "$PREV" "$TAG" -- "$@")
+            [ -n "$files" ] || { echo no; return; }
+            local body
+            body=$(git diff "$PREV" "$TAG" -- "$@" \
+              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+              | grep -vE '^[+-]version = "' \
+              | grep -vE '^[+-]  "version": "' || true)
+            [ -n "$body" ] && echo yes || echo no
+          }
+          # Sources/ is shared by both artifacts, so a pipeline change ships both.
+          AND=$(changed "Sources/" "packages/$MODEL-kotlin/")
+          NPM=$(changed "Sources/" "packages/$MODEL-node/")
+          echo "since ${PREV}: android=$AND npm=$NPM"
+          { echo "android=$([ "$AND" = yes ] && echo true || echo false)"
+            echo "npm=$([ "$NPM" = yes ] && echo true || echo false)"; } >> "$GITHUB_OUTPUT"
+
+  # ------------------------------------------------------------------ Android
+
+  android:
+    name: Publish ai.desertant:${{ needs.gate.outputs.model }} to Maven Central
+    needs: gate
+    if: needs.gate.outputs.android == 'true'
+    runs-on: ubuntu-latest
+    environment: maven-central
+    steps:
+      - uses: actions/checkout@v4
+
+      # The Swift toolchain + Android SDK bundle + NDK are large; the runner is
+      # tight on disk once they land alongside the preinstalled toolchains.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+                      /opt/hostedtoolcache/CodeQL /usr/local/lib/node_modules || true
+          sudo docker image prune --all --force || true
+          df -h /
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+
+      # `android-natives` builds against the finagolfin API-24 Swift Android SDK
+      # under a pinned OSS toolchain, which it manages with swiftly.
+      - name: Install swiftly
+        run: |
+          set -euo pipefail
+          curl -fSL -o /tmp/swiftly.tar.gz \
+            "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
+          mkdir -p /tmp/swiftly && tar -xzf /tmp/swiftly.tar.gz -C /tmp/swiftly
+          /tmp/swiftly/swiftly init --assume-yes --skip-install --quiet-shell-followup
+          echo "$HOME/.local/share/swiftly/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # The OSS toolchain (~800 MB) and the Android SDK bundle (~370 MB) install
+      # on demand; cache both so only the first release pays for them.
+      - name: Cache Swift Android toolchain + SDK
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/swiftly
+            ~/.swiftpm/swift-sdks
+            Vendor/litert
+          key: swift-android-6.2.0-api24-litert-2.1.6
+
+      - name: Build the AAR
+        run: mise run build-android
+
+      - name: Publish to Maven Central
+        if: needs.gate.outputs.dry != 'true'
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
+        run: mise run publish-android
+
+  # ---------------------------------------------------------------------- npm
+
+  # The npm package ships a prebuilt native core per server-side target. Cross-OS
+  # builds aren't possible, so each is built on its own runner and gathered by
+  # the publish job. Linux builds on ubuntu-22.04 (glibc 2.35) so the published
+  # libs run on Ubuntu 22.04+/Debian 12+, not just the build host.
+  node-natives:
+    name: native ${{ matrix.target }}
+    needs: gate
+    if: needs.gate.outputs.npm == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            runner: ubuntu-22.04
+          - target: linux-arm64
+            runner: ubuntu-22.04-arm
+          - target: darwin-arm64
+            runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Linux build deps (static Foundation autolinks these)
+        if: startsWith(matrix.target, 'linux')
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            libcurl4-openssl-dev libxml2-dev zlib1g-dev binutils file
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+
+      - name: Build the native core
+        run: mise run node-natives
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.target }}
+          path: packages/${{ needs.gate.outputs.model }}-node/native/${{ matrix.target }}/
+          if-no-files-found: error
+          retention-days: 1
+
+  npm:
+    name: Publish @desert-ant-labs/${{ needs.gate.outputs.model }} to npm
+    needs: [gate, node-natives]
+    if: needs.gate.outputs.npm == 'true'
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+
+      # Gather every prebuilt native back into the package before publishing, so
+      # the tarball carries all three server-side targets.
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: native-*
+          path: /tmp/natives
+
+      - name: Stage the natives
+        run: |
+          set -euo pipefail
+          MODEL="${{ needs.gate.outputs.model }}"
+          dest="packages/$MODEL-node/native"
+          mkdir -p "$dest"
+          for d in /tmp/natives/native-*; do
+            key="${d##*/native-}"
+            mkdir -p "$dest/$key"
+            cp -a "$d"/. "$dest/$key/"
+          done
+          find "$dest" -type f | sort
+          # Every supported target must be present or the package is broken.
+          for t in linux-x64 linux-arm64 darwin-arm64; do
+            [ -d "$dest/$t" ] || { echo "missing native for $t" >&2; exit 1; }
+          done
+
+      - name: Build the WebAssembly core
+        run: mise run build-web
+
+      - name: Publish to npm
+        if: needs.gate.outputs.dry != 'true'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: mise run publish-web
+
+  # ------------------------------------------------------------------ release
+
+  release:
+    name: GitHub Release
+    needs: gate
+    if: github.ref_type == 'tag' && needs.gate.outputs.dry != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODEL: ${{ needs.gate.outputs.model }}
+          VER: ${{ needs.gate.outputs.version }}
+          AND: ${{ needs.gate.outputs.android }}
+          NPM: ${{ needs.gate.outputs.npm }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release $TAG already exists; nothing to do."; exit 0
+          fi
+          PRODUCT="$(printf '%s' "${MODEL:0:1}" | tr '[:lower:]' '[:upper:]')${MODEL:1}"
+          notes=$(mktemp)
+          {
+            echo "## Packages"
+            echo
+            echo "- SwiftPM: \`.package(url: \"https://github.com/${GITHUB_REPOSITORY}.git\", from: \"${VER}\")\`"
+            if [ "$AND" = true ]; then
+              echo "- Android: \`ai.desertant:${MODEL}:${VER}\` (Maven Central)"
+              echo "- Android bundled model resources: \`ai.desertant:${MODEL}-tflite-resources:${VER}\`"
+            fi
+            [ "$NPM" = true ] && echo "- npm: \`@desert-ant-labs/${MODEL}@${VER}\`"
+            if [ "$AND" != true ] && [ "$NPM" != true ]; then
+              echo
+              echo "_SwiftPM-only release; the Android and npm artifacts did not change._"
+            fi
+          } > "$notes"
+          jq -n --arg tag "$TAG" --arg name "$PRODUCT $VER" --rawfile body "$notes" \
+            '{tag_name: $tag, name: $name, body: $body, generate_release_notes: true}' \
+            | gh api "repos/${GITHUB_REPOSITORY}/releases" --input - >/dev/null
+          echo "created release $TAG (android=$AND npm=$NPM)"

--- a/sdk-build/README.md
+++ b/sdk-build/README.md
@@ -48,6 +48,39 @@ is the single source of truth), `Sources/<Product>TFLiteResources/Resources`,
 and `Desert-Ant-Labs/<model>` / `ai.desertant:<model>` / `@desert-ant-labs/<model>`
 coordinates.
 
+## Releasing a model SDK
+
+Releases are tag-driven and shared: every SDK repo calls one reusable workflow,
+`.github/workflows/model-sdk-release.yml` in this repo, so the pipeline is
+defined once.
+
+```yaml
+# <model>/.github/workflows/release.yml  - the whole thing
+name: Release
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:        # dry-runs the build paths without publishing
+jobs:
+  release:
+    uses: Desert-Ant-Labs/desert-ant-core/.github/workflows/model-sdk-release.yml@v0.4.3
+    secrets: inherit
+```
+
+`mise run set-version X.Y.Z`, commit, push `vX.Y.Z`, and it publishes only what
+changed since the previous tag (a pure version bump counts as no change):
+
+| Artifact | Ships when |
+|---|---|
+| GitHub Release (the SwiftPM release) | always - the tag *is* the release |
+| `ai.desertant:<model>` + `:<model>-tflite-resources` | `Sources/` or `packages/<model>-kotlin/` changed |
+| `@desert-ant-labs/<model>` | `Sources/` or `packages/<model>-node/` changed |
+
+The npm job builds the prebuilt native core for linux-x64, linux-arm64, and
+darwin-arm64 in a matrix and gathers them into the tarball, replacing the manual
+per-platform build. Credentials are organization secrets, so a new SDK repo needs
+no secret setup - just the caller workflow above.
+
 ## Versioning
 
 The catalog rides desert-ant-core's own `vX.Y.Z` release tags: pin `includes` to


### PR DESCRIPTION
One reusable workflow every model SDK calls, so the release pipeline is defined **once** instead of copied into each SDK repo.

## How it works
A reusable workflow (`workflow_call`) checks out the **caller's** repo at the triggering ref - so the logic lives here and operates on whichever SDK invoked it. Each SDK repo gets ~8 lines:

```yaml
jobs:
  release:
    uses: Desert-Ant-Labs/desert-ant-core/.github/workflows/model-sdk-release.yml@v0.4.3
    secrets: inherit
```

Model id defaults to the repo name (same convention as `rootProject.name` and the mise catalog's `vars.model`).

## Publish-on-change, same as core
| Artifact | Ships when |
|---|---|
| GitHub Release (SwiftPM) | always - the tag *is* the release |
| `ai.desertant:<model>` + `-tflite-resources` | `Sources/` or `packages/<model>-kotlin/` changed |
| `@desert-ant-labs/<model>` | `Sources/` or `packages/<model>-node/` changed |

Version-only manifest edits don't count, so a blanket `set-version` republishes nothing. `Sources/` is shared, so a pipeline change correctly ships both.

## The npm path replaces a manual process
Today the server-side natives are built by hand (shapes has a `workflow_dispatch` for linux-arm64, then someone downloads the artifact). This builds **linux-x64 / linux-arm64 / darwin-arm64** in a matrix, gathers them into the tarball, and fails if any target is missing. Linux runs on `ubuntu-22.04` (glibc 2.35) to keep the documented Ubuntu 22.04+/Debian 12+ floor.

## Safe to try before trusting
A manual `workflow_dispatch` run **always dry-runs both build paths** - full Swift cross-compiles, no publish. That's how I'd validate on shapes before any real release.

## Not yet validated
The Android cross-compile and the 3-platform native matrix have never run in CI for the SDKs; I can't exercise them from here (no Swift toolchain, no macOS). Expect the first dry run to need tuning - most likely the swiftly install or the toolchain cache key. Caller PRs follow.