### PR TITLE
ci: run android-natives as its own step so failures are diagnosable

### DIFF
--- a/.github/workflows/model-sdk-release.yml
+++ b/.github/workflows/model-sdk-release.yml
@@ -179,6 +179,11 @@ jobs:
             Vendor/litert
           key: swift-android-6.2.0-api24-litert-2.1.6
 
+      # Run the cross-compile as its own step: Gradle's Exec task swallows the
+      # underlying mise stderr, which makes failures here undiagnosable.
+      - name: Cross-compile the Android natives
+        run: mise run android-natives
+
       - name: Build the AAR
         run: mise run build-android
 


### PR DESCRIPTION
The Android job fails inside `mise run build-android` → Gradle → `Exec` → `mise run android-natives`, and Gradle's Exec swallows the child's stderr, so the log only shows `Process 'command 'mise'' finished with non-zero exit value 1`.

Running the cross-compile as its own step surfaces its output. `build-android` then just packages the AAR (the Gradle task is up-to-date by then).

Everything else in the pipeline is now green on a real dry run: gate, all three natives (linux-x64, linux-arm64, darwin-arm64), the npm gather + wasm build, and correct dry-run skipping.