### PR TITLE
sdk-build: let the Android SDK describe its own resource layout

### DIFF
--- a/sdk-build/model-sdk.toml
+++ b/sdk-build/model-sdk.toml
@@ -485,21 +485,15 @@ for pair in "arm64-v8a:aarch64" "x86_64:x86_64"; do
     abi=${pair%:*}
     arch=${pair#*:}
     echo "== $abi ($arch) =="
-    # finagolfin names the static stdlib dir per-arch (swift_static-<arch>), but the
-    # driver derives the runtime dir as a sibling `swift_static/`, so bridge it with
-    # a per-arch symlink and point -resource-dir at it (yields a self-contained .so).
-    resources=$(find "$BUNDLE" -type d -name "swift_static-$arch" 2>/dev/null | head -1)
-    [ -n "$resources" ] || { echo "error: swift_static-$arch not found in $BUNDLE" >&2; exit 1; }
-    libdir=$(dirname "$resources")
-    # `ln -sfn` links *inside* the target when it already exists as a real
-    # directory, which would leave the sibling pointing somewhere with no
-    # android/ subdir. Clear it first so the symlink is always the link itself.
-    [ -L "$libdir/swift_static" ] || rm -rf "$libdir/swift_static"
-    ln -sfn "swift_static-$arch" "$libdir/swift_static"
-    # Point -resource-dir at the real per-arch dir (as desert-ant-core's own
-    # green Android CI does) rather than the sibling symlink, so the Android
-    # overlay + android.modulemap resolve unambiguously.
-    SW swift build -c release --product {{ vars.product }}Android --swift-sdk "$arch-unknown-linux-android$API" -Xswiftc -static-stdlib -Xswiftc -resource-dir -Xswiftc "$resources" -Xlinker -LVendor/litert/lib/android-$arch
+    # No -resource-dir override: the bundle's swift-sdk.json already declares
+    #   sdkRootPath              android-27d-sysroot
+    #   swiftStaticResourcesPath android-27d-sysroot/usr/lib/swift_static-<arch>
+    # per triple, and SwiftPM applies the static one for -static-stdlib. Passing
+    # -resource-dir by hand clobbered the sysroot association the SDK sets up, so
+    # Android.swiftmodule resolved but its SwiftAndroid C module (declared in
+    # android/<arch>/android.modulemap) did not - the "missing required module
+    # 'SwiftAndroid'" failure. Let the SDK describe its own layout.
+    SW swift build -c release --product {{ vars.product }}Android --swift-sdk "$arch-unknown-linux-android$API" -Xswiftc -static-stdlib -Xlinker -LVendor/litert/lib/android-$arch
 
     dest="$KOTLIN/jniLibs/$abi"
     rm -rf "$dest" && mkdir -p "$dest"


### PR DESCRIPTION
Root cause found, with evidence from the bundle itself.

The task passed `-Xswiftc -resource-dir` by hand. That clobbers the sysroot association SwiftPM sets up from the SDK descriptor, so `Android.swiftmodule` resolved but the `SwiftAndroid` C module it depends on (declared in `android/<arch>/android.modulemap`) did not - producing `missing required module 'SwiftAndroid'`.

The bundle's own `swift-sdk.json` already declares, per triple:
```json
"aarch64-unknown-linux-android24": {
  "sdkRootPath": "android-27d-sysroot",
  "swiftResourcesPath": "android-27d-sysroot/usr/lib/swift",
  "swiftStaticResourcesPath": "android-27d-sysroot/usr/lib/swift_static-aarch64"
}
```
`swiftStaticResourcesPath` is exactly what the override was setting, and SwiftPM picks the static one for `-static-stdlib`. So the override was redundant *and* harmful.

Removes the `-resource-dir` flag and the `swift_static` symlink dance.