### PR TITLE
Bump to 0.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.4.3")
+    implementation("ai.desertant:core:0.4.4")
 }
 ```
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.4.3"
+version = "0.4.4"
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.7.3")

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.4.3"
+version = "0.4.4"
 
 android {
     namespace = "ai.desertant.core"


### PR DESCRIPTION
Tag so the SDK callers can pin the release-workflow dependency fixes. Publishes nothing (version-only).