### PR TITLE
Make JSInferenceSession's protocol conformance public too

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.5.2")
+    implementation("ai.desertant:core:0.5.3")
 }
 ```
 

--- a/Sources/Inference/JSSession.swift
+++ b/Sources/Inference/JSSession.swift
@@ -28,7 +28,7 @@ public final class JSInferenceSession: InferenceSession, @unchecked Sendable {
         self.hostGlobal = hostGlobal
     }
 
-    func run(inputs: [String: Tensor], outputs: [String], deviceId: String?) async throws -> [Tensor] {
+    public func run(inputs: [String: Tensor], outputs: [String], deviceId: String?) async throws -> [Tensor] {
         guard let constructor = JSObject.global.Object.function else {
             throw InferenceError.runFailed("no JS Object constructor")
         }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.2"
+version = "0.5.3"
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.7.3")

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.2"
+version = "0.5.3"
 
 android {
     namespace = "ai.desertant.core"


### PR DESCRIPTION
0.5.2 restored `public` on the class and its init, but not on `run(inputs:outputs:deviceId:)` - which satisfies a requirement of the public `InferenceSession` protocol and so must also be public. The wasm build failed with:

```
method 'run(inputs:outputs:deviceId:)' must be declared public because it
matches a requirement in public protocol 'InferenceSession'
```

The other session types (CoreML, LiteRT, ORT) remain internal - they're reached via the session factory, not constructed by SDKs - so only the JS one needs public API. Bumps to 0.5.3.