### PR TITLE
ci: count manifest changes in the model-SDK publish gates

### DIFF
--- a/.github/workflows/model-sdk-release.yml
+++ b/.github/workflows/model-sdk-release.yml
@@ -116,9 +116,11 @@ jobs:
               | grep -vE '^[+-]  "version": "' || true)
             [ -n "$body" ] && echo yes || echo no
           }
-          # Sources/ is shared by both artifacts, so a pipeline change ships both.
-          AND=$(changed "Sources/" "packages/$MODEL-kotlin/")
-          NPM=$(changed "Sources/" "packages/$MODEL-node/")
+          # Sources/ and the manifest are shared by both artifacts (the manifest
+          # pins desert-ant-core, whose code is compiled into both the AAR and the
+          # Node native), so a change to either ships both.
+          AND=$(changed "Sources/" "Package.swift" "Package.resolved" "packages/$MODEL-kotlin/")
+          NPM=$(changed "Sources/" "Package.swift" "Package.resolved" "packages/$MODEL-node/")
           echo "since ${PREV}: android=$AND npm=$NPM"
           { echo "android=$([ "$AND" = yes ] && echo true || echo false)"
             echo "npm=$([ "$NPM" = yes ] && echo true || echo false)"; } >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.5.0")
+    implementation("ai.desertant:core:0.5.1")
 }
 ```
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.0"
+version = "0.5.1"
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.7.3")

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.0"
+version = "0.5.1"
 
 android {
     namespace = "ai.desertant.core"


### PR DESCRIPTION
The gates checked `Sources/` and `packages/<model>-*/` but **not `Package.swift`**. Since the manifest pins desert-ant-core - whose code is statically compiled into both the AAR and the Node native - bumping the core dependency would have produced a tag that published **nothing**.

Found while preparing the SDK bump to core 0.5.0 (which adds `Sources/Usage/`). Now both gates include `Package.swift` and `Package.resolved`.