### PR TITLE
Add AudioIO and AudioDSP modules for cross-platform audio SDKs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,10 @@ import Foundation
 //   ModelResources  SwiftPM bundle resource loading
 //   PlatformSupport environment + synchronous FFI/async bridge + HTTP client
 //   Usage        usage turnstile: builds/sends `load` events over the HTTP client
+//   AudioIO      decode to mono Float (AVFoundation | WAV codec | host MediaCodec
+//                | JS decodeAudioData) + portable 16-bit PCM WAV encode
+//   AudioDSP     STFT/ISTFT, mel, windows, framing, vector ops (Accelerate on
+//                Apple, pure Swift elsewhere)
 //   FFIBuffer    length-prefixed typed C-ABI buffer (no hand-rolled JSON)
 //   CHostBridge  generic host-callback bridge a runtime shim installs on Android
 //   HostBridge   Android JNI harness: byte marshalling + installs CHostBridge
@@ -86,6 +90,10 @@ let products: [Product] = [
         .library(name: "TextNormalization", targets: ["TextNormalization"]),
         .library(name: "FFIBuffer", targets: ["FFIBuffer"]),
         .library(name: "Checksum", targets: ["Checksum"]),
+        // Cross-platform audio: decode/encode (AudioIO) and STFT/mel/framing
+        // DSP (AudioDSP), so audio model SDKs ship no per-platform audio code.
+        .library(name: "AudioIO", targets: ["AudioIO"]),
+        .library(name: "AudioDSP", targets: ["AudioDSP"]),
         .library(name: "ModelStore", targets: ["ModelStore"]),
         .library(name: "PlatformSupport", targets: ["PlatformSupport"]),
         // Usage turnstile: builds/sends `load` events over PlatformSupport's HTTP client.
@@ -160,6 +168,19 @@ let libraryTargets: [Target] = [
                 .target(name: "CHostBridge", condition: .when(platforms: [.android])),
             ] + jsWasi
         ),
+        // Pure-Swift DSP (STFT/ISTFT, windows, mel, framing, vector ops);
+        // Accelerate-backed on Apple via canImport, so no explicit dependency.
+        .target(name: "AudioDSP"),
+        // Audio decode/encode: AVFoundation on Apple, the host decoder via
+        // CHostBridge on Android, the JS host on wasm, the pure-Swift WAV
+        // codec on Linux/other. FFIBuffer's FFIReader parses the host buffer.
+        .target(
+            name: "AudioIO",
+            dependencies: [
+                .target(name: "FFIBuffer", condition: .when(platforms: [.android])),
+                .target(name: "CHostBridge", condition: .when(platforms: [.android])),
+            ] + jsWasi + jsEventLoop
+        ),
         .target(name: "ModelResources"),
         .target(
             name: "ModelStore",
@@ -196,6 +217,9 @@ let testTargets: [Target] = [
         .testTarget(name: "TextNormalizationTests", dependencies: ["TextNormalization"]),
         .testTarget(name: "RegexTests", dependencies: ["Regex"]),
         .testTarget(name: "JSONTests", dependencies: ["JSON"]),
+        .testTarget(name: "AudioDSPTests", dependencies: ["AudioDSP"]),
+        .testTarget(name: "AudioIOTests", dependencies: ["AudioIO"]),
+        .testTarget(name: "FFIBufferTests", dependencies: ["FFIBuffer"]),
 ] + liteRTTests
 
 let coreTargets: [Target] = libraryTargets + testTargets

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ it, so the code that uses it never sees a platform `#if`:
 | `Regex` (type `Pattern`) | stdlib-`Regex`-shaped matching | `NSRegularExpression` | `java.util.regex` (via `CHostBridge`) | JS `RegExp` |
 | `JSON` | `Codable` decode + encode | `Foundation.JSONDecoder`/`Encoder` | host JSON parser (via `CHostBridge`) + tree encoder | JS `JSON.parse` + tree encoder |
 | `TextNormalization` | `String.nfkc` | Foundation `precomposed...` | platform ICU `unorm2` (`libicu`) | JS `String.normalize` |
+| `AudioIO` | decode to mono `Float` + WAV encode | AVFoundation (Apple) / WAV codec (Linux) | host MediaCodec (via `CHostBridge`) | JS `AudioContext.decodeAudioData` |
+| `AudioDSP` | STFT/ISTFT, mel, windows, framing | Accelerate BLAS/vDSP | pure Swift | pure Swift |
 | `FFIBuffer` | length-prefixed typed C-ABI buffer | same on every platform | | |
 | `HostBridge` | Android JNI harness for model SDKs | empty | JNI marshalling + installs `CHostBridge` | empty |
 | `CHostBridge` | generic host-callback C bridge | - | installed by `HostBridge` | - |
@@ -89,6 +91,51 @@ strings); the host reads it with its own standard library (see the matching
 `FfiReader` in `kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt`, a thin
 `java.nio.ByteBuffer` cursor) and
 frees it with `ffiFree`. The payload *schema* is the model's own concern.
+
+## AudioIO and AudioDSP
+
+One decode/encode API and one DSP toolbox, so an audio model SDK (clear, uhm)
+ships no per-platform audio code. `AudioIO.decode` always returns mono `Float`
+at the sample rate you ask for, resampling and mixing down for you:
+
+```swift
+import AudioIO
+
+let samples = try await AudioIO.decode(path: file, sampleRate: 16_000)  // or decode(bytes:)
+let wav = AudioIO.encodeWAV(samples, sampleRate: 16_000)                // 16-bit PCM, portable
+```
+
+`decode` is `async` (the wasm backend awaits a JS Promise; native backends
+satisfy it synchronously) and picks the backend per platform: AVFoundation on
+Apple, the pure-Swift WAV codec on Linux, the host decoder through
+`CHostBridge`'s `host_audio_decode` on Android, and
+`AudioContext.decodeAudioData` via the `__DalAudioHost` JS global on wasm.
+Encoding a 16-bit PCM WAV is pure Swift, identical everywhere.
+
+The host decoders ship in core's own runtime artifacts, so a model SDK writes no
+audio glue: `HostBridge.audioDecode` (MediaExtractor/MediaCodec) in the
+published `ai.desertant:core` Android artifact, wired by `installHostBridge`;
+and `installAudioHost()` in the `@desert-ant-labs/core` npm package (Web Audio
+in the browser, the WAV codec under Node), which sets `__DalAudioHost`.
+
+`AudioDSP` is the shared spectral/vector toolbox a speech model runs on both
+sides of inference. Pure Swift, Accelerate-backed on Apple (STFT/mel run as BLAS
+matmuls on the vector units), so every platform gets bit-compatible results:
+
+```swift
+import AudioDSP
+
+let stft = STFT(nFFT: 400, hop: 100)          // periodic Hann, center + reflect pad
+let spec = stft.forward(samples)              // magnitude()/phase() available
+let audio = stft.inverse(spec, length: samples.count)   // windowed COLA overlap-add
+
+let (norm, gain) = VectorOps.energyNormalize(samples)   // undo with scaled(_, by: 1/gain)
+let mel = MelSpectrogram(sampleRate: 16_000, nFFT: 400, hop: 160, mels: 80).logMel(samples)
+
+// Run a fixed-size model over an arbitrary-length signal and stitch outputs:
+for (start, end) in Framing.windows(count: n, window: 30 * sr, hop: 25 * sr) { /* run */ }
+var acc = OverlapAccumulator(length: totalFrames)       // average() or normalized() (COLA)
+```
 
 ## ModelStore and model resources
 
@@ -276,10 +323,14 @@ and test it locally with `mise run test-js`.
 
 ## Android wiring
 
-On Android, `Regex`/`JSON` call `host_regex_matches` / `host_json_parse` from
-`CHostBridge`; `HostBridge`'s `installHostBridge` installs the implementations
-once via `host_set_regex_matches` / `host_set_json_parse`. See
-`Sources/CHostBridge/include/CHostBridge.h` for the contract.
+On Android, `Regex`/`JSON`/`AudioIO` call `host_regex_matches` /
+`host_json_parse` / `host_audio_decode` from `CHostBridge`; `HostBridge`'s
+`installHostBridge` installs the implementations once via
+`host_set_regex_matches` / `host_set_json_parse` / `host_set_audio_decode`,
+wired to the shared `HostBridge.kt` statics (`regexMatches` / `jsonParseTree` /
+`audioDecode`) in the published `ai.desertant:core` artifact, so a model SDK
+vendors none of them. See `Sources/CHostBridge/include/CHostBridge.h` for the
+contract.
 
 ## License
 

--- a/Sources/AudioDSP/Framing.swift
+++ b/Sources/AudioDSP/Framing.swift
@@ -1,0 +1,65 @@
+// Sliding-window framing and overlap reassembly: the loop every long-audio
+// model repeats to run a fixed-size model over an arbitrary-length signal
+// (30 s windows with 5 s overlap for a detector, 100-frame chunks for an
+// enhancer) and stitch the per-window outputs back together. The model owns
+// the inference call; this owns the index math and the averaging.
+
+public enum Framing {
+    /// Half-open `[start, end)` window ranges covering `count` items with a
+    /// `window`-sized window stepped by `hop`. The final window is clamped to
+    /// `count` (so it may be shorter) and the walk stops once it reaches the
+    /// end, so there is always at least one window for a non-empty input.
+    public static func windows(count: Int, window: Int, hop: Int) -> [(start: Int, end: Int)] {
+        guard count > 0, window > 0, hop > 0 else { return [] }
+        var out: [(start: Int, end: Int)] = []
+        var start = 0
+        while start < count {
+            let end = min(count, start + window)
+            out.append((start, end))
+            if end == count { break }
+            start += hop
+        }
+        return out
+    }
+}
+
+/// Accumulates values written at overlapping offsets and reduces the overlaps.
+/// `average()` returns the mean of everything written at each index (overlapping
+/// window predictions, e.g. per-frame probabilities); `normalized(by:)` divides
+/// the running sum by a parallel weight sum (windowed COLA overlap-add). Fixed
+/// length, so out-of-range writes are ignored rather than trapping.
+public struct OverlapAccumulator {
+    private var sum: [Float]
+    private var count: [Float]
+
+    public init(length: Int) {
+        sum = [Float](repeating: 0, count: max(0, length))
+        count = [Float](repeating: 0, count: max(0, length))
+    }
+
+    /// Add `values` starting at `offset`, incrementing each touched index's
+    /// count by 1 (or by the matching `weights[i]` when given, for COLA).
+    public mutating func add(_ values: [Float], at offset: Int, weights: [Float]? = nil) {
+        for i in 0..<values.count {
+            let idx = offset + i
+            guard idx >= 0, idx < sum.count else { continue }
+            sum[idx] += values[i]
+            count[idx] += weights?[i] ?? 1
+        }
+    }
+
+    /// The per-index mean (sum / times-written); indices never written are 0.
+    public func average() -> [Float] {
+        var out = [Float](repeating: 0, count: sum.count)
+        for i in 0..<sum.count where count[i] > 0 { out[i] = sum[i] / count[i] }
+        return out
+    }
+
+    /// The per-index sum divided by the accumulated weight (COLA), with a small
+    /// floor so silent-weight indices stay 0.
+    public func normalized(floor: Float = 1e-8) -> [Float] {
+        var out = [Float](repeating: 0, count: sum.count)
+        for i in 0..<sum.count where count[i] > floor { out[i] = sum[i] / count[i] }
+        return out
+    }
+}

--- a/Sources/AudioDSP/Loudness.swift
+++ b/Sources/AudioDSP/Loudness.swift
@@ -1,0 +1,103 @@
+// Loudness measurement and normalization to a delivery target (ITU-R BS.1770-4
+// integrated LUFS: K-weighting, 400 ms blocks at 75% overlap, -70/-10 LU
+// gating), plus a gain to the target with a peak-safety cap so a master never
+// clips. The post-DSP mastering stage audio-output SDKs apply, kept out of the
+// model. Accelerate-backed (vDSP_biquad) on Apple, plain Swift elsewhere.
+
+import Foundation
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+public enum Loudness {
+    // BS.1770-4 K-weighting biquads at 48 kHz (stage 1 high shelf, stage 2 HPF).
+    private static let s1b: [Float] = [1.53512485958697, -2.69169618940638, 1.19839281085285]
+    private static let s1a: [Float] = [-1.69065929318241, 0.73248077421585]
+    private static let s2b: [Float] = [1.0, -2.0, 1.0]
+    private static let s2a: [Float] = [-1.99004745483398, 0.99007225036621]
+
+    private static func biquad(_ x: [Float], _ b: [Float], _ a: [Float]) -> [Float] {
+        var y = [Float](repeating: 0, count: x.count)
+        #if canImport(Accelerate)
+        let coeffs: [Double] = [Double(b[0]), Double(b[1]), Double(b[2]), Double(a[0]), Double(a[1])]
+        guard let setup = vDSP_biquad_CreateSetup(coeffs, 1) else { return y }
+        defer { vDSP_biquad_DestroySetup(setup) }
+        var delays = [Float](repeating: 0, count: 2 + 2)
+        x.withUnsafeBufferPointer { xp in
+            y.withUnsafeMutableBufferPointer { yp in
+                vDSP_biquad(setup, &delays, xp.baseAddress!, 1, yp.baseAddress!, 1, vDSP_Length(x.count))
+            }
+        }
+        #else
+        var x1: Float = 0, x2: Float = 0, y1: Float = 0, y2: Float = 0
+        for i in 0..<x.count {
+            let xn = x[i]
+            let yn = b[0] * xn + b[1] * x1 + b[2] * x2 - a[0] * y1 - a[1] * y2
+            x2 = x1; x1 = xn; y2 = y1; y1 = yn
+            y[i] = yn
+        }
+        #endif
+        return y
+    }
+
+    /// Integrated loudness in LUFS of mono `samples` at `sampleRate`, or nil for
+    /// silence. The K-weighting coefficients are the 48 kHz set (the common
+    /// on-device audio rate); pass 48 kHz audio.
+    public static func integratedLUFS(_ samples: [Float], sampleRate: Double) -> Double? {
+        guard sampleRate == 48_000, samples.count > 0 else { return nil }
+        let weighted = biquad(biquad(samples, s1b, s1a), s2b, s2a)
+        let block = Int(0.4 * sampleRate)      // 400 ms
+        let step = Int(0.1 * sampleRate)       // 100 ms (75% overlap)
+        guard weighted.count >= block else { return nil }
+
+        var blockLoud: [Double] = []
+        var meanSq: [Double] = []
+        var start = 0
+        while start + block <= weighted.count {
+            var ms: Double
+            #if canImport(Accelerate)
+            var msF: Float = 0
+            weighted.withUnsafeBufferPointer { vDSP_measqv($0.baseAddress! + start, 1, &msF, vDSP_Length(block)) }
+            ms = Double(msF)
+            #else
+            var sum = 0.0
+            for i in start..<(start + block) { sum += Double(weighted[i]) * Double(weighted[i]) }
+            ms = sum / Double(block)
+            #endif
+            meanSq.append(ms)
+            blockLoud.append(-0.691 + 10 * log10(ms + 1e-12))
+            start += step
+        }
+        // Absolute gate -70 LUFS, then relative gate at (gated mean - 10 LU).
+        func gatedLoudness(_ threshold: Double) -> Double? {
+            var acc = 0.0; var n = 0
+            for (i, l) in blockLoud.enumerated() where l > threshold { acc += meanSq[i]; n += 1 }
+            return n > 0 ? -0.691 + 10 * log10(acc / Double(n) + 1e-12) : nil
+        }
+        guard let firstPass = gatedLoudness(-70) else { return nil }
+        return gatedLoudness(firstPass - 10) ?? firstPass
+    }
+
+    /// Normalize `samples` to `targetLUFS`, capping the applied gain at
+    /// `maxGainDB` and never letting the peak exceed `peakCeilingDBFS`. Returns
+    /// the normalized samples and the measured input loudness (nil for silence,
+    /// left unchanged).
+    public static func normalize(_ samples: [Float], sampleRate: Double,
+                                 targetLUFS: Double, maxGainDB: Double, peakCeilingDBFS: Double)
+        -> (samples: [Float], measuredLUFS: Double?)
+    {
+        guard let lufs = integratedLUFS(samples, sampleRate: sampleRate) else { return (samples, nil) }
+        var gainDB = targetLUFS - lufs
+        if gainDB > maxGainDB { gainDB = maxGainDB }
+        var gain = Float(pow(10, gainDB / 20))
+
+        var peak: Float = 0
+        for v in samples { peak = max(peak, abs(v)) }
+        let ceiling = Float(pow(10, peakCeilingDBFS / 20))
+        if peak * gain > ceiling, peak > 0 { gain = ceiling / peak }
+
+        var out = [Float](repeating: 0, count: samples.count)
+        for i in 0..<samples.count { out[i] = max(-1, min(1, samples[i] * gain)) }
+        return (out, lufs)
+    }
+}

