### PR TITLE
ci: add build workflows for core's artifacts and the model SDKs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build
+
+# Verify desert-ant-core's three published artifacts actually build. The Swift
+# package is covered per-platform by macos/ios/wasi/android.yml; these are the
+# non-Swift artifacts, which previously only ever built during a publish - so a
+# break in them stayed invisible until release time.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  kotlin:
+    name: ai.desertant:core (Android AAR)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - run: mise run build-android
+
+  js:
+    name: "@desert-ant-labs/core (npm)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - run: mise run test-js
+
+  gradle-plugin:
+    name: model-sdk Gradle plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - run: mise run build-plugin

--- a/.github/workflows/model-sdk-build.yml
+++ b/.github/workflows/model-sdk-build.yml
@@ -1,0 +1,147 @@
+name: Model SDK build
+
+# The shared build check for every Desert Ant model SDK, so each repo verifies it
+# compiles on every platform it ships to - not just at release time. Each SDK repo
+# has an ~8-line caller:
+#
+#   name: Build
+#   on:
+#     push:
+#       branches: [main]
+#     pull_request:
+#   jobs:
+#     build:
+#       uses: Desert-Ant-Labs/desert-ant-core/.github/workflows/model-sdk-build.yml@vX.Y.Z
+#
+# Same shape as model-sdk-release.yml: a reusable workflow checks out the caller's
+# repo, so the definition lives here once and runs against whichever SDK called
+# it. The model id defaults to the repository name.
+#
+# This exists because the SDKs previously had no CI at all - only tag-triggered
+# releases - so a broken build was invisible until someone cut a tag. Each job
+# maps to a platform the SDK actually ships:
+#
+#   swift-apple   the Swift package on macOS (Core ML path)
+#   swift-linux   the Swift package on Linux (LiteRT path)
+#   android       the per-ABI Swift JNI natives + the AAR
+#   wasm          the WebAssembly core the browser package embeds
+#   node-native   the prebuilt server-side core (both host OSes)
+#
+# Build-only: nothing is published and no credentials are used.
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: "Model id (defaults to the repository name)"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  swift-apple:
+    name: swift build (macOS)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - run: mise run build-swift
+
+  swift-linux:
+    name: swift build (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: mise run build-swift
+
+  android:
+    name: android natives + AAR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+                      /opt/hostedtoolcache/CodeQL /usr/local/lib/node_modules || true
+      - name: Swift toolchain system deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            libcurl4-openssl-dev libxml2-dev zlib1g-dev
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      # The snapshot toolchain (~1.2 GB) and Android SDK (~330 MB) install on
+      # demand; cache them so only the first run on a key pays for it.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/desert-ant/toolchains
+            ~/.swiftpm/swift-sdks
+            ~/.config/swiftpm/swift-sdks
+            Vendor/litert
+          key: swift-android-6.4.x-2026-07-17-a-api24-litert-2.1.6
+      - run: mise run build-android
+
+  wasm:
+    name: wasm core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.swiftpm/swift-sdks
+            ~/.config/swiftpm/swift-sdks
+          key: swift-wasm-sdk-v1
+      - run: mise run build-web
+
+  node-native:
+    name: node native (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # One runner per host OS: the Linux and macOS code paths differ (LiteRT +
+        # static Foundation vs Core ML). Linux builds on 22.04 (glibc 2.35) to
+        # match the release floor.
+        os: [ubuntu-22.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Linux build deps (static Foundation autolinks these)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            libcurl4-openssl-dev libxml2-dev zlib1g-dev
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: mise run node-natives

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vendoring the file:
 
 ```kotlin
 dependencies {
-    implementation("ai.desertant:core:0.5.4")
+    implementation("ai.desertant:core:0.5.5")
 }
 ```
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.4"
+version = "0.5.5"
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.7.3")

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.4"
+version = "0.5.5"
 
 android {
     namespace = "ai.desertant.core"

--- a/sdk-build/README.md
+++ b/sdk-build/README.md
@@ -48,6 +48,26 @@ is the single source of truth), `Sources/<Product>TFLiteResources/Resources`,
 and `Desert-Ant-Labs/<model>` / `ai.desertant:<model>` / `@desert-ant-labs/<model>`
 coordinates.
 
+## Building a model SDK (CI)
+
+Every SDK repo verifies it compiles on all its platforms via a second shared
+reusable workflow, so a broken build is caught on the PR rather than at release:
+
+```yaml
+# <model>/.github/workflows/build.yml
+name: Build
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  build:
+    uses: Desert-Ant-Labs/desert-ant-core/.github/workflows/model-sdk-build.yml@v0.5.5
+```
+
+Jobs: `swift-apple`, `swift-linux`, `android` (natives + AAR), `wasm`, and
+`node-native` on both host OSes. Build-only - no credentials, nothing published.
+
 ## Releasing a model SDK
 
 Releases are tag-driven and shared: every SDK repo calls one reusable workflow,


### PR DESCRIPTION
Each package verifies it builds for every platform it ships to - no cross-repo compatibility checking.

**`build.yml`** - core's three published artifacts (`kotlin/` AAR, `js/` npm package, `gradle-plugin/`) previously only ever built *during a publish*, so a break stayed invisible until release. The Swift package remains covered per-platform by `macos/ios/wasi/android.yml`.

**`model-sdk-build.yml`** - the shared build check each SDK calls, same reusable-workflow shape as `model-sdk-release.yml` so the definition lives here once. The SDKs had **no CI at all** - only tag-triggered releases - so a broken build went unnoticed until someone cut a tag.

Jobs: `swift-apple`, `swift-linux`, `android` (natives + AAR), `wasm`, `node-native` × {ubuntu-22.04, macos-15}. Build-only: no credentials, nothing published. Caches the snapshot toolchain and Swift SDKs so only the first run pays.

Bumps to 0.5.5; SDK callers follow.