### PR TITLE
Fix two SDK-breaking regressions from the Usage work

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.5.1")
+    implementation("ai.desertant:core:0.5.2")
 }
 ```
 

--- a/Sources/Inference/JSSession.swift
+++ b/Sources/Inference/JSSession.swift
@@ -16,11 +16,11 @@ import JavaScriptKit
 ///
 /// Bytes cross the wasm boundary raw (host byte order), so the host rebuilds
 /// typed arrays from `data.buffer`; no per-element marshalling.
-final class JSInferenceSession: InferenceSession, @unchecked Sendable {
+public final class JSInferenceSession: InferenceSession, @unchecked Sendable {
     private let runFunction: JSObject
     private let hostGlobal: String
 
-    init(hostGlobal: String, method: String = "run") throws {
+    public init(hostGlobal: String, method: String = "run") throws {
         guard let host = JSObject.global[hostGlobal].object, let function = host[method].object else {
             throw InferenceError.sessionUnavailable("missing \(hostGlobal).\(method)")
         }

--- a/Sources/Usage/AppIdentity.swift
+++ b/Sources/Usage/AppIdentity.swift
@@ -15,7 +15,9 @@ import CHostBridge
 import JavaScriptKit
 #endif
 
-#if canImport(Glibc)
+#if os(Android)
+import Android          // on Android the Android module *is* libc (getenv et al)
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Darwin)
 import Darwin

--- a/Sources/Usage/TelemetryDebug.swift
+++ b/Sources/Usage/TelemetryDebug.swift
@@ -12,6 +12,8 @@
 
 #if os(WASI)
 import JavaScriptKit
+#elseif os(Android)
+import Android          // on Android the Android module *is* libc (getenv et al)
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Darwin)

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.1"
+version = "0.5.2"
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.7.3")

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.1"
+version = "0.5.2"
 
 android {
     namespace = "ai.desertant.core"


### PR DESCRIPTION
Both surfaced when the model SDKs bumped to core 0.5.1 - core's own suites passed while shipping them.

**1. `JSInferenceSession` was narrowed to internal.**
`git diff v0.3.0..v0.5.1` shows `-public final class JSInferenceSession` → `+final class`. Every SDK's `Sources/<Model>Web/main.swift` constructs it directly, so all three wasm builds failed with `cannot find 'JSInferenceSession' in scope`. Restored `public` on the class **and** its initializer.

**2. `getenv` unresolved on Android in the Usage module.**
`AppIdentity.swift` guarded `Glibc`/`Darwin`/`Musl` but had no Android branch - and on Android the `Android` module *is* libc. Added it.

`TelemetryDebug.swift` had the **same bug** (`#if os(WASI) / #elseif canImport(Glibc)`, calls `getenv`); it was masked only because the compile stopped at the first error. Fixed too, and swept the rest of `Sources/` for libc users missing an Android branch - none remain.

Bumps to 0.5.2.

Worth following up: core's CI should build a *consumer's* wasm and Android targets, since neither regression was catchable by core's own test suites.