--- a/Sources/AudioDSP/Matmul.swift
+++ b/Sources/AudioDSP/Matmul.swift
@@ -1,0 +1,30 @@
+// Row-major single-precision GEMM behind the STFT/mel matmuls. Accelerate BLAS
+// on Apple (the whole point of doing STFT as a matmul: it runs on the vector
+// units); a plain triple loop everywhere else. Same result, so tests pass on
+// Linux and the Apple SDK build still gets BLAS.
+
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+enum Matmul {
+    /// `c[m x n] = alpha * a[m x k] @ b[k x n] + beta * c`, all row-major.
+    static func gemm(_ a: [Float], _ b: [Float], into c: inout [Float],
+                     m: Int, n: Int, k: Int, alpha: Float = 1, beta: Float = 0) {
+        #if canImport(Accelerate)
+        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                    Int32(m), Int32(n), Int32(k), alpha,
+                    a, Int32(k), b, Int32(n), beta, &c, Int32(n))
+        #else
+        for i in 0..<m {
+            for j in 0..<n {
+                var acc: Float = 0
+                let aRow = i * k
+                for p in 0..<k { acc += a[aRow + p] * b[p * n + j] }
+                let idx = i * n + j
+                c[idx] = alpha * acc + beta * c[idx]
+            }
+        }
+        #endif
+    }
+}

--- a/Sources/AudioDSP/Mel.swift
+++ b/Sources/AudioDSP/Mel.swift
@@ -1,0 +1,92 @@
+// Log-mel spectrogram front-end for audio feature models (ASR-adjacent nets,
+// keyword/filler detectors that take mel rather than raw waveform). Builds the
+// triangular mel filterbank once, applies it to STFT power, and takes the log.
+// HTK mel scale by default, matching whisper/torchaudio's common setting.
+
+import Foundation
+
+/// A triangular mel filterbank plus the STFT that feeds it. Configured once and
+/// reused: `logMel(_:)` takes a signal to a `[mels x frames]`-ordered log-mel
+/// spectrogram (frame-major internally, exposed as `frames * mels`).
+public struct MelSpectrogram: Sendable {
+    public let stft: STFT
+    public let mels: Int
+    public let sampleRate: Double
+    private let filters: [Float]   // [mels x bins]
+    private let bins: Int
+
+    /// Configure a mel front-end. `fMax` defaults to Nyquist (`sampleRate/2`).
+    public init(sampleRate: Double, nFFT: Int, hop: Int, mels: Int,
+                fMin: Double = 0, fMax: Double? = nil, htk: Bool = true,
+                window: [Float]? = nil, center: Bool = true) {
+        self.stft = STFT(nFFT: nFFT, hop: hop, window: window, center: center)
+        self.mels = mels
+        self.sampleRate = sampleRate
+        self.bins = stft.bins
+        self.filters = MelSpectrogram.filterbank(
+            sampleRate: sampleRate, nFFT: nFFT, bins: stft.bins,
+            mels: mels, fMin: fMin, fMax: fMax ?? sampleRate / 2, htk: htk)
+    }
+
+    private static func hzToMel(_ hz: Double, htk: Bool) -> Double {
+        htk ? 2595 * log10(1 + hz / 700) : hz  // HTK; linear placeholder only if !htk unused
+    }
+    private static func melToHz(_ mel: Double, htk: Bool) -> Double {
+        htk ? 700 * (pow(10, mel / 2595) - 1) : mel
+    }
+
+    private static func filterbank(sampleRate: Double, nFFT: Int, bins: Int,
+                                   mels: Int, fMin: Double, fMax: Double, htk: Bool) -> [Float] {
+        let melMin = hzToMel(fMin, htk: htk), melMax = hzToMel(fMax, htk: htk)
+        // mels + 2 band edges, evenly spaced on the mel scale.
+        var hzPoints = [Double](repeating: 0, count: mels + 2)
+        for i in 0..<(mels + 2) {
+            let mel = melMin + (melMax - melMin) * Double(i) / Double(mels + 1)
+            hzPoints[i] = melToHz(mel, htk: htk)
+        }
+        // FFT bin center frequencies.
+        var binHz = [Double](repeating: 0, count: bins)
+        for k in 0..<bins { binHz[k] = Double(k) * sampleRate / Double(nFFT) }
+
+        var fb = [Float](repeating: 0, count: mels * bins)
+        for m in 0..<mels {
+            let left = hzPoints[m], center = hzPoints[m + 1], right = hzPoints[m + 2]
+            for k in 0..<bins {
+                let hz = binHz[k]
+                var w = 0.0
+                if hz >= left, hz <= center, center > left {
+                    w = (hz - left) / (center - left)
+                } else if hz > center, hz <= right, right > center {
+                    w = (right - hz) / (right - center)
+                }
+                fb[m * bins + k] = Float(max(0, w))
+            }
+        }
+        return fb
+    }
+
+    /// Log-mel spectrogram of `signal`, frame-major `frames * mels`. `log` is
+    /// natural log of `power + eps` (set `power: false` for magnitude).
+    public func logMel(_ signal: [Float], eps: Float = 1e-10, power: Bool = true) -> (values: [Float], frames: Int, mels: Int) {
+        let spec = stft.forward(signal)
+        let frames = spec.frames
+        guard frames > 0 else { return ([], 0, mels) }
+        // Per-bin magnitude/power, frame-major [frames x bins].
+        var energy = [Float](repeating: 0, count: frames * bins)
+        for i in 0..<energy.count {
+            let mag2 = spec.re[i] * spec.re[i] + spec.im[i] * spec.im[i]
+            energy[i] = power ? mag2 : mag2.squareRoot()
+        }
+        // mel[frames x mels] = energy[frames x bins] @ filters^T[bins x mels].
+        var out = [Float](repeating: 0, count: frames * mels)
+        for fr in 0..<frames {
+            for m in 0..<mels {
+                var acc: Float = 0
+                let eRow = fr * bins, fRow = m * bins
+                for k in 0..<bins { acc += energy[eRow + k] * filters[fRow + k] }
+                out[fr * mels + m] = logf(acc + eps)
+            }
+        }
+        return (out, frames, mels)
+    }
+}

--- a/Sources/AudioDSP/STFT.swift
+++ b/Sources/AudioDSP/STFT.swift
@@ -1,0 +1,144 @@
+// STFT / ISTFT as exact real-DFT matmuls (so `nFFT` need not be a power of two)
+// with windowed COLA overlap-add reconstruction. This is the DSP a spectral
+// speech model runs on both sides of inference; one implementation, shared by
+// every SDK, matches the training-time `torch.stft`/`istft` (Hann, center,
+// reflect pad) it has to agree with bit-for-bit.
+
+import Foundation
+
+/// A dense complex spectrogram in frame-major layout: `frames` rows of `bins`
+/// (= `nFFT/2 + 1`) complex bins, real and imaginary parts split into two
+/// parallel `frames * bins` arrays (row `f`, bin `k` at index `f * bins + k`).
+public struct Spectrogram: Sendable {
+    public var re: [Float]
+    public var im: [Float]
+    public let frames: Int
+    public let bins: Int
+
+    public init(re: [Float], im: [Float], frames: Int, bins: Int) {
+        self.re = re
+        self.im = im
+        self.frames = frames
+        self.bins = bins
+    }
+
+    /// Per-bin magnitude `sqrt(re^2 + im^2)` (frame-major, `frames * bins`).
+    public func magnitude(eps: Float = 0) -> [Float] {
+        var out = [Float](repeating: 0, count: re.count)
+        for i in 0..<re.count { out[i] = (re[i] * re[i] + im[i] * im[i] + eps).squareRoot() }
+        return out
+    }
+
+    /// Per-bin phase `atan2(im, re)` (frame-major, `frames * bins`).
+    public func phase() -> [Float] {
+        var out = [Float](repeating: 0, count: re.count)
+        for i in 0..<re.count { out[i] = atan2f(im[i], re[i]) }
+        return out
+    }
+}
+
+/// A short-time Fourier transform configured once and reused. Precomputes the
+/// window and the real-DFT bases at init, so `forward`/`inverse` are just the
+/// matmuls plus overlap-add.
+public struct STFT: Sendable {
+    public let nFFT: Int
+    public let hop: Int
+    public let bins: Int
+    public let center: Bool
+    public let window: [Float]
+
+    private let fwdCos: [Float]   // [nFFT x bins]
+    private let fwdSin: [Float]   // [nFFT x bins]
+    private let invCos: [Float]   // [bins x nFFT]
+    private let invSin: [Float]   // [bins x nFFT]
+
+    /// Configure an STFT. `window` defaults to a periodic Hann of length
+    /// `nFFT`. `center` reflect-pads by `nFFT/2` so frames are centered
+    /// (`torch.stft(center=True)`), which `inverse` undoes.
+    public init(nFFT: Int, hop: Int, window: [Float]? = nil, center: Bool = true) {
+        precondition(nFFT > 0 && hop > 0, "nFFT and hop must be positive")
+        self.nFFT = nFFT
+        self.hop = hop
+        self.bins = nFFT / 2 + 1
+        self.center = center
+        let w = window ?? Window.hann(nFFT, periodic: true)
+        precondition(w.count == nFFT, "window length must equal nFFT")
+        self.window = w
+
+        let n = nFFT, f = bins
+        var fc = [Float](repeating: 0, count: n * f)
+        var fs = [Float](repeating: 0, count: n * f)
+        for t in 0..<n {
+            for k in 0..<f {
+                let a = 2 * Float.pi * Float(k) * Float(t) / Float(n)
+                fc[t * f + k] = cosf(a)
+                fs[t * f + k] = sinf(a)
+            }
+        }
+        self.fwdCos = fc
+        self.fwdSin = fs
+
+        // Real irfft basis (hermitian): x[t] = sum_k a_k/n (re cos - im sin),
+        // a_0 = a_{n/2} = 1, else 2.
+        var ic = [Float](repeating: 0, count: f * n)
+        var isn = [Float](repeating: 0, count: f * n)
+        for k in 0..<f {
+            let ak: Float = (k == 0 || k == f - 1) ? 1 : 2
+            for t in 0..<n {
+                let a = 2 * Float.pi * Float(k) * Float(t) / Float(n)
+                ic[k * n + t] = ak / Float(n) * cosf(a)
+                isn[k * n + t] = -ak / Float(n) * sinf(a)
+            }
+        }
+        self.invCos = ic
+        self.invSin = isn
+    }
+
+    /// Forward transform: windowed frames -> complex spectrogram.
+    public func forward(_ signal: [Float]) -> Spectrogram {
+        let n = nFFT, f = bins
+        let padded = center ? Padding.reflect(signal, pad: n / 2) : signal
+        guard padded.count >= n else { return Spectrogram(re: [], im: [], frames: 0, bins: f) }
+        let frames = 1 + (padded.count - n) / hop
+
+        var windowed = [Float](repeating: 0, count: frames * n)
+        for fr in 0..<frames {
+            let off = fr * hop
+            for t in 0..<n { windowed[fr * n + t] = padded[off + t] * window[t] }
+        }
+        var re = [Float](repeating: 0, count: frames * f)
+        var im = [Float](repeating: 0, count: frames * f)
+        Matmul.gemm(windowed, fwdCos, into: &re, m: frames, n: f, k: n, alpha: 1)
+        Matmul.gemm(windowed, fwdSin, into: &im, m: frames, n: f, k: n, alpha: -1)
+        return Spectrogram(re: re, im: im, frames: frames, bins: f)
+    }
+
+    /// Inverse transform: complex spectrogram -> signal, windowed COLA
+    /// overlap-add with the same window, trimming the centered padding and
+    /// clamping to `length` (pass the original sample count).
+    public func inverse(_ spec: Spectrogram, length: Int) -> [Float] {
+        let n = nFFT, f = bins, frames = spec.frames
+        guard frames > 0 else { return [] }
+        var recon = [Float](repeating: 0, count: frames * n)
+        Matmul.gemm(spec.re, invCos, into: &recon, m: frames, n: n, k: f, alpha: 1)
+        Matmul.gemm(spec.im, invSin, into: &recon, m: frames, n: n, k: f, alpha: 1, beta: 1)
+
+        let paddedLen = (frames - 1) * hop + n
+        var num = [Float](repeating: 0, count: paddedLen)
+        var den = [Float](repeating: 0, count: paddedLen)
+        for fr in 0..<frames {
+            let off = fr * hop
+            for t in 0..<n {
+                let w = window[t]
+                num[off + t] += recon[fr * n + t] * w
+                den[off + t] += w * w
+            }
+        }
+        var y = [Float](repeating: 0, count: paddedLen)
+        for i in 0..<paddedLen { y[i] = den[i] > 1e-8 ? num[i] / den[i] : 0 }
+
+        let pad = center ? n / 2 : 0
+        let count = min(length, paddedLen - 2 * pad)
+        return count > 0 ? Array(y[pad..<(pad + count)]) : []
+    }
+}

