### PR TITLE
sdk-build: only disable default traits when the package has traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.5.3")
+    implementation("ai.desertant:core:0.5.4")
 }
 ```
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.3"
+version = "0.5.4"
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.7.3")

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.3"
+version = "0.5.4"
 
 android {
     namespace = "ai.desertant.core"

--- a/sdk-build/model-sdk.toml
+++ b/sdk-build/model-sdk.toml
@@ -169,13 +169,19 @@ set -euo pipefail
 # they run on Ubuntu 22.04+/Debian 12+, not just the build host), and link
 # `-z nodelete` so the process doesn't dlclose the static Swift runtime at
 # shutdown (which otherwise segfaults on natural exit on some glibc versions).
+# --disable-default-traits is rejected by SwiftPM on a package that declares no
+# traits, so only pass it when the manifest actually has some. Models small
+# enough to bundle declare a BundledModel trait (disabled here, since the npm
+# package ships no SwiftPM resource bundle); larger models declare none.
+TRAITS=""
+grep -q "traits:" Package.swift && TRAITS="--disable-default-traits"
 ARCH=$(uname -m); case "$ARCH" in x86_64|amd64) NARCH=x64;; arm64|aarch64) NARCH=arm64;; *) NARCH=$ARCH;; esac
 if [ "$(uname)" = "Darwin" ]; then
     # macOS: the Node native uses Core ML (against the OS-provided Swift runtime
     # and system frameworks) and loads the bundled .mlmodelc by path - so it
     # needs no LiteRT and ships no extra runtime.
     KEY="darwin-$NARCH"; dest="packages/{{ vars.model }}-node/native/$KEY"; rm -rf "$dest" && mkdir -p "$dest"
-    swift build -c release --product {{ vars.product }}Node --disable-default-traits -Xlinker -rpath -Xlinker @loader_path
+    swift build -c release --product {{ vars.product }}Node $TRAITS -Xlinker -rpath -Xlinker @loader_path
     cp ".build/release/lib{{ vars.product }}Node.dylib" "$dest/"
 else
     KEY="linux-$NARCH"; dest="packages/{{ vars.model }}-node/native/$KEY"; rm -rf "$dest" && mkdir -p "$dest"
@@ -189,7 +195,7 @@ else
         [ -n "$src" ] && ln -sf "$src" "$tmp/$(echo "$so" | sed 's/\\.so.*/.so/')" || true
     done
     LARCH=$([ "$NARCH" = "x64" ] && echo linux-x64 || echo linux-arm64)
-    DAL_INFERENCE_LITERT=1 swift build -c release --product {{ vars.product }}Node --disable-default-traits -Xswiftc -static-stdlib \\
+    DAL_INFERENCE_LITERT=1 swift build -c release --product {{ vars.product }}Node $TRAITS -Xswiftc -static-stdlib \\
         -Xlinker "-L$tmp" -Xlinker "-LVendor/litert/lib/$LARCH" -Xlinker -rpath -Xlinker '$ORIGIN' \\
         -Xlinker -z -Xlinker nodelete
     cp ".build/release/lib{{ vars.product }}Node.so" "$dest/"


### PR DESCRIPTION
redact's `node-natives` failed on all three platforms:
```
error: Disabled default traits by command-line trait configuration on package
'redact' (Redact) that declares no traits. This is prohibited...
```
shapes and emo are small enough to bundle their model, so they declare a `BundledModel` trait - which `node-natives` disables, since the npm package ships no SwiftPM resource bundle. redact's model is ~23 MB and declares **no traits**, and SwiftPM rejects `--disable-default-traits` in that case.

Pass the flag only when `Package.swift` declares traits. Bumps to 0.5.4.