### PR TITLE
ci: install the system deps the SDK release jobs assume

### DIFF
--- a/.github/workflows/model-sdk-release.yml
+++ b/.github/workflows/model-sdk-release.yml
@@ -143,6 +143,14 @@ jobs:
           sudo docker image prune --all --force || true
           df -h /
 
+      # The swiftly-installed OSS toolchain needs these; swiftly warns about
+      # libcurl explicitly and the build fails without them.
+      - name: Swift toolchain system deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            libcurl4-openssl-dev libxml2-dev zlib1g-dev
+
       - name: Set up mise
         uses: jdx/mise-action@v2
         with:
@@ -218,6 +226,13 @@ jobs:
         uses: jdx/mise-action@v2
         with:
           install: false
+
+      # `litert-libs` extracts libLiteRt.so from the ai-edge-litert wheel with uv,
+      # which dev machines have but runners do not.
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Build the native core
         run: mise run node-natives


### PR DESCRIPTION
Fixes from the first dry run of the shared release workflow (shapes). Two missing runner deps, both present on dev machines so neither showed up locally:

- **`uv`** - `litert-libs` extracts `libLiteRt.so` from the ai-edge-litert wheel with uv. `uv: command not found` failed both Linux native jobs.
- **`libcurl4-openssl-dev`** - the swiftly-installed OSS toolchain needs it (swiftly prints the warning itself). Without it `android-natives` failed immediately after installing Swift 6.2.0.

What already worked on that run: the gate, dry-run skipping of both publishes, the job graph, artifact naming, and the **darwin-arm64 native built successfully**.