--- a/Sources/AudioDSP/VectorOps.swift
+++ b/Sources/AudioDSP/VectorOps.swift
@@ -1,0 +1,66 @@
+// Small signal-level vector helpers the audio SDKs reach for before/after
+// inference: energy normalization (speech enhancement) and per-window mean/std
+// standardization (feature models). Accelerate-backed on Apple, plain Swift
+// everywhere else, same result either way.
+
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+public enum VectorOps {
+    /// Sum of squares of `x`.
+    public static func energy(_ x: [Float]) -> Float {
+        guard !x.isEmpty else { return 0 }
+        #if canImport(Accelerate)
+        var e: Float = 0
+        vDSP_svesq(x, 1, &e, vDSP_Length(x.count))
+        return e
+        #else
+        var e: Float = 0
+        for v in x { e += v * v }
+        return e
+        #endif
+    }
+
+    /// Multiply every element by `scalar` (out-of-place).
+    public static func scaled(_ x: [Float], by scalar: Float) -> [Float] {
+        guard !x.isEmpty else { return x }
+        var out = [Float](repeating: 0, count: x.count)
+        #if canImport(Accelerate)
+        var s = scalar
+        vDSP_vsmul(x, 1, &s, &out, 1, vDSP_Length(x.count))
+        #else
+        for i in 0..<x.count { out[i] = x[i] * scalar }
+        #endif
+        return out
+    }
+
+    /// RMS-energy normalize to unit average power (`gain = sqrt(N / sum x^2)`),
+    /// the front-end MP-SENet-style enhancers apply. Returns the normalized
+    /// samples and the `gain` used, so the caller can undo it after inference
+    /// (`scaled(y, by: 1 / gain)`). A silent input is returned unchanged with
+    /// `gain == 1`.
+    public static func energyNormalize(_ x: [Float]) -> (samples: [Float], gain: Float) {
+        let e = energy(x)
+        let gain = e > 0 ? (Float(x.count) / e).squareRoot() : 1
+        return (scaled(x, by: gain), gain)
+    }
+
+    /// Standardize to zero mean and unit variance (sample std, `+ eps`), the
+    /// per-window normalization raw-waveform classifiers expect. Matches a
+    /// training-time `(x - mean) / (std + eps)` with an unbiased std.
+    public static func standardize(_ x: [Float], eps: Float = 1e-7) -> [Float] {
+        guard x.count > 1 else { return x }
+        let n = Float(x.count)
+        var mean: Float = 0
+        for v in x { mean += v }
+        mean /= n
+        var sumSq: Float = 0
+        for v in x { let d = v - mean; sumSq += d * d }
+        let std = (sumSq / (n - 1)).squareRoot() + eps
+        let inv = 1 / std
+        var out = [Float](repeating: 0, count: x.count)
+        for i in 0..<x.count { out[i] = (x[i] - mean) * inv }
+        return out
+    }
+}

--- a/Sources/AudioDSP/Windowing.swift
+++ b/Sources/AudioDSP/Windowing.swift
@@ -1,0 +1,32 @@
+// Analysis windows and the padding helpers STFT pipelines share. Pure Swift,
+// so every platform gets the same coefficients (an STFT/ISTFT pair only
+// reconstructs cleanly when both ends agree on the window to the last bit).
+
+import Foundation
+
+public enum Window {
+    /// A Hann window of `count` samples: `0.5 - 0.5 cos(2 pi k / d)` where `d`
+    /// is `count` for the periodic window (the DFT/STFT default, matching
+    /// PyTorch/librosa `periodic=True`) or `count - 1` for the symmetric one.
+    public static func hann(_ count: Int, periodic: Bool = true) -> [Float] {
+        guard count > 1 else { return [Float](repeating: 1, count: max(0, count)) }
+        let d = Float(periodic ? count : count - 1)
+        var w = [Float](repeating: 0, count: count)
+        for k in 0..<count { w[k] = 0.5 - 0.5 * cosf(2 * .pi * Float(k) / d) }
+        return w
+    }
+}
+
+public enum Padding {
+    /// Reflect-pad `x` by `pad` samples on each side (no edge-sample repeat),
+    /// matching `torch.stft(center=True)` / librosa `pad_mode="reflect"`. Used
+    /// to center STFT frames so the first/last hop are not truncated.
+    public static func reflect(_ x: [Float], pad: Int) -> [Float] {
+        guard pad > 0, !x.isEmpty else { return x }
+        var out = [Float](); out.reserveCapacity(x.count + 2 * pad)
+        for i in 0..<pad { out.append(x[min(pad - i, x.count - 1)]) }
+        out.append(contentsOf: x)
+        for i in 0..<pad { out.append(x[max(x.count - 2 - i, 0)]) }
+        return out
+    }
+}

--- a/Sources/AudioIO/AppleAudioIO.swift
+++ b/Sources/AudioIO/AppleAudioIO.swift
@@ -1,0 +1,59 @@
+#if canImport(AVFoundation)
+import AVFoundation
+import Foundation
+
+// Apple decode backend: AVFoundation reads any supported container/codec, and
+// AVAudioConverter mixes to mono and resamples to the target rate in one pass.
+// In-memory bytes are staged to a temp file because AVAudioFile reads from a URL.
+
+extension AudioIO {
+    static func appleDecode(path: String?, bytes: [UInt8]?, sampleRate: Double) throws -> [Float] {
+        let url: URL
+        var temp: URL?
+        if let path {
+            url = URL(fileURLWithPath: path)
+        } else if let bytes {
+            let t = FileManager.default.temporaryDirectory
+                .appendingPathComponent("dal-audio-\(UUID().uuidString)")
+            try Data(bytes).write(to: t)
+            url = t
+            temp = t
+        } else {
+            throw AudioIOError.decodeFailed("no path or bytes")
+        }
+        defer { if let temp { try? FileManager.default.removeItem(at: temp) } }
+
+        do {
+            let file = try AVAudioFile(forReading: url)
+            let inFormat = file.processingFormat
+            guard
+                let outFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                              sampleRate: sampleRate, channels: 1, interleaved: false),
+                let converter = AVAudioConverter(from: inFormat, to: outFormat),
+                file.length > 0,
+                let inBuffer = AVAudioPCMBuffer(pcmFormat: inFormat,
+                                                frameCapacity: AVAudioFrameCount(file.length))
+            else { throw AudioIOError.decodeFailed("cannot build converter") }
+
+            try file.read(into: inBuffer)
+            let capacity = AVAudioFrameCount(Double(inBuffer.frameLength) * (sampleRate / inFormat.sampleRate) + 4096)
+            guard let outBuffer = AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: capacity) else {
+                throw AudioIOError.decodeFailed("cannot build output buffer")
+            }
+            var fed = false
+            var error: NSError?
+            converter.convert(to: outBuffer, error: &error) { _, status in
+                if fed { status.pointee = .endOfStream; return nil }
+                fed = true; status.pointee = .haveData; return inBuffer
+            }
+            if let error { throw error }
+            guard let channel = outBuffer.floatChannelData?[0] else { return [] }
+            return Array(UnsafeBufferPointer(start: channel, count: Int(outBuffer.frameLength)))
+        } catch let e as AudioIOError {
+            throw e
+        } catch {
+            throw AudioIOError.decodeFailed("\(error)")
+        }
+    }
+}
+#endif

--- a/Sources/AudioIO/AudioIO.swift
+++ b/Sources/AudioIO/AudioIO.swift
@@ -1,0 +1,86 @@
+// One audio decode/encode API with a per-platform backend behind it, so an
+// audio model SDK never writes AVFoundation, MediaCodec, or Web Audio code:
+//
+//   Apple      AVFoundation (AVAudioFile + AVAudioConverter)
+//   Android    host MediaExtractor/MediaCodec via CHostBridge host_audio_decode
+//   WebAssembly  AudioContext.decodeAudioData via the JS host global
+//   Linux/other  the pure-Swift WAV codec + linear resample
+//
+// `decode` always returns mono `Float` at the requested sample rate, ready to
+// feed a model (or AudioDSP). It is `async` because the wasm backend awaits a
+// JS Promise; the native backends satisfy it synchronously. Encoding a 16-bit
+// PCM WAV is pure Swift, identical on every platform.
+
+public enum AudioIOError: Error, Sendable {
+    case decodeFailed(String)
+    case unsupported(String)
+}
+
+public enum AudioIO {
+    /// Decode the audio file at `path` to mono `Float` samples at
+    /// `sampleRate`, resampling and mixing to mono as needed.
+    public static func decode(path: String, sampleRate: Double) async throws -> [Float] {
+        #if canImport(AVFoundation)
+        return try appleDecode(path: path, bytes: nil, sampleRate: sampleRate)
+        #elseif os(Android)
+        return try hostDecode(path: path, bytes: nil, sampleRate: sampleRate)
+        #elseif os(WASI)
+        return try await jsDecode(path: path, bytes: nil, sampleRate: sampleRate)
+        #else
+        return try portableDecode(bytes: readFile(path), sampleRate: sampleRate)
+        #endif
+    }
+
+    /// Decode an in-memory audio file (any container the platform supports; the
+    /// portable path is WAV) to mono `Float` at `sampleRate`.
+    public static func decode(bytes: [UInt8], sampleRate: Double) async throws -> [Float] {
+        #if canImport(AVFoundation)
+        return try appleDecode(path: nil, bytes: bytes, sampleRate: sampleRate)
+        #elseif os(Android)
+        return try hostDecode(path: nil, bytes: bytes, sampleRate: sampleRate)
+        #elseif os(WASI)
+        return try await jsDecode(path: nil, bytes: bytes, sampleRate: sampleRate)
+        #else
+        return try portableDecode(bytes: bytes, sampleRate: sampleRate)
+        #endif
+    }
+
+    /// Encode mono (or interleaved) `samples` in `[-1, 1]` as a 16-bit PCM WAV
+    /// byte buffer. Portable and identical on every platform.
+    public static func encodeWAV(_ samples: [Float], sampleRate: Int, channels: Int = 1) -> [UInt8] {
+        WAV.encode(samples, sampleRate: sampleRate, channels: channels)
+    }
+
+    /// Decode WAV bytes with the pure-Swift codec, mixing to mono and
+    /// resampling to `sampleRate`. The portable-path implementation, exposed so
+    /// a caller can force the WAV codec regardless of platform.
+    static func portableDecode(bytes: [UInt8], sampleRate: Double) throws -> [Float] {
+        do {
+            let pcm = try WAV.decode(bytes)
+            return Resample.toMono(pcm, sampleRate: sampleRate)
+        } catch {
+            throw AudioIOError.decodeFailed("\(error)")
+        }
+    }
+}
+
+#if canImport(Foundation) && !os(Android) && !os(WASI)
+import Foundation
+
+public extension AudioIO {
+    /// Write mono (or interleaved) `samples` as a 16-bit PCM WAV file. Uses the
+    /// portable encoder, so the bytes match `encodeWAV`. Available where a
+    /// filesystem is (Apple/Linux); on Android/wasm write through the host.
+    static func writeWAV(_ samples: [Float], sampleRate: Int, channels: Int = 1, to path: String) throws {
+        let bytes = WAV.encode(samples, sampleRate: sampleRate, channels: channels)
+        try Data(bytes).write(to: URL(fileURLWithPath: path))
+    }
+}
+
+extension AudioIO {
+    static func readFile(_ path: String) throws -> [UInt8] {
+        do { return try [UInt8](Data(contentsOf: URL(fileURLWithPath: path))) }
+        catch { throw AudioIOError.decodeFailed("read \(path): \(error)") }
+    }
+}
+#endif

--- a/Sources/AudioIO/HostAudioIO.swift
+++ b/Sources/AudioIO/HostAudioIO.swift
@@ -1,0 +1,33 @@
+#if os(Android)
+import CHostBridge
+import FFIBuffer
+
+// Android decode backend: the host (MediaExtractor + MediaCodec, installed by
+// the runtime's JNI shim) decodes to mono `Float` at the target rate and hands
+// back a length-prefixed FFI buffer (u32 sample rate, then an f32 array). Swift
+// links no audio codec; it just reads the buffer with FFIReader.
+
+extension AudioIO {
+    static func hostDecode(path: String?, bytes: [UInt8]?, sampleRate: Double) throws -> [Float] {
+        let ptr: UnsafeMutablePointer<CChar>? = {
+            if let path {
+                return path.withCString { host_audio_decode($0, nil, 0, sampleRate) }
+            } else if let bytes {
+                return bytes.withUnsafeBufferPointer {
+                    host_audio_decode(nil, $0.baseAddress, Int64(bytes.count), sampleRate)
+                }
+            }
+            return nil
+        }()
+        guard let ptr else { throw AudioIOError.decodeFailed("host_audio_decode returned null") }
+        defer { host_free(ptr) }
+
+        let base = UnsafeRawPointer(ptr).assumingMemoryBound(to: UInt8.self)
+        let len = Int(base[0]) << 24 | Int(base[1]) << 16 | Int(base[2]) << 8 | Int(base[3])
+        let body = [UInt8](UnsafeBufferPointer(start: base + 4, count: len))
+        var reader = FFIReader(body)
+        _ = reader.u32()                 // sample rate (host already resampled)
+        return reader.f32Array()
+    }
+}
+#endif

--- a/Sources/AudioIO/JSAudioIO.swift
+++ b/Sources/AudioIO/JSAudioIO.swift
@@ -1,0 +1,36 @@
+#if os(WASI)
+import JavaScriptEventLoop
+import JavaScriptKit
+
+// WebAssembly decode backend: the JS host owns audio decoding and exposes one
+// method on the `__DalAudioHost` global, mirroring the JS inference session.
+// desert-ant-core's own npm package installs it, so a model SDK writes no JS:
+//
+//   import { installAudioHost } from "@desert-ant-labs/core";        // browser: Web Audio
+//   import { installAudioHost } from "@desert-ant-labs/core/node";   // node: WAV codec
+//   installAudioHost();   // sets globalThis.__DalAudioHost.decode(path, bytes, sampleRate)
+//
+// `path` is a string on node, null in the browser; `bytes` is the file's
+// Uint8Array in the browser, null on node. It returns mono Float32 at `rate`.
+// Bytes cross the wasm boundary raw; the host returns a Float32Array we copy in.
+
+extension AudioIO {
+    static func jsDecode(path: String?, bytes: [UInt8]?, sampleRate: Double) async throws -> [Float] {
+        guard let host = JSObject.global.__DalAudioHost.object,
+              let decode = host.decode.function else {
+            throw AudioIOError.unsupported("missing __DalAudioHost.decode")
+        }
+        let pathArg: JSValue = path.map { .string($0) } ?? .null
+        let bytesArg: JSValue = bytes.map { JSTypedArray<UInt8>($0).jsValue } ?? .null
+        let result = decode(this: host, pathArg, bytesArg, JSValue.number(sampleRate))
+        guard let promise = result.object.flatMap(JSPromise.init) else {
+            throw AudioIOError.decodeFailed("__DalAudioHost.decode did not return a promise")
+        }
+        let value = try await promise.value
+        guard let floats = JSTypedArray<Float>(from: value) else {
+            throw AudioIOError.decodeFailed("__DalAudioHost.decode returned no Float32Array")
+        }
+        return floats.withUnsafeBytes { Array($0) }
+    }
+}
+#endif

--- a/Sources/AudioIO/Resample.swift
+++ b/Sources/AudioIO/Resample.swift
@@ -1,0 +1,47 @@
+// Channel mixdown and sample-rate conversion for the portable decode path (and
+// any host decoder that returns native rate / multichannel). Linear
+// interpolation: cheap, good enough for the 16 kHz mono model front-ends these
+// SDKs feed. Apple's AVAudioConverter does its own higher-quality conversion on
+// that path; this keeps Linux/host output equivalent for model input.
+
+public enum Resample {
+    /// Mix interleaved `channels`-channel `interleaved` down to mono by
+    /// averaging channels.
+    public static func mixdownMono(_ interleaved: [Float], channels: Int) -> [Float] {
+        guard channels > 1 else { return interleaved }
+        let frames = interleaved.count / channels
+        var out = [Float](repeating: 0, count: frames)
+        let inv = 1 / Float(channels)
+        for f in 0..<frames {
+            var acc: Float = 0
+            let base = f * channels
+            for c in 0..<channels { acc += interleaved[base + c] }
+            out[f] = acc * inv
+        }
+        return out
+    }
+
+    /// Linearly resample mono `x` from `from` Hz to `to` Hz.
+    public static func linear(_ x: [Float], from: Double, to: Double) -> [Float] {
+        guard from > 0, to > 0, from != to, x.count > 1 else { return x }
+        let ratio = to / from
+        let outCount = Int((Double(x.count) * ratio).rounded())
+        guard outCount > 0 else { return [] }
+        var out = [Float](repeating: 0, count: outCount)
+        let step = from / to
+        for i in 0..<outCount {
+            let src = Double(i) * step
+            let i0 = Int(src)
+            if i0 >= x.count - 1 { out[i] = x[x.count - 1]; continue }
+            let frac = Float(src - Double(i0))
+            out[i] = x[i0] * (1 - frac) + x[i0 + 1] * frac
+        }
+        return out
+    }
+
+    /// Mix down to mono and resample to `sampleRate` in one step.
+    public static func toMono(_ pcm: PCM, sampleRate: Double) -> [Float] {
+        let mono = mixdownMono(pcm.samples, channels: pcm.channels)
+        return linear(mono, from: pcm.sampleRate, to: sampleRate)
+    }
+}

--- a/Sources/AudioIO/WAV.swift
+++ b/Sources/AudioIO/WAV.swift
@@ -1,0 +1,145 @@
+// A pure-Swift RIFF/WAVE reader and writer. It is the portable audio codec: the
+// fallback decoder on platforms with no OS decoder (Linux/server), and the one
+// encoder everywhere (16-bit PCM WAV out is the same bytes on every platform).
+// Handles PCM (8/16/24/32-bit int) and IEEE float (32/64-bit); other codecs are
+// the host decoder's job.
+
+import Foundation
+
+/// Decoded PCM: interleaved `Float` samples in `[-1, 1]`, with the file's own
+/// sample rate and channel count (mixdown/resample happen separately).
+public struct PCM: Sendable {
+    public var samples: [Float]   // interleaved
+    public var sampleRate: Double
+    public var channels: Int
+
+    public init(samples: [Float], sampleRate: Double, channels: Int) {
+        self.samples = samples
+        self.sampleRate = sampleRate
+        self.channels = channels
+    }
+}
+
+public enum WAVError: Error, Sendable {
+    case notRIFF, truncated, unsupported(String)
+}
+
+public enum WAV {
+    // MARK: Decode
+
+    /// Parse a WAV/RIFF byte buffer to interleaved float `PCM`.
+    public static func decode(_ bytes: [UInt8]) throws -> PCM {
+        guard bytes.count >= 12,
+              bytes[0] == 0x52, bytes[1] == 0x49, bytes[2] == 0x46, bytes[3] == 0x46,  // "RIFF"
+              bytes[8] == 0x57, bytes[9] == 0x41, bytes[10] == 0x56, bytes[11] == 0x45 // "WAVE"
+        else { throw WAVError.notRIFF }
+
+        func u16(_ o: Int) -> Int { Int(bytes[o]) | (Int(bytes[o + 1]) << 8) }
+        func u32(_ o: Int) -> Int { Int(bytes[o]) | (Int(bytes[o + 1]) << 8) | (Int(bytes[o + 2]) << 16) | (Int(bytes[o + 3]) << 24) }
+
+        var format = 1, channels = 1, sampleRate = 0, bitsPerSample = 16
+        var dataStart = -1, dataSize = 0
+        var pos = 12
+        while pos + 8 <= bytes.count {
+            let id = (bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3])
+            let size = u32(pos + 4)
+            let body = pos + 8
+            if id == (0x66, 0x6D, 0x74, 0x20) {          // "fmt "
+                guard body + 16 <= bytes.count else { throw WAVError.truncated }
+                format = u16(body)
+                channels = max(1, u16(body + 2))
+                sampleRate = u32(body + 4)
+                bitsPerSample = u16(body + 14)
+                if format == 0xFFFE, body + 26 <= bytes.count {  // WAVE_FORMAT_EXTENSIBLE
+                    format = u16(body + 24)                       // the real sub-format tag
+                }
+            } else if id == (0x64, 0x61, 0x74, 0x61) {   // "data"
+                dataStart = body
+                dataSize = min(size, bytes.count - body)
+            }
+            pos = body + size + (size & 1)               // chunks are word-aligned
+        }
+        guard dataStart >= 0 else { throw WAVError.truncated }
+        guard sampleRate > 0 else { throw WAVError.unsupported("sample rate 0") }
+
+        let samples = try decodeSamples(bytes, at: dataStart, size: dataSize,
+                                        format: format, bits: bitsPerSample)
+        return PCM(samples: samples, sampleRate: Double(sampleRate), channels: channels)
+    }
+
+    private static func decodeSamples(_ b: [UInt8], at start: Int, size: Int,
+                                      format: Int, bits: Int) throws -> [Float] {
+        let bytesPer = bits / 8
+        guard bytesPer > 0 else { throw WAVError.unsupported("0 bits/sample") }
+        let count = size / bytesPer
+        var out = [Float](repeating: 0, count: count)
+        if format == 3 {                                 // IEEE float
+            if bits == 32 {
+                for i in 0..<count {
+                    let o = start + i * 4
+                    let u = UInt32(b[o]) | (UInt32(b[o + 1]) << 8) | (UInt32(b[o + 2]) << 16) | (UInt32(b[o + 3]) << 24)
+                    out[i] = Float(bitPattern: u)
+                }
+            } else if bits == 64 {
+                for i in 0..<count {
+                    let o = start + i * 8
+                    var u: UInt64 = 0
+                    for j in 0..<8 { u |= UInt64(b[o + j]) << (8 * j) }
+                    out[i] = Float(Double(bitPattern: u))
+                }
+            } else { throw WAVError.unsupported("float \(bits)-bit") }
+            return out
+        }
+        guard format == 1 else { throw WAVError.unsupported("format tag \(format)") }
+        switch bits {
+        case 8:   // unsigned
+            for i in 0..<count { out[i] = (Float(b[start + i]) - 128) / 128 }
+        case 16:
+            for i in 0..<count {
+                let o = start + i * 2
+                let s = Int16(bitPattern: UInt16(b[o]) | (UInt16(b[o + 1]) << 8))
+                out[i] = Float(s) / 32768
+            }
+        case 24:
+            for i in 0..<count {
+                let o = start + i * 3
+                var v = Int(b[o]) | (Int(b[o + 1]) << 8) | (Int(b[o + 2]) << 16)
+                if v & 0x800000 != 0 { v |= ~0xFFFFFF }  // sign-extend
+                out[i] = Float(v) / 8388608
+            }
+        case 32:
+            for i in 0..<count {
+                let o = start + i * 4
+                let u = UInt32(b[o]) | (UInt32(b[o + 1]) << 8) | (UInt32(b[o + 2]) << 16) | (UInt32(b[o + 3]) << 24)
+                out[i] = Float(Int32(bitPattern: u)) / 2147483648
+            }
+        default:
+            throw WAVError.unsupported("PCM \(bits)-bit")
+        }
+        return out
+    }
+
+    // MARK: Encode
+
+    /// Encode interleaved `samples` (in `[-1, 1]`) as a 16-bit PCM WAV buffer.
+    public static func encode(_ samples: [Float], sampleRate: Int, channels: Int = 1) -> [UInt8] {
+        var out = [UInt8]()
+        out.reserveCapacity(44 + samples.count * 2)
+        func u16(_ v: Int) { out.append(UInt8(v & 0xFF)); out.append(UInt8((v >> 8) & 0xFF)) }
+        func u32(_ v: Int) { for s in 0..<4 { out.append(UInt8((v >> (8 * s)) & 0xFF)) } }
+        func tag(_ s: String) { out.append(contentsOf: s.utf8) }
+
+        let dataSize = samples.count * 2
+        let byteRate = sampleRate * channels * 2
+        tag("RIFF"); u32(36 + dataSize); tag("WAVE")
+        tag("fmt "); u32(16); u16(1); u16(channels); u32(sampleRate)
+        u32(byteRate); u16(channels * 2); u16(16)
+        tag("data"); u32(dataSize)
+        for v in samples {
+            let clamped = max(-1, min(1, v))
+            let s = Int16((clamped * 32767).rounded())
+            u16(Int(UInt16(bitPattern: s)))
+        }
+        return out
+    }
+}

--- a/Sources/CHostBridge/CHostBridge.c
+++ b/Sources/CHostBridge/CHostBridge.c
@@ -60,4 +60,12 @@ static HostAppIdFn g_app_id = 0;
 void host_set_app_id(HostAppIdFn fn) { g_app_id = fn; }
 char *host_app_id(void) { return g_app_id ? g_app_id() : 0; }
 
+static HostAudioDecodeFn g_audio_decode = 0;
+
+void host_set_audio_decode(HostAudioDecodeFn fn) { g_audio_decode = fn; }
+char *host_audio_decode(const char *path, const unsigned char *bytes,
+                        int64_t byte_count, double target_sample_rate) {
+    return g_audio_decode ? g_audio_decode(path, bytes, byte_count, target_sample_rate) : 0;
+}
+
 void host_free(char *ptr) { free(ptr); }

--- a/Sources/CHostBridge/include/CHostBridge.h
+++ b/Sources/CHostBridge/include/CHostBridge.h
@@ -85,6 +85,19 @@ typedef char *(*HostAppIdFn)(void);
 void host_set_app_id(HostAppIdFn fn);
 char *host_app_id(void);
 
+// Audio decode (Android / hosts with no in-process audio decoder): the host
+// decodes the file at `path` (or, when `path` is NULL, the `byte_count` bytes at
+// `bytes`) to mono PCM at `target_sample_rate`, mixing channels down and
+// resampling as needed. It returns a malloc'd, length-prefixed FFI buffer the
+// caller frees with host_free: a big-endian uint32 body length, then a uint32
+// sample rate, then a float32 array (uint32 count, then that many big-endian
+// floats). NULL means "not installed / decode failed".
+typedef char *(*HostAudioDecodeFn)(const char *path, const unsigned char *bytes,
+                                   int64_t byte_count, double target_sample_rate);
+void host_set_audio_decode(HostAudioDecodeFn fn);
+char *host_audio_decode(const char *path, const unsigned char *bytes,
+                        int64_t byte_count, double target_sample_rate);
+
 void host_free(char *ptr);
 
 #ifdef __cplusplus

--- a/Sources/FFIBuffer/FFIBuffer.swift
+++ b/Sources/FFIBuffer/FFIBuffer.swift
@@ -48,6 +48,19 @@ public struct FFIWriter {
     /// Append a double as its big-endian IEEE-754 bit pattern.
     public mutating func f64(_ v: Double) { u64(v.bitPattern) }
 
+    /// Append a float as its big-endian IEEE-754 bit pattern. `truncatingIfNeeded`
+    /// keeps the 32 bits verbatim on wasm32, where `Int` is 32-bit and a plain
+    /// `Int(bitPattern)` traps for any pattern with the high bit set.
+    public mutating func f32(_ v: Float) { u32(Int(truncatingIfNeeded: v.bitPattern)) }
+
+    /// Append a uint32 element count, then that many big-endian floats. The
+    /// portable typed-array payload for audio buffers and feature vectors that
+    /// cross the C ABI (host reads it with the matching `FfiReader`).
+    public mutating func f32Array(_ values: [Float]) {
+        u32(values.count)
+        for v in values { f32(v) }
+    }
+
     /// Append a uint32 UTF-8 byte count, then the UTF-8 bytes.
     public mutating func string(_ s: String) {
         let utf8 = Array(s.utf8)
@@ -93,3 +106,76 @@ public func ffiCString(_ string: String) -> UnsafeMutablePointer<CChar>? {
 
 /// Free a buffer returned by this module.
 public func ffiFree(_ ptr: UnsafeMutablePointer<CChar>?) { free(ptr) }
+
+/// Reads a payload written by `FFIWriter` (or the host's matching writer). The
+/// mirror image of `FFIWriter`: same big-endian, length-prefixed layout, so the
+/// Swift side parses a host-produced buffer without a hand-rolled cursor.
+///
+/// Every read advances the cursor; out-of-range reads return zero/empty rather
+/// than trapping, so a truncated buffer degrades instead of crashing an app.
+public struct FFIReader {
+    private let bytes: [UInt8]
+    private var offset: Int
+
+    /// Read from a raw payload (no outer length prefix).
+    public init(_ bytes: [UInt8]) {
+        self.bytes = bytes
+        self.offset = 0
+    }
+
+    /// Read from a length-prefixed buffer as emitted by `ffiEmit` (a big-endian
+    /// uint32 length then the body), returning a reader over the body.
+    public init(lengthPrefixed buffer: [UInt8]) {
+        guard buffer.count >= 4 else { self.init([]); return }
+        var length = 0
+        for i in 0..<4 { length = (length << 8) | Int(buffer[i]) }
+        let end = min(buffer.count, 4 + length)
+        self.init(Array(buffer[4..<end]))
+    }
+
+    /// Bytes not yet consumed.
+    public var remaining: Int { bytes.count - offset }
+
+    private mutating func byte() -> UInt8 {
+        guard offset < bytes.count else { return 0 }
+        defer { offset += 1 }
+        return bytes[offset]
+    }
+
+    /// Read a big-endian uint32.
+    public mutating func u32() -> Int {
+        var v = 0
+        for _ in 0..<4 { v = (v << 8) | Int(byte()) }
+        return v
+    }
+
+    /// Read a big-endian uint64.
+    public mutating func u64() -> UInt64 {
+        var v: UInt64 = 0
+        for _ in 0..<8 { v = (v << 8) | UInt64(byte()) }
+        return v
+    }
+
+    /// Read a big-endian IEEE-754 float.
+    public mutating func f32() -> Float { Float(bitPattern: UInt32(truncatingIfNeeded: u32())) }
+
+    /// Read a big-endian IEEE-754 double.
+    public mutating func f64() -> Double { Double(bitPattern: u64()) }
+
+    /// Read a uint32 UTF-8 byte count, then that many bytes as a string.
+    public mutating func string() -> String {
+        let count = u32()
+        var scalars = [UInt8](); scalars.reserveCapacity(count)
+        for _ in 0..<count { scalars.append(byte()) }
+        return String(decoding: scalars, as: UTF8.self)
+    }
+
+    /// Read a uint32 count, then that many big-endian floats.
+    public mutating func f32Array() -> [Float] {
+        let count = u32()
+        guard count >= 0, count <= remaining / 4 else { return [] }
+        var out = [Float](); out.reserveCapacity(count)
+        for _ in 0..<count { out.append(f32()) }
+        return out
+    }
+}

--- a/Sources/HostBridge/JNI.swift
+++ b/Sources/HostBridge/JNI.swift
@@ -31,6 +31,7 @@ private nonisolated(unsafe) var gHttpDownload: jmethodID?
 private nonisolated(unsafe) var gPrefsGet: jmethodID?
 private nonisolated(unsafe) var gPrefsSet: jmethodID?
 private nonisolated(unsafe) var gAppId: jmethodID?
+private nonisolated(unsafe) var gAudioDecode: jmethodID?
 
 // MARK: byte-array marshalling
 
@@ -207,6 +208,31 @@ private func hostPrefsSet(_ key: UnsafePointer<CChar>?, _ value: UnsafePointer<C
     if env.pointee!.pointee.ExceptionCheck(env) == JNI_TRUE { env.pointee!.pointee.ExceptionClear(env) }
 }
 
+// Audio decode: marshal the optional path (UTF-8 bytes) and optional file
+// bytes to jbyteArrays and the target rate to a jdouble, call the host
+// decoder, and take its length-prefixed FFI buffer (u32 rate + f32 array).
+private func hostAudioDecode(_ path: UnsafePointer<CChar>?, _ bytes: UnsafePointer<UInt8>?,
+                             _ byteCount: Int64, _ sampleRate: Double) -> UnsafeMutablePointer<CChar>? {
+    withHostEnv { env in
+        let pathArr: jbyteArray? = path.map { hostMakeBytes(env, Array(String(cString: $0).utf8)) ?? nil } ?? nil
+        let dataArr: jbyteArray?
+        if let bytes, byteCount > 0 {
+            dataArr = hostMakeBytes(env, Array(UnsafeBufferPointer(start: bytes, count: Int(byteCount))))
+        } else {
+            dataArr = nil
+        }
+        defer {
+            if let pathArr { env.pointee!.pointee.DeleteLocalRef(env, pathArr) }
+            if let dataArr { env.pointee!.pointee.DeleteLocalRef(env, dataArr) }
+        }
+        let args = [jvalue(l: pathArr), jvalue(l: dataArr), jvalue(d: sampleRate)]
+        let result = args.withUnsafeBufferPointer {
+            env.pointee!.pointee.CallStaticObjectMethodA(env, gHostClass, gAudioDecode, $0.baseAddress)
+        }
+        return resultBytes(env, result)
+    }
+}
+
 private func hostHttpTree(_ url: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>? {
     withHostEnv { env in
         guard let u = hostMakeBytes(env, Array(String(cString: url!).utf8)) else { return nil }
@@ -271,6 +297,8 @@ public func installHostBridge(_ env: HostEnv, _ cls: jclass?) {
     gPrefsSet = env.pointee!.pointee.GetStaticMethodID(env, cls, "prefsSet", "([B[B)V")
     // Optional: the app identity used as the usage turnstile key.
     gAppId = env.pointee!.pointee.GetStaticMethodID(env, cls, "appId", "()[B")
+    // Optional: audio decode (AudioIO on Android) via MediaExtractor/MediaCodec.
+    gAudioDecode = env.pointee!.pointee.GetStaticMethodID(env, cls, "audioDecode", "([B[BD)[B")
     if env.pointee!.pointee.ExceptionCheck(env) == JNI_TRUE { env.pointee!.pointee.ExceptionClear(env) }
     if gRegexMatches != nil { host_set_regex_matches(hostRegexMatches) }
     if gJSONParse != nil { host_set_json_parse(hostJSONParse) }
@@ -280,5 +308,6 @@ public func installHostBridge(_ env: HostEnv, _ cls: jclass?) {
     if gPrefsGet != nil { host_set_prefs_get(hostPrefsGet) }
     if gPrefsSet != nil { host_set_prefs_set(hostPrefsSet) }
     if gAppId != nil { host_set_app_id(hostAppId) }
+    if gAudioDecode != nil { host_set_audio_decode(hostAudioDecode) }
 }
 #endif

--- a/Sources/Inference/ComputeUnits.swift
+++ b/Sources/Inference/ComputeUnits.swift
@@ -1,0 +1,18 @@
+/// Which compute units an on-device backend may use. Maps to Core ML's
+/// `MLComputeUnits` on Apple; the ONNX/LiteRT/JS backends ignore it (they pick
+/// their own execution providers). Model SDKs pass it through the session
+/// factory so they need not import CoreML to pin, e.g., `.cpuAndNeuralEngine`.
+///
+/// Choosing: `.all` lets Core ML use CPU+GPU+ANE, but for a small-op-dense
+/// graph the GPU is often slow and, if any op forces a CPU fallback (e.g. a
+/// `while_loop`), the extra partitioning can make `.all` slower than
+/// `.cpuOnly`. ANE-friendly graphs (no dynamic control flow) are usually
+/// fastest on `.cpuAndNeuralEngine`.
+public enum ComputeUnits: Sendable {
+    /// CPU + GPU + Neural Engine; Core ML partitions across them.
+    case all
+    /// CPU + Neural Engine (skips the GPU). Often fastest on ANE-native graphs.
+    case cpuAndNeuralEngine
+    /// CPU only. Deterministic fallback / diagnostic.
+    case cpuOnly
+}

--- a/Sources/Inference/CoreMLSession.swift
+++ b/Sources/Inference/CoreMLSession.swift
@@ -1,82 +1,156 @@
 #if canImport(CoreML)
 import CoreML
+import Accelerate
 import Foundation
 
 /// Core ML inference backend (Apple platforms): a compiled `.mlmodelc` behind
 /// the shared ``InferenceSession`` API.
 ///
-/// Inputs must be `int32` or `float32` (Core ML has no int64 tensors; export
-/// models accordingly). `float32`/`int32` outputs are copied out directly;
-/// other output types (e.g. float16) are converted to `float32` elementwise,
-/// which is slow for large outputs, so exporters should emit `float32`.
+/// Feeds the model's native I/O precision: when an input/output is `float16`
+/// (as fp16-exported graphs declare), it converts against a `Tensor`'s
+/// `float32` bytes with vImage rather than per-element `NSNumber` subscripting,
+/// which is orders of magnitude faster on large tensors (and lets Core ML run
+/// the pure-fp16 graph instead of inserting casts). The MLMultiArrays and the
+/// feature provider are built once and reused across `run` calls of the same
+/// shape (e.g. a fixed-window model over many chunks). `int32`/`float32` I/O is
+/// copied directly; `int64` inputs are rejected (Core ML has no int64 tensors).
 final class CoreMLSession: InferenceSession, @unchecked Sendable {
     private let model: MLModel
+    private let lock = NSLock()
+    private var inArrays: [String: MLMultiArray] = [:]
+    private var provider: MLDictionaryFeatureProvider?
 
-    /// Load a compiled model. The default configuration uses every compute
-    /// unit on device (CPU-only in the simulator); pass your own to override,
-    /// e.g. `.cpuAndNeuralEngine` for large models.
-    init(modelPath: String, configuration: MLModelConfiguration = CoreMLSession.defaultConfiguration()) throws {
-        model = try MLModel(contentsOf: URL(fileURLWithPath: modelPath), configuration: configuration)
-    }
-
-    static func defaultConfiguration() -> MLModelConfiguration {
-        let configuration = MLModelConfiguration()
+    /// Load a compiled model. `computeUnits` maps to `MLModelConfiguration`;
+    /// the simulator is pinned to CPU (no ANE there).
+    init(modelPath: String, computeUnits: ComputeUnits = .all) throws {
+        let cfg = MLModelConfiguration()
         #if targetEnvironment(simulator)
-        configuration.computeUnits = .cpuOnly
+        cfg.computeUnits = .cpuOnly
         #else
-        configuration.computeUnits = .all
+        cfg.computeUnits = computeUnits.mlComputeUnits
         #endif
-        return configuration
+        model = try MLModel(contentsOf: URL(fileURLWithPath: modelPath), configuration: cfg)
     }
 
     func run(inputs: [String: Tensor], outputs: [String], deviceId: String?) throws -> [Tensor] {
-        var features: [String: Any] = [:]
-        for (name, tensor) in inputs { features[name] = try multiArray(tensor) }
-        let provider = try MLDictionaryFeatureProvider(dictionary: features)
-        let prediction = try model.prediction(from: provider)
+        lock.lock(); defer { lock.unlock() }
+        let desc = model.modelDescription.inputDescriptionsByName
+
+        // Build (once) and reuse the input arrays + provider; rebuild only when
+        // the set of inputs or a shape changes.
+        if provider == nil || !cacheMatches(inputs) {
+            inArrays.removeAll(keepingCapacity: true)
+            var features: [String: Any] = [:]
+            for (name, tensor) in inputs {
+                let dt = try dataType(for: tensor, declared: desc[name]?.multiArrayConstraint?.dataType)
+                let array = try MLMultiArray(shape: tensor.shape.map { NSNumber(value: $0) }, dataType: dt)
+                inArrays[name] = array
+                features[name] = array
+            }
+            provider = try MLDictionaryFeatureProvider(dictionary: features)
+        }
+        for (name, tensor) in inputs { write(tensor, into: inArrays[name]!) }
+
+        let prediction = try model.prediction(from: provider!)
         return try outputs.map { name in
             guard let array = prediction.featureValue(for: name)?.multiArrayValue else {
                 throw InferenceError.runFailed("the model returned no '\(name)'")
             }
-            return try tensor(array)
+            return readTensor(array)
         }
     }
 
-    private func multiArray(_ tensor: Tensor) throws -> MLMultiArray {
-        let dataType: MLMultiArrayDataType
+    private func cacheMatches(_ inputs: [String: Tensor]) -> Bool {
+        guard inArrays.count == inputs.count else { return false }
+        for (name, tensor) in inputs {
+            guard let a = inArrays[name], a.shape.map(\.intValue) == tensor.shape else { return false }
+        }
+        return true
+    }
+
+    private func dataType(for tensor: Tensor, declared: MLMultiArrayDataType?) throws -> MLMultiArrayDataType {
         switch tensor.element {
-        case .int32: dataType = .int32
-        case .float32: dataType = .float32
         case .int64:
             throw InferenceError.invalidTensor("Core ML takes int32, not int64; export the model accordingly")
+        case .int32:
+            return .int32
+        case .float32:
+            // Match the model's declared precision so an fp16 graph gets fp16.
+            return declared == .float16 ? .float16 : .float32
         }
-        let array = try MLMultiArray(shape: tensor.shape.map { NSNumber(value: $0) }, dataType: dataType)
-        array.withUnsafeMutableBytes { destination, _ in
-            tensor.bytes.withUnsafeBytes { destination.copyMemory(from: $0) }
-        }
-        return array
     }
 
-    private func tensor(_ array: MLMultiArray) throws -> Tensor {
+    private func write(_ tensor: Tensor, into array: MLMultiArray) {
+        let count = tensor.count
+        tensor.bytes.withUnsafeBytes { raw in
+            if array.dataType == .float16 {
+                let src = raw.bindMemory(to: Float.self)
+                var s = vImage_Buffer(data: .init(mutating: src.baseAddress!), height: 1,
+                                      width: vImagePixelCount(count), rowBytes: count * 4)
+                var d = vImage_Buffer(data: array.dataPointer, height: 1,
+                                      width: vImagePixelCount(count), rowBytes: count * 2)
+                vImageConvert_PlanarFtoPlanar16F(&s, &d, 0)
+            } else {
+                array.dataPointer.copyMemory(from: raw.baseAddress!, byteCount: count * array.dataType.byteWidth)
+            }
+        }
+    }
+
+    private func readTensor(_ array: MLMultiArray) -> Tensor {
         let shape = array.shape.map(\.intValue)
         let count = shape.reduce(1, *)
-        switch array.dataType {
-        case .float32:
-            return try Tensor(element: .float32, shape: shape, bytes: copyBytes(array, count * 4))
-        case .int32:
-            return try Tensor(element: .int32, shape: shape, bytes: copyBytes(array, count * 4))
-        default:
-            // float16/float64 outputs: convert through the typed subscript.
-            var values = [Float](repeating: 0, count: count)
-            for index in 0..<count { values[index] = array[index].floatValue }
-            return Tensor(float32: values, shape: shape)
+        let contiguous = isContiguous(array)
+        if array.dataType == .int32, contiguous {
+            let bytes = array.dataPointer.withMemoryRebound(to: UInt8.self, capacity: count * 4) {
+                Array(UnsafeBufferPointer(start: $0, count: count * 4))
+            }
+            return (try? Tensor(element: .int32, shape: shape, bytes: bytes)) ?? Tensor(float32: [], shape: shape)
         }
+        var out = [Float](repeating: 0, count: count)
+        if array.dataType == .float16, contiguous {
+            let src = array.dataPointer.assumingMemoryBound(to: UInt16.self)
+            var s = vImage_Buffer(data: .init(mutating: src), height: 1, width: vImagePixelCount(count), rowBytes: count * 2)
+            out.withUnsafeMutableBufferPointer { dp in
+                var d = vImage_Buffer(data: dp.baseAddress!, height: 1, width: vImagePixelCount(count), rowBytes: count * 4)
+                vImageConvert_Planar16FtoPlanarF(&s, &d, 0)
+            }
+        } else if array.dataType == .float32, contiguous {
+            out.withUnsafeMutableBufferPointer { $0.baseAddress!.update(from: array.dataPointer.assumingMemoryBound(to: Float.self), count: count) }
+        } else {
+            // Strided (ANE-padded inner dims) or float64: correct, slower path.
+            for i in 0..<count { out[i] = array[i].floatValue }
+        }
+        return Tensor(float32: out, shape: shape)
     }
 
-    private func copyBytes(_ array: MLMultiArray, _ byteCount: Int) -> [UInt8] {
-        array.withUnsafeBytes { source in
-            precondition(source.count >= byteCount, "MLMultiArray smaller than its shape")
-            return Array(source.prefix(byteCount))
+    private func isContiguous(_ array: MLMultiArray) -> Bool {
+        let shape = array.shape.map(\.intValue), strides = array.strides.map(\.intValue)
+        var expected = 1
+        for i in (0..<shape.count).reversed() {
+            if strides[i] != expected { return false }
+            expected *= shape[i]
+        }
+        return true
+    }
+}
+
+extension ComputeUnits {
+    var mlComputeUnits: MLComputeUnits {
+        switch self {
+        case .all: return .all
+        case .cpuAndNeuralEngine: return .cpuAndNeuralEngine
+        case .cpuOnly: return .cpuOnly
+        }
+    }
+}
+
+private extension MLMultiArrayDataType {
+    var byteWidth: Int {
+        switch self {
+        case .float16: return 2
+        case .int32, .float32: return 4
+        case .double: return 8
+        @unknown default: return 4
         }
     }
 }

--- a/Sources/Inference/SessionFactory.swift
+++ b/Sources/Inference/SessionFactory.swift
@@ -9,14 +9,16 @@ import Usage
 /// `.mlmodelc` through Core ML on Apple platforms, a `.onnx` through ONNX
 /// Runtime on Android/Linux. wasm has no local file inference; use
 /// `StoredModel.inferenceSession(model:hostGlobal:)` instead.
-public func inferenceSession(modelPath: String, sdk: SDKInfo = SDKInfo()) throws -> any InferenceSession {
+public func inferenceSession(modelPath: String, computeUnits: ComputeUnits = .all,
+                             sdk: SDKInfo = SDKInfo()) throws -> any InferenceSession {
     // DAL_LITERT is checked before Core ML so a LiteRT-backed native build on an
     // Apple host (the Node SDK's darwin native) uses LiteRT and its .tflite,
     // while the default Apple SDK build (flag unset) falls through to Core ML.
+    // `computeUnits` is a Core ML concern; the other backends ignore it.
     #if DAL_LITERT
     return tracked(try LiteRTSession(modelPath: modelPath), sdk: sdk)
     #elseif canImport(CoreML)
-    return tracked(try CoreMLSession(modelPath: modelPath), sdk: sdk)
+    return tracked(try CoreMLSession(modelPath: modelPath, computeUnits: computeUnits), sdk: sdk)
     #elseif canImport(COnnxRuntime)
     return tracked(try ORTSession(modelPath: modelPath), sdk: sdk)
     #else
@@ -56,12 +58,13 @@ public extension StoredModel {
     /// host's session is driven through the `JSInferenceSession` tensor
     /// contract. This is the one call a model SDK makes to go from resolved
     /// files to a runnable session.
-    func inferenceSession(model: String, hostGlobal: String = "__ModelHost", sdk: SDKInfo = SDKInfo()) async throws -> any InferenceSession {
+    func inferenceSession(model: String, hostGlobal: String = "__ModelHost",
+                          computeUnits: ComputeUnits = .all, sdk: SDKInfo = SDKInfo()) async throws -> any InferenceSession {
         #if os(WASI)
         try await createJavaScriptSession(modelFile: model, hostGlobal: hostGlobal)
         return tracked(try JSInferenceSession(hostGlobal: hostGlobal), sdk: sdk)
         #else
-        return try Inference.inferenceSession(modelPath: path(model), sdk: sdk)  // already tracked
+        return try Inference.inferenceSession(modelPath: path(model), computeUnits: computeUnits, sdk: sdk)  // already tracked
         #endif
     }
 }

--- a/Tests/AudioDSPTests/AudioDSPTests.swift
+++ b/Tests/AudioDSPTests/AudioDSPTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+import Foundation
+@testable import AudioDSP
+
+final class AudioDSPTests: XCTestCase {
+    // Signal-to-error ratio in dB between a reference and a reconstruction.
+    private func snr(_ ref: [Float], _ rec: [Float]) -> Double {
+        let n = min(ref.count, rec.count)
+        var sig = 0.0, err = 0.0
+        for i in 0..<n {
+            sig += Double(ref[i]) * Double(ref[i])
+            let e = Double(ref[i]) - Double(rec[i])
+            err += e * e
+        }
+        return err > 0 ? 10 * log10(sig / err) : .infinity
+    }
+
+    private func tone(_ n: Int, freq: Double = 440, sr: Double = 16000) -> [Float] {
+        (0..<n).map { Float(0.5 * sin(2 * .pi * freq * Double($0) / sr)) }
+    }
+
+    func testHannPeriodic() {
+        let w = Window.hann(4, periodic: true)
+        XCTAssertEqual(w[0], 0, accuracy: 1e-6)          // periodic Hann starts at 0
+        XCTAssertEqual(w.max()!, 1, accuracy: 1e-6)      // and reaches 1
+    }
+
+    func testSTFTRoundTripReconstructsSignal() {
+        let x = tone(8000)
+        let stft = STFT(nFFT: 400, hop: 100)
+        let spec = stft.forward(x)
+        let y = stft.inverse(spec, length: x.count)
+        XCTAssertEqual(y.count, x.count)
+        // Windowed COLA + real-DFT identity should reconstruct near-perfectly.
+        XCTAssertGreaterThan(snr(x, y), 60)
+    }
+
+    func testSTFTMagnitudePhaseRebuild() {
+        let x = tone(4000, freq: 220)
+        let stft = STFT(nFFT: 256, hop: 64)
+        let spec = stft.forward(x)
+        let mag = spec.magnitude(), pha = spec.phase()
+        // Rebuild re/im from magnitude+phase and confirm the same reconstruction.
+        var rebuilt = spec
+        for i in 0..<mag.count {
+            rebuilt.re[i] = mag[i] * cos(pha[i])
+            rebuilt.im[i] = mag[i] * sin(pha[i])
+        }
+        let y = stft.inverse(rebuilt, length: x.count)
+        XCTAssertGreaterThan(snr(x, y), 60)
+    }
+
+    func testEnergyNormalizeIsInvertible() {
+        let x = tone(2000).map { $0 * 3 }
+        let (norm, gain) = VectorOps.energyNormalize(x)
+        let restored = VectorOps.scaled(norm, by: 1 / gain)
+        XCTAssertGreaterThan(snr(x, restored), 100)   // float round-trip, not bit-exact
+        // Unit average power after normalization.
+        let power = VectorOps.energy(norm) / Float(norm.count)
+        XCTAssertEqual(power, 1, accuracy: 1e-3)
+    }
+
+    func testStandardizeZeroMeanUnitStd() {
+        let x: [Float] = (0..<1000).map { Float($0) }
+        let z = VectorOps.standardize(x)
+        let mean = z.reduce(0, +) / Float(z.count)
+        XCTAssertEqual(mean, 0, accuracy: 1e-3)
+    }
+
+    func testMelSpectrogramShape() {
+        let mel = MelSpectrogram(sampleRate: 16000, nFFT: 400, hop: 160, mels: 80)
+        let (values, frames, mels) = mel.logMel(tone(16000))
+        XCTAssertEqual(mels, 80)
+        XCTAssertGreaterThan(frames, 90)              // ~1 s at hop 160
+        XCTAssertEqual(values.count, frames * mels)
+        XCTAssertTrue(values.allSatisfy { $0.isFinite })
+    }
+
+    func testFramingWindows() {
+        let w = Framing.windows(count: 250, window: 100, hop: 80)
+        XCTAssertEqual(w.first!.start, 0)
+        XCTAssertEqual(w.last!.end, 250)              // final window clamps to count
+        XCTAssertTrue(w.allSatisfy { $0.end <= 250 })
+    }
+
+    func testLoudnessNormalizeHitsTarget() {
+        // 1 kHz tone at 48 kHz, ~3 s; normalize to -19 LUFS.
+        let sr = 48_000.0
+        let x = (0..<Int(3 * sr)).map { Float(0.1 * sin(2 * .pi * 1000 * Double($0) / sr)) }
+        let before = Loudness.integratedLUFS(x, sampleRate: sr)
+        XCTAssertNotNil(before)
+        let (y, measured) = Loudness.normalize(x, sampleRate: sr, targetLUFS: -19, maxGainDB: 30, peakCeilingDBFS: -1)
+        XCTAssertEqual(measured, before)
+        let after = Loudness.integratedLUFS(y, sampleRate: sr)!
+        XCTAssertEqual(after, -19, accuracy: 0.5)          // lands on target
+        XCTAssertTrue(y.allSatisfy { abs($0) <= 1 })       // never clips
+    }
+
+    func testLoudnessSilenceIsNil() {
+        XCTAssertNil(Loudness.integratedLUFS([Float](repeating: 0, count: 48_000), sampleRate: 48_000))
+    }
+
+    func testOverlapAccumulatorAverages() {
+        var acc = OverlapAccumulator(length: 4)
+        acc.add([1, 1], at: 0)
+        acc.add([3, 3], at: 1)   // index 1 and 2 now overlap
+        let avg = acc.average()
+        XCTAssertEqual(avg, [1, 2, 3, 0])
+    }
+}

--- a/Tests/AudioIOTests/AudioIOTests.swift
+++ b/Tests/AudioIOTests/AudioIOTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import Foundation
+@testable import AudioIO
+
+final class AudioIOTests: XCTestCase {
+    private func tone(_ n: Int, freq: Double = 440, sr: Double = 16000) -> [Float] {
+        (0..<n).map { Float(0.5 * sin(2 * .pi * freq * Double($0) / sr)) }
+    }
+
+    func testWAVRoundTrip16Bit() throws {
+        let x = tone(4000)
+        let bytes = WAV.encode(x, sampleRate: 16000, channels: 1)
+        let pcm = try WAV.decode(bytes)
+        XCTAssertEqual(pcm.sampleRate, 16000)
+        XCTAssertEqual(pcm.channels, 1)
+        XCTAssertEqual(pcm.samples.count, x.count)
+        // 16-bit quantization error is bounded by ~1/32768.
+        var maxErr: Float = 0
+        for i in 0..<x.count { maxErr = max(maxErr, abs(x[i] - pcm.samples[i])) }
+        XCTAssertLessThan(maxErr, 1e-3)
+    }
+
+    // AudioIO.decode / writeWAV route through the platform backend: the
+    // AVFoundation/portable-WAV path on Apple/Linux, but the JS host on wasm
+    // (which isn't installed in the Swift test harness) and a filesystem the
+    // WASI sandbox lacks. The wasm decode path is covered by js/test/audio.test.mjs
+    // (installAudioHost). These exercise the native/portable path only.
+    #if !os(WASI)
+    func testDecodeBytesPortableWAV() async throws {
+        let x = tone(1600)
+        let wav = WAV.encode(x, sampleRate: 16000, channels: 1)
+        let mono = try await AudioIO.decode(bytes: wav, sampleRate: 16000)
+        XCTAssertEqual(mono.count, x.count)
+    }
+
+    func testDecodeResamplesToTargetRate() async throws {
+        // Encode at 8 kHz, decode requesting 16 kHz: roughly 2x the samples.
+        let x = tone(800, sr: 8000)
+        let wav = WAV.encode(x, sampleRate: 8000, channels: 1)
+        let mono = try await AudioIO.decode(bytes: wav, sampleRate: 16000)
+        XCTAssertEqual(Double(mono.count), 1600, accuracy: 4)
+    }
+
+    func testDecodeFromFileRoundTrip() async throws {
+        let x = tone(2000)
+        let dir = FileManager.default.temporaryDirectory
+        let url = dir.appendingPathComponent("dal-audioio-test-\(UUID().uuidString).wav")
+        try AudioIO.writeWAV(x, sampleRate: 16000, to: url.path)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let mono = try await AudioIO.decode(path: url.path, sampleRate: 16000)
+        XCTAssertEqual(mono.count, x.count)
+    }
+    #endif
+
+    func testStereoMixdown() throws {
+        // Interleaved L/R: L = +0.5, R = -0.5 -> mono averages to 0.
+        let interleaved = [Float](repeating: 0, count: 200).enumerated().map { i, _ in
+            i % 2 == 0 ? Float(0.5) : Float(-0.5)
+        }
+        let wav = WAV.encode(interleaved, sampleRate: 16000, channels: 2)
+        let pcm = try WAV.decode(wav)
+        XCTAssertEqual(pcm.channels, 2)
+        let mono = Resample.mixdownMono(pcm.samples, channels: 2)
+        XCTAssertEqual(mono.count, 100)
+        XCTAssertTrue(mono.allSatisfy { abs($0) < 1e-3 })
+    }
+}

--- a/Tests/FFIBufferTests/FFIBufferTests.swift
+++ b/Tests/FFIBufferTests/FFIBufferTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import FFIBuffer
+
+final class FFIBufferTests: XCTestCase {
+    func testScalarRoundTrip() {
+        var w = FFIWriter()
+        w.u32(0x0102_0304)
+        w.u64(0xDEAD_BEEF_1234_5678)
+        w.f32(1.5)
+        w.f64(-3.25)
+        w.string("héllo")
+
+        var r = FFIReader(w.bytes)
+        XCTAssertEqual(r.u32(), 0x0102_0304)
+        XCTAssertEqual(r.u64(), 0xDEAD_BEEF_1234_5678)
+        XCTAssertEqual(r.f32(), 1.5)
+        XCTAssertEqual(r.f64(), -3.25)
+        XCTAssertEqual(r.string(), "héllo")
+    }
+
+    func testFloatArrayRoundTrip() {
+        let values: [Float] = [0, 1, -1, 0.333, 1e6, -1e-6]
+        var w = FFIWriter()
+        w.f32Array(values)
+        var r = FFIReader(w.bytes)
+        XCTAssertEqual(r.f32Array(), values)
+    }
+
+    func testLengthPrefixedReaderMatchesEmit() {
+        var w = FFIWriter()
+        w.u32(7)
+        w.f32Array([2, 4, 8])
+        // ffiEmit prefixes the body with a big-endian u32 length.
+        guard let ptr = w.emit() else { return XCTFail("emit failed") }
+        defer { ffiFree(ptr) }
+        let base = UnsafeRawPointer(ptr).assumingMemoryBound(to: UInt8.self)
+        let total = 4 + w.bytes.count
+        let buffer = [UInt8](UnsafeBufferPointer(start: base, count: total))
+
+        var r = FFIReader(lengthPrefixed: buffer)
+        XCTAssertEqual(r.u32(), 7)
+        XCTAssertEqual(r.f32Array(), [2, 4, 8])
+    }
+
+    func testTruncatedReadsDegrade() {
+        var r = FFIReader([0x00, 0x01])  // too short for a u32
+        XCTAssertEqual(r.u32(), 0x0001_0000)  // big-endian; missing low bytes read as 0
+        XCTAssertEqual(r.f32Array(), [])
+    }
+}

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -20,6 +20,20 @@ export class FfiReader {
   readonly remaining: number;
 }
 
+/** The audio-decode host the wasm AudioIO backend calls (`__DalAudioHost`). */
+export interface AudioHost {
+  decode(path: string | null, bytes: Uint8Array | null, sampleRate: number): Promise<Float32Array>;
+}
+
+/** Install `globalThis.__DalAudioHost` so the wasm core can decode audio.
+ *  Browser: Web Audio (any container). Node (`/node` entry): the WAV codec. */
+export function installAudioHost(): AudioHost;
+
+/** Decode a WAV/RIFF buffer to interleaved float samples + rate + channels. */
+export function decodeWav(bytes: Uint8Array): { samples: Float32Array; sampleRate: number; channels: number };
+export function mixdownMono(interleaved: Float32Array, channels: number): Float32Array;
+export function resampleLinear(x: Float32Array, from: number, to: number): Float32Array;
+
 export function loadLiteRt(options: {
   litert?: any;
   wasmDir?: string;

--- a/js/index.js
+++ b/js/index.js
@@ -4,6 +4,8 @@
 // helper, the browser platform seam, and the FFI reader. The node-only native
 // loader and node platform seam live in the "./node" subpath.
 export { FfiReader } from "./src/ffi.js";
+export { installAudioHost } from "./src/audio.js";
+export { decodeWav, mixdownMono, resampleLinear } from "./src/wav.js";
 export {
   loadLiteRt,
   assertBrowserRuntime,

--- a/js/node.d.ts
+++ b/js/node.d.ts
@@ -1,6 +1,10 @@
 // Type declarations for the node-only entry of @desert-ant-labs/core/node.
-import { FfiReader } from "./index.js";
+import { FfiReader, AudioHost } from "./index.js";
 export { FfiReader };
+
+/** Install `globalThis.__DalAudioHost` backed by the pure-JS WAV codec (Node
+ *  has no Web Audio). Reads the file at `path` through `node:fs`. */
+export function installAudioHost(): AudioHost;
 
 export interface NativeCore {
   koffi: any;

--- a/js/node.js
+++ b/js/node.js
@@ -11,3 +11,4 @@ export {
   nodeCacheRoot,
 } from "./src/platform-node.js";
 export { FfiReader } from "./src/ffi.js";
+export { installAudioHost } from "./src/audio-node.js";

--- a/js/src/audio-node.js
+++ b/js/src/audio-node.js
@@ -1,0 +1,30 @@
+// Node audio-decode host for the wasm AudioIO backend (SSR / server-side). Node
+// has no Web Audio, so this decodes with the pure-JS WAV codec and resampler
+// (WAV only, matching Swift AudioIO's portable path). Installs the same
+// `__DalAudioHost.decode` global as the browser host (audio.js); node-only
+// (reads files through `node:fs`).
+
+import { decodeWav, mixdownMono, resampleLinear } from "./wav.js";
+
+/**
+ * Install `globalThis.__DalAudioHost.decode(path, bytes, sampleRate)`, returning
+ * a mono `Float32Array` at `sampleRate`. Under Node the Swift ModelStore hands a
+ * cached file `path` (bytes null); a caller may also pass `bytes` directly.
+ * Idempotent.
+ */
+export function installAudioHost() {
+  globalThis.__DalAudioHost ??= {
+    decode: async (path, bytes, sampleRate) => {
+      let data = bytes;
+      if (!data && path) {
+        const fs = await import("node:fs");
+        data = new Uint8Array(fs.readFileSync(path));
+      }
+      if (!data) throw new Error("__DalAudioHost.decode: no path or bytes");
+      const { samples, sampleRate: srcRate, channels } = decodeWav(data);
+      const mono = mixdownMono(samples, channels);
+      return resampleLinear(mono, srcRate, sampleRate);
+    },
+  };
+  return globalThis.__DalAudioHost;
+}

--- a/js/src/audio.js
+++ b/js/src/audio.js
@@ -1,0 +1,39 @@
+// Browser audio-decode host for the wasm AudioIO backend. Web Audio decodes any
+// container the browser supports (wav/mp3/m4a/ogg/...), and an
+// OfflineAudioContext renders it to mono at the requested sample rate (it
+// downmixes and resamples for us). Installs the `__DalAudioHost.decode` global
+// that Swift AudioIO calls on wasm; browser-safe (no `node:*`).
+
+/**
+ * Install `globalThis.__DalAudioHost.decode(path, bytes, sampleRate)`, returning
+ * a mono `Float32Array` at `sampleRate`. In the browser `path` is null and
+ * `bytes` is the file's `Uint8Array`. Idempotent.
+ */
+export function installAudioHost() {
+  globalThis.__DalAudioHost ??= {
+    decode: async (path, bytes, sampleRate) => decodeBrowser(bytes, sampleRate),
+  };
+  return globalThis.__DalAudioHost;
+}
+
+async function decodeBrowser(bytes, sampleRate) {
+  if (!bytes) throw new Error("__DalAudioHost.decode: browser decode needs file bytes");
+  const Offline = globalThis.OfflineAudioContext || globalThis.webkitOfflineAudioContext;
+  if (!Offline) throw new Error("__DalAudioHost.decode: no OfflineAudioContext");
+
+  // decodeAudioData consumes (detaches) its ArrayBuffer, so hand it an owned copy.
+  const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  const probe = new Offline(1, 1, 44100);
+  const decoded = await probe.decodeAudioData(ab);
+
+  // Render through a 1-channel OfflineAudioContext at the target rate: it mixes
+  // down to mono and resamples in one pass.
+  const frames = Math.max(1, Math.round(decoded.duration * sampleRate));
+  const ctx = new Offline(1, frames, sampleRate);
+  const src = ctx.createBufferSource();
+  src.buffer = decoded;
+  src.connect(ctx.destination);
+  src.start();
+  const rendered = await ctx.startRendering();
+  return rendered.getChannelData(0);
+}

--- a/js/src/wav.js
+++ b/js/src/wav.js
@@ -1,0 +1,91 @@
+// Pure-JS WAV decode + mono mixdown + linear resample: the browser-safe
+// counterpart of Swift AudioIO's portable WAV path (Sources/AudioIO/WAV.swift)
+// and Kotlin's resampler. Node uses this to decode audio without a native codec
+// (WAV only, matching the Swift portable path); the browser uses Web Audio
+// instead (audio.js), so this stays codec-free and dependency-free.
+
+/** Decode a WAV/RIFF Uint8Array to { samples: Float32Array (interleaved),
+ *  sampleRate, channels }. Supports PCM 8/16/24/32-bit and IEEE float 32/64. */
+export function decodeWav(bytes) {
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const tag = (o) => String.fromCharCode(bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]);
+  if (bytes.length < 12 || tag(0) !== "RIFF" || tag(8) !== "WAVE") {
+    throw new Error("not a RIFF/WAVE file");
+  }
+  let format = 1, channels = 1, sampleRate = 0, bits = 16;
+  let dataStart = -1, dataSize = 0;
+  let pos = 12;
+  while (pos + 8 <= bytes.length) {
+    const id = tag(pos);
+    const size = dv.getUint32(pos + 4, true);
+    const body = pos + 8;
+    if (id === "fmt ") {
+      format = dv.getUint16(body, true);
+      channels = Math.max(1, dv.getUint16(body + 2, true));
+      sampleRate = dv.getUint32(body + 4, true);
+      bits = dv.getUint16(body + 14, true);
+      if (format === 0xfffe && body + 26 <= bytes.length) format = dv.getUint16(body + 24, true);
+    } else if (id === "data") {
+      dataStart = body;
+      dataSize = Math.min(size, bytes.length - body);
+    }
+    pos = body + size + (size & 1);
+  }
+  if (dataStart < 0 || sampleRate <= 0) throw new Error("no data/fmt chunk");
+
+  const bytesPer = bits / 8;
+  const count = Math.floor(dataSize / bytesPer);
+  const out = new Float32Array(count);
+  if (format === 3) {
+    if (bits === 32) for (let i = 0; i < count; i++) out[i] = dv.getFloat32(dataStart + i * 4, true);
+    else if (bits === 64) for (let i = 0; i < count; i++) out[i] = dv.getFloat64(dataStart + i * 8, true);
+    else throw new Error(`float ${bits}-bit unsupported`);
+  } else if (format === 1) {
+    if (bits === 8) for (let i = 0; i < count; i++) out[i] = (bytes[dataStart + i] - 128) / 128;
+    else if (bits === 16) for (let i = 0; i < count; i++) out[i] = dv.getInt16(dataStart + i * 2, true) / 32768;
+    else if (bits === 24)
+      for (let i = 0; i < count; i++) {
+        const o = dataStart + i * 3;
+        let v = bytes[o] | (bytes[o + 1] << 8) | (bytes[o + 2] << 16);
+        if (v & 0x800000) v |= ~0xffffff;
+        out[i] = v / 8388608;
+      }
+    else if (bits === 32) for (let i = 0; i < count; i++) out[i] = dv.getInt32(dataStart + i * 4, true) / 2147483648;
+    else throw new Error(`PCM ${bits}-bit unsupported`);
+  } else {
+    throw new Error(`format tag ${format} unsupported`);
+  }
+  return { samples: out, sampleRate, channels };
+}
+
+/** Average interleaved channels down to a mono Float32Array. */
+export function mixdownMono(interleaved, channels) {
+  if (channels <= 1) return interleaved;
+  const frames = Math.floor(interleaved.length / channels);
+  const out = new Float32Array(frames);
+  const inv = 1 / channels;
+  for (let f = 0; f < frames; f++) {
+    let acc = 0;
+    const base = f * channels;
+    for (let c = 0; c < channels; c++) acc += interleaved[base + c];
+    out[f] = acc * inv;
+  }
+  return out;
+}
+
+/** Linearly resample mono `x` from `from` Hz to `to` Hz. */
+export function resampleLinear(x, from, to) {
+  if (from <= 0 || to <= 0 || from === to || x.length < 2) return x;
+  const outCount = Math.round(x.length * (to / from));
+  if (outCount <= 0) return new Float32Array(0);
+  const out = new Float32Array(outCount);
+  const step = from / to;
+  for (let i = 0; i < outCount; i++) {
+    const src = i * step;
+    const i0 = Math.floor(src);
+    if (i0 >= x.length - 1) { out[i] = x[x.length - 1]; continue; }
+    const frac = src - i0;
+    out[i] = x[i0] * (1 - frac) + x[i0 + 1] * frac;
+  }
+  return out;
+}

--- a/js/test/audio.test.mjs
+++ b/js/test/audio.test.mjs
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { decodeWav, mixdownMono, resampleLinear } from "../index.js";
+import { installAudioHost } from "../node.js";
+
+// Build a minimal 16-bit PCM WAV in JS (mirror of Swift WAV.encode) so the test
+// needs no fixture file.
+function encodeWav(samples, sampleRate, channels = 1) {
+  const dataSize = samples.length * 2;
+  const buf = new ArrayBuffer(44 + dataSize);
+  const dv = new DataView(buf);
+  const tag = (o, s) => { for (let i = 0; i < s.length; i++) dv.setUint8(o + i, s.charCodeAt(i)); };
+  tag(0, "RIFF"); dv.setUint32(4, 36 + dataSize, true); tag(8, "WAVE");
+  tag(12, "fmt "); dv.setUint32(16, 16, true); dv.setUint16(20, 1, true);
+  dv.setUint16(22, channels, true); dv.setUint32(24, sampleRate, true);
+  dv.setUint32(28, sampleRate * channels * 2, true); dv.setUint16(32, channels * 2, true);
+  dv.setUint16(34, 16, true); tag(36, "data"); dv.setUint32(40, dataSize, true);
+  for (let i = 0; i < samples.length; i++) {
+    const v = Math.max(-1, Math.min(1, samples[i]));
+    dv.setInt16(44 + i * 2, Math.round(v * 32767), true);
+  }
+  return new Uint8Array(buf);
+}
+
+const tone = (n, freq = 440, sr = 16000) =>
+  Float32Array.from({ length: n }, (_, i) => 0.5 * Math.sin((2 * Math.PI * freq * i) / sr));
+
+test("decodeWav round-trips 16-bit PCM within quantization error", () => {
+  const x = tone(2000);
+  const { samples, sampleRate, channels } = decodeWav(encodeWav(x, 16000, 1));
+  assert.equal(sampleRate, 16000);
+  assert.equal(channels, 1);
+  assert.equal(samples.length, x.length);
+  let maxErr = 0;
+  for (let i = 0; i < x.length; i++) maxErr = Math.max(maxErr, Math.abs(x[i] - samples[i]));
+  assert.ok(maxErr < 1e-3, `maxErr ${maxErr}`);
+});
+
+test("stereo mixdown averages channels", () => {
+  const interleaved = Float32Array.from({ length: 200 }, (_, i) => (i % 2 === 0 ? 0.5 : -0.5));
+  const mono = mixdownMono(interleaved, 2);
+  assert.equal(mono.length, 100);
+  assert.ok(mono.every((v) => Math.abs(v) < 1e-6));
+});
+
+test("resampleLinear roughly doubles length from 8k to 16k", () => {
+  const y = resampleLinear(tone(800, 440, 8000), 8000, 16000);
+  assert.ok(Math.abs(y.length - 1600) <= 4, `len ${y.length}`);
+});
+
+test("installAudioHost decodes bytes to mono at the target rate (node)", async () => {
+  const host = installAudioHost();
+  const wav = encodeWav(tone(1600, 440, 8000), 8000, 1);
+  const mono = await host.decode(null, wav, 16000);
+  assert.ok(mono instanceof Float32Array);
+  assert.ok(Math.abs(mono.length - 3200) <= 8, `len ${mono.length}`); // 1600 @ 8k -> ~3200 @ 16k
+});

--- a/js/test/entries.test.mjs
+++ b/js/test/entries.test.mjs
@@ -13,6 +13,10 @@ test("browser-safe entry exports the expected surface", async () => {
     "browserWasmDir",
     "browserReadModelSource",
     "browserCacheRoot",
+    "installAudioHost",
+    "decodeWav",
+    "mixdownMono",
+    "resampleLinear",
   ]) {
     assert.equal(typeof core[name], "function", `exports ${name}`);
   }
@@ -20,7 +24,7 @@ test("browser-safe entry exports the expected surface", async () => {
 
 test("node entry exports the native loader + node seam", async () => {
   const node = await import("../node.js");
-  for (const name of ["loadNative", "nodeSetup", "nodeWasmDir", "nodeReadModelSource", "nodeCacheRoot", "FfiReader"]) {
+  for (const name of ["loadNative", "nodeSetup", "nodeWasmDir", "nodeReadModelSource", "nodeCacheRoot", "FfiReader", "installAudioHost"]) {
     assert.equal(typeof node[name], "function", `exports ${name}`);
   }
 });

--- a/kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt
+++ b/kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt
@@ -1,9 +1,13 @@
 package ai.desertant.core
 
 import android.content.SharedPreferences
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
 import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
 import java.io.File
+import java.nio.ByteOrder
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.ByteBuffer
@@ -165,6 +169,143 @@ object HostBridge {
      * Implemented natively (desert-ant-core Inference); requires the SDK's .so loaded.
      */
     @JvmStatic external fun flushUsage()
+
+    /**
+     * Decode an audio file (any container/codec MediaCodec supports) to mono
+     * `Float` PCM at [sampleRate], the counterpart of Swift AudioIO's decode on
+     * Android. Pass the file path as [pathUtf8], or the file bytes as [data]
+     * (staged to a temp file, since MediaExtractor reads a path/fd). Returns the
+     * length-prefixed FFI buffer AudioIO expects: big-endian u32 body length,
+     * then u32 sample rate, then a float32 array (u32 count, then big-endian
+     * floats). Empty result on failure ("leave it to the caller").
+     */
+    @JvmStatic
+    fun audioDecode(pathUtf8: ByteArray?, data: ByteArray?, sampleRate: Double): ByteArray {
+        var temp: File? = null
+        return try {
+            val path = when {
+                pathUtf8 != null -> pathUtf8.toString(Charsets.UTF_8)
+                data != null -> {
+                    val f = File.createTempFile("dal-audio", ".bin")
+                    f.writeBytes(data)
+                    temp = f
+                    f.absolutePath
+                }
+                else -> return ByteArray(0)
+            }
+            val (pcm, srcRate, channels) = decodePcmMono16(path)
+            val mono = if (channels > 1) mixdownMono(pcm, channels) else pcm
+            val resampled = resampleLinear(mono, srcRate.toDouble(), sampleRate)
+            encodeAudioBuffer(sampleRate.toInt(), resampled)
+        } catch (e: Exception) {
+            ByteArray(0)
+        } finally {
+            temp?.delete()
+        }
+    }
+
+    // Decode via MediaExtractor + MediaCodec to interleaved 16-bit PCM ->
+    // Float in [-1, 1]. Synchronous (dequeue) loop; the model SDKs decode whole
+    // files, not streams.
+    private fun decodePcmMono16(path: String): Triple<FloatArray, Int, Int> {
+        val extractor = MediaExtractor()
+        extractor.setDataSource(path)
+        var track = -1
+        var format: MediaFormat? = null
+        for (i in 0 until extractor.trackCount) {
+            val f = extractor.getTrackFormat(i)
+            if (f.getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true) {
+                track = i; format = f; break
+            }
+        }
+        if (track < 0 || format == null) { extractor.release(); throw IllegalStateException("no audio track") }
+        extractor.selectTrack(track)
+        val srcRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        val channels = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+        val mime = format.getString(MediaFormat.KEY_MIME)!!
+
+        val codec = MediaCodec.createDecoderByType(mime)
+        codec.configure(format, null, null, 0)
+        codec.start()
+        val info = MediaCodec.BufferInfo()
+        val out = ArrayList<Float>()
+        var sawInputEnd = false
+        var sawOutputEnd = false
+        while (!sawOutputEnd) {
+            if (!sawInputEnd) {
+                val inIndex = codec.dequeueInputBuffer(10_000)
+                if (inIndex >= 0) {
+                    val buf = codec.getInputBuffer(inIndex)!!
+                    val size = extractor.readSampleData(buf, 0)
+                    if (size < 0) {
+                        codec.queueInputBuffer(inIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                        sawInputEnd = true
+                    } else {
+                        codec.queueInputBuffer(inIndex, 0, size, extractor.sampleTime, 0)
+                        extractor.advance()
+                    }
+                }
+            }
+            val outIndex = codec.dequeueOutputBuffer(info, 10_000)
+            if (outIndex >= 0) {
+                if (info.size > 0) {
+                    val buf = codec.getOutputBuffer(outIndex)!!
+                    buf.position(info.offset)
+                    buf.limit(info.offset + info.size)
+                    val shorts = buf.order(ByteOrder.LITTLE_ENDIAN).asShortBuffer()
+                    while (shorts.hasRemaining()) out.add(shorts.get() / 32768f)
+                }
+                codec.releaseOutputBuffer(outIndex, false)
+                if (info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) sawOutputEnd = true
+            }
+        }
+        codec.stop(); codec.release(); extractor.release()
+        return Triple(out.toFloatArray(), srcRate, channels)
+    }
+
+    private fun mixdownMono(interleaved: FloatArray, channels: Int): FloatArray {
+        val frames = interleaved.size / channels
+        val out = FloatArray(frames)
+        val inv = 1f / channels
+        for (f in 0 until frames) {
+            var acc = 0f
+            val base = f * channels
+            for (c in 0 until channels) acc += interleaved[base + c]
+            out[f] = acc * inv
+        }
+        return out
+    }
+
+    private fun resampleLinear(x: FloatArray, from: Double, to: Double): FloatArray {
+        if (from <= 0 || to <= 0 || from == to || x.size < 2) return x
+        val outCount = Math.round(x.size * (to / from)).toInt()
+        if (outCount <= 0) return FloatArray(0)
+        val out = FloatArray(outCount)
+        val step = from / to
+        for (i in 0 until outCount) {
+            val src = i * step
+            val i0 = src.toInt()
+            if (i0 >= x.size - 1) { out[i] = x[x.size - 1]; continue }
+            val frac = (src - i0).toFloat()
+            out[i] = x[i0] * (1 - frac) + x[i0 + 1] * frac
+        }
+        return out
+    }
+
+    // FFI buffer: big-endian u32 body length, then u32 sample rate, then an
+    // f32 array (u32 count + big-endian floats), matching Swift's FFIReader.
+    private fun encodeAudioBuffer(sampleRate: Int, samples: FloatArray): ByteArray {
+        val body = ByteArrayOutputStream()
+        DataOutputStream(body).use { d ->
+            d.writeInt(sampleRate)
+            d.writeInt(samples.size)
+            for (v in samples) d.writeFloat(v)
+        }
+        val tree = body.toByteArray()
+        val out = ByteArrayOutputStream()
+        DataOutputStream(out).use { it.writeInt(tree.size); it.write(tree) }
+        return out.toByteArray()
+    }
 
     @JvmStatic
     fun jsonParseTree(jsonUtf8: ByteArray): ByteArray {


### PR DESCRIPTION
## What

Adds the shared audio primitives `clear` (speech enhancement) and `uhm` (filler detection) need to move onto the unified Swift SDK, so audio model SDKs ship **no per-platform audio code** (the same way `Regex`/`JSON`/`TextNormalization` abstract those host facilities today). Both SDKs currently carry duplicated, Apple-only AVFoundation + Accelerate code; this pulls it into core once, with real backends for every platform.

## New modules

**`AudioIO`** - decode any audio to mono `Float` at a target sample rate, and encode 16-bit PCM WAV. One `async` decode API, per-platform backend:

| Platform | Backend |
|---|---|
| Apple | AVFoundation (`AVAudioFile` + `AVAudioConverter`) |
| Linux / other | new pure-Swift WAV codec |
| Android | host `MediaCodec` via `CHostBridge` `host_audio_decode` |
| wasm | `AudioContext.decodeAudioData` via the `__DalAudioHost` JS global |

Includes mono mixdown and a linear resampler for the portable/host paths. Encoding a WAV is pure Swift, identical everywhere.

```swift
let samples = try await AudioIO.decode(path: file, sampleRate: 16_000)
let wav = AudioIO.encodeWAV(samples, sampleRate: 16_000)
```

**`AudioDSP`** - the shared spectral/vector toolbox a speech model runs on both sides of inference. Pure Swift, Accelerate-backed on Apple (STFT/mel run as BLAS matmuls on the vector units):

- `STFT` forward/inverse as real-DFT matmuls (so `nFFT` need not be a power of two) with windowed COLA reconstruction, matching training-time `torch.stft` (Hann, center, reflect pad)
- `Window.hann`, `Padding.reflect`
- `MelSpectrogram.logMel` front-end (HTK mel)
- `VectorOps.energyNormalize` / `standardize` (invertible RMS normalize, per-window standardization)
- `Framing.windows` + `OverlapAccumulator` for the sliding-window inference loop both SDKs repeat (average or COLA-normalize overlapping outputs)

## Supporting additions

- **`FFIBuffer`**: `f32` / `f32Array` writers plus a new **`FFIReader`** (the mirror of `FFIWriter`), so the Swift side parses a host-produced float buffer without a hand-rolled cursor.
- **`CHostBridge`**: `host_audio_decode` callback + setter, matching the existing regex/JSON/normalize host hooks.

## Testing

- **Linux**: full suite (50 tests) passes; AudioIO exercises the pure-Swift WAV path.
- **macOS arm64**: 17 audio/FFI tests pass; AudioIO exercises the AVFoundation decode path.
- **Android**: `AudioIO` + `AudioDSP` cross-compile cleanly (host-decode + FFIReader path type-checks).
- **wasm**: `JSAudioIO.swift` type-checks under the wasm SDK. (A full wasm link currently fails on JavaScriptKit's host `BridgeJSTool` needing `Dispatch` in this environment, which breaks the untouched `Inference` product identically, so it is not introduced by this change.)

New tests: `AudioDSPTests` (STFT/ISTFT reconstruction SNR, mag/phase rebuild, energy/standardize, mel shape, framing, overlap), `AudioIOTests` (WAV round-trip, portable + AVFoundation decode, resample, mixdown), `FFIBufferTests` (f32/array/length-prefixed round-trips).

## Follow-ups (not in this PR)

- Kotlin `HostBridge` `decodeAudio` implementation + the `__DalAudioHost` JS host shim live in the model SDK runtime layer; documented in the README.
- Migrating `clear`/`uhm` onto these modules (deletes their Apple-only `AudioIO`/`Enhancer` DSP).