### PR TITLE
Give wasm one model-agnostic ABI, like the dal_* C ABI

### DIFF
--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -24,3 +24,8 @@ jobs:
 
       - name: Test (WASI)
         run: mise run test-wasi
+
+      # The model wasm entry points are executables, so the test run above does
+      # not build them; compile them here so a broken one fails the PR.
+      - name: Build the model wasm entry points
+        run: mise run build-wasm-entries

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ import Foundation
 //   PlatformSupport environment + synchronous FFI/async bridge + HTTP client
 //   Usage        usage turnstile: builds/sends `load` events over the HTTP client
 //   FFIBuffer    length-prefixed typed C-ABI buffer (no hand-rolled JSON)
+//   WasmBindings model-agnostic wasm export surface (the `dal_*` ABI's twin)
 //   CHostBridge  generic host-callback bridge a runtime shim installs on Android
 //   HostBridge   Android JNI harness: byte marshalling + installs CHostBridge
 //                callbacks against a host class (pairs with kotlin/HostBridge.kt)
@@ -109,6 +110,8 @@ let products: [Product] = [
         .library(name: "HostBridge", targets: ["HostBridge"]),
         // Exposed so an Android runtime's JNI shim can install the callbacks.
         .library(name: "CHostBridge", targets: ["CHostBridge"]),
+        // The wasm entry-point ABI a model's Web target installs (empty off wasm).
+        .library(name: "WasmBindings", targets: ["WasmBindings"]),
         // Android on-device integration harness, cross-compiled to a JNI .so and
         // driven by the instrumented test in androidtest/ (empty off-Android).
         .library(name: "CoreAndroidTests", type: .dynamic, targets: ["CoreAndroidTests"]),
@@ -139,7 +142,7 @@ let modelProducts: [Product] = [
 let modelWasmTargets: [Target] = noJavaScriptKit ? [] : [
         .executableTarget(
             name: "EmoWeb",
-            dependencies: ["Emo"] + jsWasi + jsEventLoop,
+            dependencies: ["Emo", "WasmBindings"] + jsWasi + jsEventLoop,
             // The wasm hosts bridge JavaScriptKit's non-Sendable JS values across
             // the event-loop executor; this package's 5.9 tools version means
             // language mode 5, so those crossings stay warnings.
@@ -147,7 +150,7 @@ let modelWasmTargets: [Target] = noJavaScriptKit ? [] : [
         ),
         .executableTarget(
             name: "RedactWeb",
-            dependencies: ["Redact"] + jsWasi + jsEventLoop,
+            dependencies: ["Redact", "WasmBindings"] + jsWasi + jsEventLoop,
             path: "Sources/ModelCatalog/Redact/Web"
         ),
 ]
@@ -280,6 +283,14 @@ let libraryTargets: [Target] = [
                 "FFIBuffer",
                 .target(name: "CHostBridge", condition: .when(platforms: [.android])),
             ]
+        ),
+        // The wasm entry-point ABI: one export surface for every model, so a
+        // model's Web target is its declaration plus the self-hosted-files hook.
+        // Its body is `#if os(WASI)`, so it compiles to nothing (and pulls no
+        // JavaScriptKit) on every other platform.
+        .target(
+            name: "WasmBindings",
+            dependencies: ["DesertAnt"] + jsWasi + jsEventLoop
         ),
         .target(
             name: "CoreAndroidTests",

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ importable for consumers that want a narrower dependency:
 | `JSON` | `Codable` decode + encode | `Foundation.JSONDecoder`/`Encoder` | host JSON parser (via `CHostBridge`) + tree encoder | JS `JSON.parse` + tree encoder |
 | `TextNormalization` | `String.nfkc` | Foundation `precomposed...` | platform ICU `unorm2` (`libicu`) | JS `String.normalize` |
 | `FFIBuffer` | length-prefixed typed C-ABI buffer | same on every platform | | |
+| `WasmBindings` | model-agnostic wasm export surface | empty | empty | `globalThis.__DesertAntExports` |
 | `HostBridge` | Android JNI harness for model SDKs | empty | JNI marshalling + installs `CHostBridge` | empty |
 | `CHostBridge` | generic host-callback C bridge | - | installed by `HostBridge` | - |
 | `ModelStore` | verified Hub downloads and `StoredModel` access | URLSession + FileManager | host HTTP + POSIX | JS fetch + node fs / memory |
@@ -96,6 +97,40 @@ strings); the host reads it with its own standard library (see the matching
 `FfiReader` in `kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt`, a thin
 `java.nio.ByteBuffer` cursor) and
 frees it with `ffiFree`. The payload *schema* is the model's own concern.
+
+## WasmBindings (the wasm ABI)
+
+One export surface for every model, the WebAssembly twin of the `dal_*` C ABI in
+`Sources/Bindings`: options in and results out are `FFIBuffer` payloads the model
+encodes itself, so adding a model adds no export, no plumbing, and no JS glue.
+A model's wasm entry point installs it and says only how the JS host's
+self-hosted files become an instance:
+
+```swift
+// Sources/ModelCatalog/<Model>/Web/main.swift, in full
+installWasmExports([
+    WasmModel(EmoModel.self, binding: EmoBinding.self) { sidecars, session in
+        Emo(assets: ModelAssets(metaJSON: ..., tokenizer: ..., session: session))
+    },
+])
+```
+
+That installs, keyed by model id so two SDKs on one page cannot clobber each
+other:
+
+```js
+globalThis.__DesertAntExports.emo = {
+  create(cacheRoot?, directory?), createSelfHosted(files),   // -> handle
+  isDownloaded(handle), download(handle, onProgress?),
+  run(handle, text, options?, group?, deviceId?),            // -> Uint8Array
+  endCallGroup(id), destroy(handle), flushTelemetry(),
+}
+```
+
+The JS side resolves it with `wasmExports(modelId)` (or gets it back from
+`browserSetup`/`nodeSetup`), so a model package supplies only its payload codecs.
+`group` and `deviceId` behave exactly as on the C ABI, so usage attribution and
+call grouping work identically on every runtime.
 
 ## ModelStore and model resources
 

--- a/Sources/Bindings/CABI.swift
+++ b/Sources/Bindings/CABI.swift
@@ -70,7 +70,8 @@ public func dal_is_downloaded(_ handle: UnsafeMutableRawPointer?) -> Int32 {
 public func dal_download(_ handle: UnsafeMutableRawPointer?) -> Int32 {
     guard let model = model(handle) else { return -1 }
     let ok: Bool = blockingValue {
-        do { try await model.download(); return true } catch { return false }
+        // The C ABI has no progress channel; hosts poll or just await the call.
+        do { try await model.download(progress: { _ in }); return true } catch { return false }
     }
     return ok ? 0 : -1
 }

--- a/Sources/ModelBinding/ModelBinding.swift
+++ b/Sources/ModelBinding/ModelBinding.swift
@@ -21,8 +21,10 @@ public protocol BoundModel: AnyObject {
     /// Whether the model is usable with no network (cached, or files present).
     func isDownloaded() -> Bool
 
-    /// Fetch and verify the model ahead of time. Throws on failure.
-    func download() async throws
+    /// Fetch and verify the model ahead of time, reporting the download
+    /// fraction in `0...1`. Throws on failure. Hosts that cannot report progress
+    /// (the C ABI) pass a closure that ignores it.
+    func download(progress: @Sendable @escaping (Double) -> Void) async throws
 
     /// Run the model. `options` is the model's own payload, written by the host
     /// with the same field order the model reads here; an empty reader means

--- a/Sources/ModelCatalog/Emo/Binding.swift
+++ b/Sources/ModelCatalog/Emo/Binding.swift
@@ -6,11 +6,6 @@
 import DesertAnt
 
 extension Emo: BoundModel {
-    /// `download(progress:)`'s defaulted argument does not witness the
-    /// no-argument requirement, so forward explicitly. The host reports progress
-    /// through its own channel, not this call.
-    public func download() async throws { try await download(progress: { _ in }) }
-
     /// Options payload: `u32 limit`, `u32 skinTone` (0 default, 1 light,
     /// 2 mediumLight, 3 medium, 4 mediumDark, 5 dark). An empty payload means
     /// the SDK defaults.

--- a/Sources/ModelCatalog/Emo/ModelLoading.swift
+++ b/Sources/ModelCatalog/Emo/ModelLoading.swift
@@ -41,7 +41,7 @@ public struct ModelAssets: Sendable {
         ModelAssets(
             metaJSON: try files.readString(EmoModel.meta),
             tokenizer: try files.read(EmoModel.tokenizer),
-            session: try await files.inferenceSession(model: EmoModel.artifact, hostGlobal: "__EmoHost", sdk: EmoModel.sdkInfo))
+            session: try await files.inferenceSession(model: EmoModel.artifact, hostGlobal: EmoModel.hostGlobal, sdk: EmoModel.sdkInfo))
     }
 }
 

--- a/Sources/ModelCatalog/Emo/Web/main.swift
+++ b/Sources/ModelCatalog/Emo/Web/main.swift
@@ -1,159 +1,29 @@
 #if os(WASI)
 import DesertAnt
-import JavaScriptEventLoop
-import JavaScriptKit
+import WasmBindings
 @_spi(EmoBindings) import Emo
 
-// WebAssembly entry point. Mirrors the iOS/Swift SDK (suggestion only). The JS
-// host must set `globalThis.__EmoHost` (an async LiteRT.js session + runner, see
-// desert-ant-core's JSInferenceSession) before the first suggestion. After
-// start, the module exposes:
+// Emo's WebAssembly entry point.
 //
-//     globalThis.__EmoExports = {
-//       load(cacheRoot, directory?, onProgress?)          -> Promise<boolean>,
-//       loadSelfHosted(metaJSON, tokenizerBytes)         -> Promise<boolean>,
-//       suggest(text, limit?, skinTone?, deviceId?)       -> Promise<[{emoji, confidence}]>,
-//     }
+// The exported surface is the shared, model-agnostic ABI in `WasmBindings`
+// (`globalThis.__DesertAntExports.emo`), the wasm twin of the `dal_*` C ABI:
+// options and results cross as the FFI payloads `Emo/Binding.swift` already
+// encodes, so nothing model-specific is repeated here. The one exception is the
+// `modelBaseUrl` path, where the JS host fetched the files and compiled the
+// model itself: only Emo knows that its sidecars are the meta JSON and the
+// tokenizer.
 //
-// `deviceId` may be a string or a zero-arg function returning one; it is
-// collected per call and bound to that call's task tree (safe for concurrent
-// multi-tenant hosts), attributing usage to a specific end-user device.
-//
-// `skinTone` is a number: 0 default, 1 light, 2 mediumLight, 3 medium,
-// 4 mediumDark, 5 dark. `packages/emo-node` wraps this in the public typed API;
-// nothing else should touch these globals.
-JavaScriptEventLoop.installGlobalExecutor()
-
-private nonisolated(unsafe) var suggester: Emo?
-private func instance() throws -> Emo {
-    guard let suggester else { throw EmoError.modelNotFound }
-    return suggester
-}
-
-private func skinTone(_ raw: Double?) -> EmojiSkinTone {
-    switch Int(raw ?? 0) {
-    case 1: return .light
-    case 2: return .mediumLight
-    case 3: return .medium
-    case 4: return .mediumDark
-    case 5: return .dark
-    default: return .default
-    }
-}
-
-private func encode(_ suggestions: [EmoSuggestion]) -> JSValue {
-    let arr = JSObject.global.Array.function!.new()
-    for (i, s) in suggestions.enumerated() {
-        let o = JSObject.global.Object.function!.new()
-        o.emoji = .string(s.emoji)
-        o.confidence = .number(s.confidence)
-        arr[i] = .object(o)
-    }
-    return .object(arr)
-}
-
-private func collectDeviceId(_ value: JSValue?) -> String? {
-    guard let value else { return nil }
-    if let string = value.string, !string.isEmpty { return string }
-    if let getter = value.function, let string = getter().string, !string.isEmpty { return string }
-    return nil
-}
-
-let suggestFn = JSClosure { args in
-    let text = args.first?.string ?? ""
-    let limit = args.count > 1 ? Int(args[1].number ?? 3) : 3
-    let tone = skinTone(args.count > 2 ? args[2].number : nil)
-    // Collect the per-call device id now (before any await), then bind it to
-    // this call's task tree so concurrent calls stay isolated.
-    let deviceId = collectDeviceId(args.count > 3 ? args[3] : nil)
-    return JSPromise { resolve in
-        Task {
-            do {
-                let suggestions = try await InferenceContext.$deviceId.withValue(deviceId) {
-                    try await instance().suggestions(for: text, limit: limit, skinTone: tone)
-                }
-                resolve(.success(encode(suggestions)))
-            } catch {
-                resolve(.failure(.string(String(describing: error))))
-            }
+// `packages/emo-node` wraps this in the public typed API; nothing else should
+// touch these globals.
+installWasmExports([
+    WasmModel(EmoModel.self, binding: EmoBinding.self) { sidecars, session in
+        guard let meta = sidecars[EmoModel.meta], let tokenizer = sidecars[EmoModel.tokenizer] else {
+            throw EmoError.modelNotFound
         }
-    }.jsValue
-}
-
-// load(cacheRoot, directory, onProgress?): the repo and revision are pinned to
-// the SDK. `cacheRoot` is the base for the managed nested cache (node `~/.cache`;
-// empty in the browser). `directory`, when non-empty, is an explicit model
-// directory (adopt files there, else download into it). `onProgress`, when a
-// function, is called with the download fraction in [0, 1].
-let loadFn = JSClosure { args in
-    let cacheRoot = args.first?.string.flatMap { $0.isEmpty ? nil : $0 }
-    let directory = (args.count > 1 ? args[1].string : nil).flatMap { $0.isEmpty ? nil : $0 }
-    let onProgress: JSFunction? = args.count > 2 ? args[2].function : nil
-    let emo = Emo(directory: directory, cacheRoot: cacheRoot)
-    return JSPromise { resolve in
-        Task {
-            do {
-                try await emo.download { fraction in
-                    if let onProgress { _ = onProgress(fraction) }
-                }
-                suggester = emo
-                resolve(.success(.boolean(true)))
-            } catch {
-                resolve(.failure(.string(String(describing: error))))
-            }
-        }
-    }.jsValue
-}
-
-// loadSelfHosted(metaJSON, tokenizerBytes): wire model files the app serves
-// itself (the JS host's `modelBaseUrl` option, the browser's equivalent of
-// pointing a native SDK at a directory that already holds the model, so nothing
-// is downloaded). The host has already compiled the model into
-// its LiteRT.js session (createSession/loadAndCompile), so only the metadata
-// and tokenizer sidecars cross into wasm here; the multi-MB model bytes never
-// do (they stay on the JS side).
-private func typedArrayBytes(_ value: JSValue?) -> [UInt8]? {
-    guard let value, let array = JSTypedArray<UInt8>(from: value) else { return nil }
-    return array.withUnsafeBytes { Array($0) }
-}
-
-let loadSelfHostedFn = JSClosure { args in
-    let metaJSON = args.first?.string
-    let tokenizer = typedArrayBytes(args.count > 1 ? args[1] : nil)
-    return JSPromise { resolve in
-        Task {
-            do {
-                guard let metaJSON, let tokenizer else { throw EmoError.modelNotFound }
-                let assets = try ModelAssets(
-                    metaJSON: metaJSON, tokenizer: tokenizer,
-                    session: inferenceSession(hostGlobal: "__EmoHost"))
-                let emo = Emo(assets: assets)
-                try await emo.waitUntilLoaded()
-                suggester = emo
-                resolve(.success(.boolean(true)))
-            } catch {
-                resolve(.failure(.string(String(describing: error))))
-            }
-        }
-    }.jsValue
-}
-
-// flushTelemetry(): force any tracked session to emit now (bypassing the 3s
-// debounce + re-emit window) and await the send, so the usage POST actually
-// goes out before the caller continues. Requires `globalThis.__dalHttpDebug`.
-let flushTelemetryFn = JSClosure { _ in
-    JSPromise { resolve in
-        Task {
-            await TelemetryDebug.shared.flushAndWait()
-            resolve(.success(.boolean(true)))
-        }
-    }.jsValue
-}
-
-let exports = JSObject.global.Object.function!.new()
-exports.load = .object(loadFn)
-exports.loadSelfHosted = .object(loadSelfHostedFn)
-exports.suggest = .object(suggestFn)
-exports.flushTelemetry = .object(flushTelemetryFn)
-JSObject.global.__EmoExports = .object(exports)
+        return Emo(assets: ModelAssets(
+            metaJSON: String(decoding: meta, as: UTF8.self),
+            tokenizer: tokenizer,
+            session: session))
+    },
+])
 #endif

--- a/Sources/ModelCatalog/ModelDeclaration.swift
+++ b/Sources/ModelCatalog/ModelDeclaration.swift
@@ -48,6 +48,11 @@ public extension ModelDeclaration {
     /// bills its inference to the default identity) or let the version go stale.
     static var sdkInfo: SDKInfo { SDKInfo(name: product, version: sdkVersion) }
 
+    /// The JavaScript global the wasm build drives its inference session
+    /// through (`__EmoHost`, `__RedactHost`, …). Derived, so the Swift side and
+    /// the JS package cannot disagree about the name.
+    static var hostGlobal: String { "__\(product)Host" }
+
     /// This model's Hub declaration: repo, pinned revision, per-platform files.
     /// The single value an SDK needs to download, adopt, or verify its model.
     static var distribution: ModelDistribution {

--- a/Sources/ModelCatalog/Redact/Binding.swift
+++ b/Sources/ModelCatalog/Redact/Binding.swift
@@ -6,11 +6,6 @@
 import DesertAnt
 
 extension Redact: BoundModel {
-    /// `download(progress:)`'s defaulted argument does not witness the
-    /// no-argument requirement, so forward explicitly. The host reports progress
-    /// through its own channel, not this call.
-    public func download() async throws { try await download(progress: { _ in }) }
-
     /// Options payload: `f64 minimumConfidence`, then `u32 labelCount` and that
     /// many length-prefixed label names (an empty list means every label). An
     /// empty payload means the SDK defaults.

--- a/Sources/ModelCatalog/Redact/ModelLoading.swift
+++ b/Sources/ModelCatalog/Redact/ModelLoading.swift
@@ -39,7 +39,7 @@ public struct ModelAssets: Sendable {
             tokenizer: try files.read(RedactModel.tokenizer),
             labelsJSON: try files.readString(RedactModel.labels),
             session: try await files.inferenceSession(
-                model: RedactModel.artifact, hostGlobal: "__RedactHost", sdk: RedactModel.sdkInfo))
+                model: RedactModel.artifact, hostGlobal: RedactModel.hostGlobal, sdk: RedactModel.sdkInfo))
     }
 }
 

--- a/Sources/ModelCatalog/Redact/Web/main.swift
+++ b/Sources/ModelCatalog/Redact/Web/main.swift
@@ -1,129 +1,30 @@
 #if os(WASI)
 import DesertAnt
-import JavaScriptEventLoop
-import JavaScriptKit
+import WasmBindings
 @_spi(RedactBindings) import Redact
 
-// WebAssembly entry point. Mirrors the iOS/Swift SDK (redaction only). The JS
-// host must set `globalThis.__RedactHost` (an async LiteRT.js session + runner, see
-// `ModelLoading.swift`) before the first redaction. After start, the module
-// exposes:
+// Redact's WebAssembly entry point.
 //
-//     globalThis.__RedactExports = {
-//       load(cacheRoot, directory?, onProgress?)    -> Promise<boolean>,
-//       loadSelfHosted(labelsJSON, tokenizerBytes)  -> Promise<boolean>,
-//       redaction(text, minimumConfidence, labels?) -> Promise<{redactedText, items}>,
-//     }
+// The exported surface is the shared, model-agnostic ABI in `WasmBindings`
+// (`globalThis.__DesertAntExports.redact`), the wasm twin of the `dal_*` C ABI:
+// options and results cross as the FFI payloads `Redact/Binding.swift` already
+// encodes, so nothing model-specific is repeated here. The one exception is the
+// `modelBaseUrl` path, where the JS host fetched the files and compiled the
+// model itself: only Redact knows that its sidecars are the tokenizer and the
+// label map.
 //
-// `packages/redact-node` wraps this in the public typed API; nothing else
-// should touch these globals.
-JavaScriptEventLoop.installGlobalExecutor()
-
-private nonisolated(unsafe) var redactor: Redact?
-private func instance() throws -> Redact {
-    guard let redactor else { throw RedactError.resourceMissing }
-    return redactor
-}
-
-private func parseOptions(_ args: [JSValue]) -> Options {
-    let minimum = args.count > 1 ? (args[1].number ?? 0.6) : 0.6
-    var labels: Set<Label>?
-    if args.count > 2, let arr = args[2].object, let n = arr.length.number {
-        labels = Set((0..<Int(n)).compactMap { arr[$0].string.flatMap(Label.init(rawValue:)) })
-    }
-    return Options(minimumConfidence: minimum, labels: labels)
-}
-
-let redactionFn = JSClosure { args in
-    let text = args.first?.string ?? ""
-    let options = parseOptions(args)
-    return JSPromise { resolve in
-        Task {
-            do {
-                let r = try await instance().redaction(of: text, options: options)
-                let items = JSObject.global.Array.function!.new()
-                for (i, item) in r.items.enumerated() {
-                    let o = JSObject.global.Object.function!.new()
-                    o.label = .string(item.label.rawValue)
-                    o.original = .string(item.original)
-                    o.placeholder = .string(item.placeholder)
-                    o.confidence = .number(item.confidence)
-                    o.start = .number(Double(item.range.lowerBound.utf16Offset(in: text)))
-                    o.end = .number(Double(item.range.upperBound.utf16Offset(in: text)))
-                    items[i] = .object(o)
-                }
-                let out = JSObject.global.Object.function!.new()
-                out.redactedText = .string(r.redactedText)
-                out.items = .object(items)
-                resolve(.success(.object(out)))
-            } catch {
-                resolve(.failure(.string(String(describing: error))))
-            }
+// `packages/redact-node` wraps this in the public typed API; nothing else should
+// touch these globals.
+installWasmExports([
+    WasmModel(RedactModel.self, binding: RedactBinding.self) { sidecars, session in
+        guard let tokenizer = sidecars[RedactModel.tokenizer],
+              let labels = sidecars[RedactModel.labels] else {
+            throw RedactError.resourceMissing
         }
-    }.jsValue
-}
-
-// load(cacheRoot, directory, onProgress?): the repo and revision are pinned to
-// the SDK. `cacheRoot` is the base for the managed nested cache (node `~/.cache`;
-// empty in the browser). `directory`, when non-empty, is an explicit model
-// directory (adopt files there, else download into it). `onProgress`, when a
-// function, is called with the download fraction in [0, 1].
-let loadFn = JSClosure { args in
-    let cacheRoot = args.first?.string.flatMap { $0.isEmpty ? nil : $0 }
-    let directory = (args.count > 1 ? args[1].string : nil).flatMap { $0.isEmpty ? nil : $0 }
-    let onProgress: JSFunction? = args.count > 2 ? args[2].function : nil
-    let redact = Redact(directory: directory, cacheRoot: cacheRoot)
-    return JSPromise { resolve in
-        Task {
-            do {
-                try await redact.download { fraction in
-                    if let onProgress { _ = onProgress(fraction) }
-                }
-                redactor = redact
-                resolve(.success(.boolean(true)))
-            } catch {
-                resolve(.failure(.string(String(describing: error))))
-            }
-        }
-    }.jsValue
-}
-
-// loadSelfHosted(labelsJSON, tokenizerBytes): wire model files the app serves
-// itself (the JS host's `modelBaseUrl` option, the browser's equivalent of
-// pointing a native SDK at a directory that already holds the model, so nothing
-// is downloaded). The host has already compiled the model into
-// its LiteRT.js session (createSession/loadAndCompile), so only the labels and
-// tokenizer sidecars cross into wasm here; the multi-MB model bytes never do
-// (they stay on the JS side).
-private func typedArrayBytes(_ value: JSValue?) -> [UInt8]? {
-    guard let value, let array = JSTypedArray<UInt8>(from: value) else { return nil }
-    return array.withUnsafeBytes { Array($0) }
-}
-
-let loadSelfHostedFn = JSClosure { args in
-    let labelsJSON = args.first?.string
-    let tokenizer = typedArrayBytes(args.count > 1 ? args[1] : nil)
-    return JSPromise { resolve in
-        Task {
-            do {
-                guard let labelsJSON, let tokenizer else { throw RedactError.resourceMissing }
-                let assets = try ModelAssets(
-                    tokenizer: tokenizer, labelsJSON: labelsJSON,
-                    session: JSInferenceSession(hostGlobal: "__RedactHost"))
-                let redact = Redact(assets: assets)
-                try await redact.waitUntilLoaded()
-                redactor = redact
-                resolve(.success(.boolean(true)))
-            } catch {
-                resolve(.failure(.string(String(describing: error))))
-            }
-        }
-    }.jsValue
-}
-
-let exports = JSObject.global.Object.function!.new()
-exports.load = .object(loadFn)
-exports.loadSelfHosted = .object(loadSelfHostedFn)
-exports.redaction = .object(redactionFn)
-JSObject.global.__RedactExports = .object(exports)
+        return Redact(assets: ModelAssets(
+            tokenizer: tokenizer,
+            labelsJSON: String(decoding: labels, as: UTF8.self),
+            session: session))
+    },
+])
 #endif

--- a/Sources/WasmBindings/WasmABI.swift
+++ b/Sources/WasmBindings/WasmABI.swift
@@ -1,0 +1,265 @@
+// The WebAssembly half of the cross-language bindings: one model-agnostic
+// export surface, the wasm twin of the `dal_*` C ABI in Sources/Bindings.
+//
+// A model's wasm entry point used to hand-write its own globals (`load`,
+// `loadSelfHosted`, a per-model `suggest`/`redaction`, the promise plumbing, the
+// device-id collector, the exports object) - about 130 lines that differed only
+// in names. The C ABI solved that problem once already: options in and results
+// out cross as `FFIBuffer` payloads the model itself encodes, so one surface
+// serves every model and the host picks the model by id. This file applies the
+// same shape to wasm, so a model's `Web/main.swift` is just its declaration plus
+// how the JS host's self-hosted files become an instance.
+//
+// After `installWasmExports`, the module exposes one entry per installed model:
+//
+//     globalThis.__DesertAntExports.<modelId> = {
+//       create(cacheRoot?, directory?)                 -> handle,
+//       createSelfHosted({ name: string | Uint8Array }) -> handle,
+//       isDownloaded(handle)                           -> boolean,
+//       download(handle, onProgress?)                  -> Promise<boolean>,
+//       run(handle, text, options?, group?, deviceId?) -> Promise<Uint8Array>,
+//       endCallGroup(id),
+//       destroy(handle),
+//       flushTelemetry()                               -> Promise<boolean>,
+//     }
+//
+// Keyed by model id rather than a single flat object, so two SDK packages loaded
+// on the same page each register their own entry instead of racing to overwrite
+// one global. `options` and the resolved `Uint8Array` are the model's own FFI
+// payloads (see its `Binding.swift`), which is what lets this file name no
+// model. `deviceId` may be a string or a zero-arg function returning one; it is
+// collected before the first `await` and bound to that call's task tree, so
+// concurrent calls on a multi-tenant host stay isolated. `group` bills several
+// runs as one usage call (release it with `endCallGroup`), matching `dal_run`.
+#if os(WASI)
+import DesertAnt
+import JavaScriptEventLoop
+import JavaScriptKit
+
+/// One model a wasm module exposes: the binding that constructs it, plus the
+/// only genuinely model-specific piece of the wasm path - how files the JS host
+/// fetched itself (the `modelBaseUrl` option, the browser's equivalent of
+/// pointing a native SDK at a directory that already holds the model) become an
+/// instance. Everything else is derived from the model's declaration.
+public struct WasmModel {
+    let id: String
+    let hostGlobal: String
+    let sdk: SDKInfo
+    let binding: any ModelBinding.Type
+    let selfHosted: ([String: [UInt8]], any InferenceSession) throws -> any BoundModel
+
+    /// - Parameters:
+    ///   - declaration: the model's catalog entry; supplies the id, the JS host
+    ///     global, and the usage identity every session is tracked under.
+    ///   - binding: the model's `ModelBinding`, as used by the C ABI.
+    ///   - selfHosted: build the model from the sidecar files the host fetched
+    ///     (keyed by their catalog file names) and a session backed by the host's
+    ///     already-compiled model.
+    public init<Declaration: ModelDeclaration>(
+        _ declaration: Declaration.Type,
+        binding: any ModelBinding.Type,
+        selfHosted: @escaping ([String: [UInt8]], any InferenceSession) throws -> any BoundModel
+    ) {
+        self.id = Declaration.id
+        self.hostGlobal = Declaration.hostGlobal
+        self.sdk = Declaration.sdkInfo
+        self.binding = binding
+        self.selfHosted = selfHosted
+    }
+}
+
+/// Errors this ABI reports to JS as a rejected promise.
+enum WasmABIError: Error, CustomStringConvertible {
+    case unknownHandle(Int)
+    case runFailed
+    case selfHostedFailed
+
+    var description: String {
+        switch self {
+        case let .unknownHandle(h): "unknown model handle \(h)"
+        case .runFailed: "the model failed to run"
+        case .selfHostedFailed: "could not build the model from the supplied files"
+        }
+    }
+}
+
+// Loaded instances behind the opaque numeric handles JS holds, the wasm
+// counterpart of the C ABI's retained pointers. wasm is single-threaded, so
+// plain globals need no lock. The closures are retained here too: they outlive
+// `installWasmExports`, and their lifetime is the module's.
+private nonisolated(unsafe) var models: [Int: any BoundModel] = [:]
+private nonisolated(unsafe) var nextHandle = 1
+private nonisolated(unsafe) var retained: [JSClosure] = []
+
+private func store(_ model: any BoundModel) -> Int {
+    let handle = nextHandle
+    nextHandle += 1
+    models[handle] = model
+    return handle
+}
+
+/// The instance behind a handle JS passed back.
+private func loaded(_ handle: Int) throws -> any BoundModel {
+    guard let model = models[handle] else { throw WasmABIError.unknownHandle(handle) }
+    return model
+}
+
+/// Install the shared ABI for `models` on `globalThis.__DesertAntExports`, and
+/// start the JS-backed global executor the async entry points run on. Call this
+/// once from a model's wasm entry point.
+public func installWasmExports(_ wasmModels: [WasmModel]) {
+    JavaScriptEventLoop.installGlobalExecutor()
+    let registry = JSObject.global.__DesertAntExports.object ?? JSObject.global.Object.function!.new()
+    for model in wasmModels { registry[model.id] = .object(exports(for: model)) }
+    JSObject.global.__DesertAntExports = .object(registry)
+}
+
+private func exports(for model: WasmModel) -> JSObject {
+    let exports = JSObject.global.Object.function!.new()
+
+    // create(cacheRoot?, directory?): lazy, like `dal_create` - no download and
+    // no model load until `download`/`run`. `cacheRoot` is the base for the
+    // managed nested cache (node `~/.cache`; empty in the browser) and
+    // `directory`, when non-empty, is an explicit model directory (adopt the
+    // files there, else download into it).
+    exports.create = closure { args in
+        .number(Double(store(model.binding.make(
+            cacheRoot: text(args, 0), directory: text(args, 1)))))
+    }
+
+    // createSelfHosted(files): the host fetched the sidecars and compiled the
+    // model into its own session already, so only the sidecars cross into wasm
+    // (the multi-MB artifact never does). 0 if the files are not what the model
+    // needs.
+    exports.createSelfHosted = closure { args in
+        do {
+            let session = try inferenceSession(hostGlobal: model.hostGlobal, sdk: model.sdk)
+            return .number(Double(store(try model.selfHosted(sidecars(args.first), session))))
+        } catch {
+            return .number(0)
+        }
+    }
+
+    exports.isDownloaded = closure { args in
+        .boolean((try? loaded(handle(args, 0)).isDownloaded()) ?? false)
+    }
+
+    // download(handle, onProgress?): fetch and verify ahead of time, then load,
+    // so the first `run` is instant and load errors surface here. A no-op once
+    // available. `onProgress`, when a function, gets the fraction in [0, 1].
+    exports.download = promise { args in
+        let onProgress: JSFunction? = args.count > 1 ? args[1].function : nil
+        try await loaded(handle(args, 0)).download { fraction in
+            if let onProgress { _ = onProgress(fraction) }
+        }
+        return .boolean(true)
+    }
+
+    // run(handle, text, options?, group?, deviceId?): the model decodes
+    // `options` and encodes the result, so this ABI stays model-agnostic.
+    exports.run = promise { args in
+        let input = args.count > 1 ? (args[1].string ?? "") : ""
+        let options = bytes(args.count > 2 ? args[2] : nil) ?? []
+        let group = text(args, 3)
+        let deviceId = collectDeviceId(args.count > 4 ? args[4] : nil)
+        let instance = try loaded(handle(args, 0))
+        let payload = await InferenceContext.$deviceId.withValue(deviceId) {
+            await InferenceContext.withCallGroup(id: group) {
+                await instance.run(text: input, options: FFIReader(options))
+            }
+        }
+        guard let payload else { throw WasmABIError.runFailed }
+        return JSTypedArray<UInt8>(payload).jsValue
+    }
+
+    /// Release a call group opened by passing `group` to `run`.
+    exports.endCallGroup = closure { args in
+        if let id = text(args, 0) { InferenceContext.endCallGroup(id) }
+        return .undefined
+    }
+
+    exports.destroy = closure { args in
+        models[handle(args, 0)] = nil
+        return .undefined
+    }
+
+    // flushTelemetry(): force any tracked session to emit now (bypassing the
+    // debounce + re-emit window) and await the send, so the usage POST goes out
+    // before the caller continues. Requires `globalThis.__dalHttpDebug`.
+    exports.flushTelemetry = promise { _ in
+        await TelemetryDebug.shared.flushAndWait()
+        return .boolean(true)
+    }
+
+    return exports
+}
+
+// MARK: JS plumbing
+
+/// A retained synchronous JS function.
+private func closure(_ body: @escaping ([JSValue]) -> JSValue) -> JSValue {
+    let fn = JSClosure { args in body(args) }
+    retained.append(fn)
+    return .object(fn)
+}
+
+/// A retained JS function returning a promise, with `throw` rejecting it. Every
+/// async entry point here is the same shape, so the error handling lives once.
+private func promise(_ body: @escaping ([JSValue]) async throws -> JSValue) -> JSValue {
+    closure { args in
+        JSPromise { resolve in
+            Task {
+                do {
+                    resolve(.success(try await body(args)))
+                } catch {
+                    resolve(.failure(.string(String(describing: error))))
+                }
+            }
+        }.jsValue
+    }
+}
+
+private func handle(_ args: [JSValue], _ index: Int) -> Int {
+    args.count > index ? Int(args[index].number ?? 0) : 0
+}
+
+/// An optional string argument. Empty strings mean "not supplied" so JS hosts
+/// can pass `""` where a value is absent (as the node/browser seams do).
+private func text(_ args: [JSValue], _ index: Int) -> String? {
+    guard args.count > index, let string = args[index].string, !string.isEmpty else { return nil }
+    return string
+}
+
+private func bytes(_ value: JSValue?) -> [UInt8]? {
+    guard let value, let array = JSTypedArray<UInt8>(from: value) else { return nil }
+    return array.withUnsafeBytes { Array($0) }
+}
+
+/// `{ "emo_meta.json": "<json>", "emo_tokenizer.bin": Uint8Array }` -> bytes per
+/// name, so a host can pass text sidecars as strings and binary ones as arrays.
+private func sidecars(_ value: JSValue?) -> [String: [UInt8]] {
+    guard let object = value?.object,
+          let keys = JSObject.global.Object.function?.keys?(object).object,
+          let count = keys.length.number else { return [:] }
+    var out: [String: [UInt8]] = [:]
+    for i in 0..<Int(count) {
+        guard let name = keys[i].string else { continue }
+        let value = object[name]
+        if let string = value.string {
+            out[name] = Array(string.utf8)
+        } else if let blob = bytes(value) {
+            out[name] = blob
+        }
+    }
+    return out
+}
+
+/// The per-call device id, resolved before the first `await` (a getter must not
+/// be called from another call's task tree).
+private func collectDeviceId(_ value: JSValue?) -> String? {
+    guard let value else { return nil }
+    if let string = value.string, !string.isEmpty { return string }
+    if let getter = value.function, let string = getter().string, !string.isEmpty { return string }
+    return nil
+}
+#endif

--- a/examples/emo/EmoWasmExample/browser.html
+++ b/examples/emo/EmoWasmExample/browser.html
@@ -50,8 +50,9 @@
       deviceId: selfProvidedDeviceId,
     });
     // Force the usage telemetry POST out now and await it before continuing.
-    if (globalThis.__EmoExports?.flushTelemetry) {
-      await globalThis.__EmoExports.flushTelemetry();
+    const core = globalThis.__DesertAntExports?.emo;
+    if (core?.flushTelemetry) {
+      await core.flushTelemetry();
     }
     return { suggestions, ms: Math.round(performance.now() - start) };
   }

--- a/js/README.md
+++ b/js/README.md
@@ -22,8 +22,16 @@ Browser-safe entry (`@desert-ant-labs/core`, no `node:*`):
 - `fetchModelFrom(baseUrl, files)` - the self-hosted (`modelBaseUrl`) opt-out.
 - `browserSetup` / `browserWasmDir` / `browserReadModelSource` /
   `browserCacheRoot` - the browser half of a model's `#platform` seam.
-- `FfiReader` - big-endian cursor over the length-prefixed FFIBuffer payload the
-  native core returns (the JS counterpart of Kotlin's `FfiReader`).
+- `wasmExports(modelId)` - the model-agnostic WebAssembly ABI a Swift core
+  installs on `globalThis.__DesertAntExports[modelId]` (`create`,
+  `createSelfHosted`, `isDownloaded`, `download`, `run`, `endCallGroup`,
+  `destroy`, `flushTelemetry`), the twin of the native `dal_*` symbols. Both
+  setups return it, so a model package writes no wasm glue: options and results
+  cross as FFIBuffer payloads it encodes with the codecs it already needs for
+  the native entry.
+- `FfiReader` / `FfiWriter` - big-endian cursor over the length-prefixed
+  FFIBuffer payloads both cores speak (the JS counterpart of Kotlin's
+  `FfiReader`).
 
 Node entry (`@desert-ant-labs/core/node`, uses `node:*` + koffi):
 

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -55,11 +55,33 @@ export function fetchModelFrom(
   files: { meta: string; model: string },
 ): Promise<{ metaJSON: string; modelBytes: Uint8Array }>;
 
+/** The model-agnostic WebAssembly ABI a Desert Ant core installs, the twin of
+ *  the native `dal_*` symbols. Handles are opaque numbers. */
+export interface WasmCore {
+  create(cacheRoot?: string, directory?: string): number;
+  createSelfHosted(files: Record<string, string | Uint8Array>): number;
+  isDownloaded(handle: number): boolean;
+  download(handle: number, onProgress?: (fraction: number) => void): Promise<boolean>;
+  run(
+    handle: number,
+    text: string,
+    options?: Uint8Array | null,
+    group?: string | null,
+    deviceId?: string | (() => string) | null,
+  ): Promise<Uint8Array>;
+  endCallGroup(id: string): void;
+  destroy(handle: number): void;
+  flushTelemetry(): Promise<boolean>;
+}
+
 export function browserSetup(options: {
   hostGlobal: string;
-  exportsGlobal: string;
+  modelId: string;
   init: () => Promise<{ init: (arg: object) => Promise<unknown> }>;
-}): Promise<any>;
+}): Promise<WasmCore>;
+
+/** The registered ABI for `modelId` (`globalThis.__DesertAntExports[modelId]`). */
+export function wasmExports(modelId: string): WasmCore;
 
 export function browserWasmDir(): Promise<string>;
 export function browserReadModelSource(source: any): Promise<any>;

--- a/js/index.js
+++ b/js/index.js
@@ -10,6 +10,7 @@ export {
   installLiteRtHost,
   fetchModelFrom,
   browserSetup,
+  wasmExports,
   browserWasmDir,
   browserReadModelSource,
   browserCacheRoot,

--- a/js/node.d.ts
+++ b/js/node.d.ts
@@ -37,10 +37,10 @@ export function loadNative(options: {
 
 export function nodeSetup(options: {
   hostGlobal: string;
-  exportsGlobal: string;
+  modelId: string;
   instantiate: () => Promise<{ instantiate: Function }>;
   nodePlatform: () => Promise<{ defaultNodeSetup: Function }>;
-}): Promise<any>;
+}): Promise<import("./index.js").WasmCore>;
 
 export interface CallGroups {
   withCallGroup: <T>(body: (group: string) => Promise<T>) => Promise<T>;

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/js/src/litert.js
+++ b/js/src/litert.js
@@ -169,13 +169,31 @@ export async function fetchModelFrom(baseUrl, files) {
 // The browser half of a model package's `#platform` import. A model's
 // platform-browser.js is a thin wrapper around these.
 
-/** Instantiate the wasm core and return its exports global. `init` imports the
- *  model's own ./dist/index.js. */
-export async function browserSetup({ hostGlobal, exportsGlobal, init }) {
+/** Instantiate the wasm core and return the model's entry in the shared export
+ *  registry (`globalThis.__DesertAntExports[modelId]`, installed by Swift's
+ *  WasmBindings). `init` imports the model's own ./dist/index.js. */
+export async function browserSetup({ hostGlobal, modelId, init }) {
   globalThis[hostGlobal] ??= {};
   const { init: initCore } = await init();
   await initCore({});
-  return globalThis[exportsGlobal];
+  return wasmExports(modelId);
+}
+
+/**
+ * The model-agnostic wasm ABI a Desert Ant core installs for `modelId` (the
+ * twin of the native `dal_*` symbols): `create`, `createSelfHosted`,
+ * `isDownloaded`, `download`, `run`, `endCallGroup`, `destroy`,
+ * `flushTelemetry`. Keyed by model id so two SDKs on one page never clobber
+ * each other's exports.
+ */
+export function wasmExports(modelId) {
+  const exports = globalThis.__DesertAntExports?.[modelId];
+  if (!exports) {
+    throw new Error(
+      `the WebAssembly core did not register "${modelId}" on globalThis.__DesertAntExports`,
+    );
+  }
+  return exports;
 }
 
 /** Where LiteRT.js loads its Wasm runtime from in the browser: the jsDelivr

--- a/js/src/platform-node.js
+++ b/js/src/platform-node.js
@@ -5,22 +5,24 @@
 // around these.
 //
 // Node-only (uses node:*).
+import { wasmExports } from "./litert.js";
 
 /**
- * Instantiate the wasm core under Node (WASI shim) and return its exports.
+ * Instantiate the wasm core under Node (WASI shim) and return the model's entry
+ * in the shared export registry (`globalThis.__DesertAntExports[modelId]`).
  * Gives the Swift ModelStore node's fs through the shared `__DalNodeFS` seam
  * (no `require` under the WASI shim); the download/verify/cache logic stays in
  * Swift.
  *
  * @param {object} o
  * @param {string} o.hostGlobal e.g. "__ShapesHost"
- * @param {string} o.exportsGlobal e.g. "__ShapesExports"
+ * @param {string} o.modelId catalog id, e.g. "shapes"
  * @param {() => Promise<{ instantiate: Function }>} o.instantiate imports the
  *   model's own ./dist/instantiate.js
  * @param {() => Promise<{ defaultNodeSetup: Function }>} o.nodePlatform imports
  *   the model's own ./dist/platforms/node.js
  */
-export async function nodeSetup({ hostGlobal, exportsGlobal, instantiate, nodePlatform }) {
+export async function nodeSetup({ hostGlobal, modelId, instantiate, nodePlatform }) {
   globalThis[hostGlobal] ??= {};
   const { instantiate: inst } = await instantiate();
   const fsmod = await import("node:fs");
@@ -38,7 +40,7 @@ export async function nodeSetup({ hostGlobal, exportsGlobal, instantiate, nodePl
   };
   const { defaultNodeSetup } = await nodePlatform();
   await inst(await defaultNodeSetup({}));
-  return globalThis[exportsGlobal];
+  return wasmExports(modelId);
 }
 
 /**

--- a/js/test/wasm.test.mjs
+++ b/js/test/wasm.test.mjs
@@ -1,0 +1,57 @@
+// The wasm export registry: the JS half of the model-agnostic WebAssembly ABI
+// installed by Swift's WasmBindings (`globalThis.__DesertAntExports[modelId]`).
+// The Swift half is covered by the wasm build; here we pin the seam every model
+// package resolves its core through.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { wasmExports, browserSetup } from "../src/litert.js";
+
+/** Stand-in for what a Swift core installs at start. */
+function fakeCore(modelId) {
+  const core = {
+    create: () => 1,
+    createSelfHosted: () => 2,
+    isDownloaded: () => true,
+    download: async () => true,
+    run: async () => new Uint8Array(),
+    endCallGroup: () => {},
+    destroy: () => {},
+    flushTelemetry: async () => true,
+  };
+  globalThis.__DesertAntExports = { ...(globalThis.__DesertAntExports ?? {}), [modelId]: core };
+  return core;
+}
+
+test("wasmExports returns the core registered for a model id", () => {
+  const core = fakeCore("emo");
+  assert.equal(wasmExports("emo"), core);
+});
+
+test("two models register side by side instead of clobbering one global", () => {
+  const emo = fakeCore("emo");
+  const redact = fakeCore("redact");
+  assert.equal(wasmExports("emo"), emo);
+  assert.equal(wasmExports("redact"), redact);
+});
+
+test("wasmExports names the model when a core did not register", () => {
+  assert.throws(() => wasmExports("nope"), /nope.*__DesertAntExports/s);
+});
+
+test("browserSetup seeds the host global, instantiates, and returns the core", async () => {
+  delete globalThis.__ShapesHost;
+  let initialized = 0;
+  const init = async () => ({
+    init: async () => {
+      initialized += 1;
+      fakeCore("shapes"); // the core installs its exports at start, as Swift does
+    },
+  });
+  const core = await browserSetup({ hostGlobal: "__ShapesHost", modelId: "shapes", init });
+  assert.equal(initialized, 1);
+  // The host object must exist before the core starts: the wasm session looks it
+  // up through this global.
+  assert.equal(typeof globalThis.__ShapesHost, "object");
+  assert.equal(core, wasmExports("shapes"));
+  assert.equal(typeof core.run, "function");
+});

--- a/mise.toml
+++ b/mise.toml
@@ -149,6 +149,34 @@ fi
 ./gradlew --no-daemon -p androidtest connectedAndroidTest
 """
 
+[tasks.build-wasm-entries]
+description = "Build every model's WebAssembly entry point (wasm32-unknown-wasi)"
+dir = "{{ config_root }}"
+shell = "bash -c"
+tools = { swift = "6.3.3" }
+# The model Web products are the only targets `test-wasi` does not build (it
+# builds test targets), so a broken wasm entry point used to surface only when a
+# model repo ran `build-web`. They are thin now - the ABI is shared in
+# WasmBindings - but they are still per-model, so keep compiling them here.
+run = """
+set -euo pipefail
+
+SWIFT_VER=$(swift --version 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]/){print $i; exit}}')
+[ -n "$SWIFT_VER" ] || { echo "error: could not determine the Swift version" >&2; exit 1; }
+SDK=${WASM_SDK:-swift-$SWIFT_VER-RELEASE_wasm}
+
+have_bundle() { for d in "$HOME/.swiftpm/swift-sdks" "$HOME/.config/swiftpm/swift-sdks" "$HOME/Library/org.swift.swiftpm/swift-sdks"; do [ -d "$d/$1" ] && return 0; done; return 1; }
+if ! have_bundle "$SDK.artifactbundle"; then
+    echo "Installing the Swift WebAssembly SDK $SWIFT_VER (one-time)..."
+    tmp=$(mktemp -d)
+    curl -fSL -o "$tmp/sdk.tar.gz" "https://download.swift.org/swift-$SWIFT_VER-release/wasm-sdk/swift-$SWIFT_VER-RELEASE/$SDK.artifactbundle.tar.gz"
+    swift sdk install "$tmp/sdk.tar.gz"
+    rm -rf "$tmp"
+fi
+
+swift build --swift-sdk "$SDK" --product EmoWeb --product RedactWeb
+"""
+
 [tasks.test-wasi]
 description = "Run the test suite on WebAssembly (wasm32-unknown-wasi) under Node"
 dir = "{{ config_root }}"

--- a/packages/emo-node/browser.js
+++ b/packages/emo-node/browser.js
@@ -7,6 +7,11 @@
 // XNNPACK-accelerated CPU ("wasm") by default, with optional WebGPU in the
 // browser.
 //
+// The WebAssembly core exposes the same model-agnostic ABI as the native core
+// (create / download / run / destroy, with options and results as FFI payloads),
+// so this file and node.js share `codec.js` and differ only in which core they
+// drive.
+//
 // All node-only code lives behind the `#platform` import, which bundlers resolve
 // at build time by condition (browser -> platform-browser.js, otherwise
 // platform-node.js). That keeps this file free of `node:*` and of any static
@@ -14,13 +19,10 @@
 // target of a multi-target bundler. For a prebuilt native server core (no
 // @litertjs/core, best server throughput), import `@desert-ant-labs/emo/native`.
 import { setupCore, defaultWasmDir, readModelSource, defaultCacheRoot } from "#platform";
-import { installLiteRtHost, loadLiteRt, assertBrowserRuntime } from "@desert-ant-labs/core";
-
-const PACKAGE_NAME = "@desert-ant-labs/emo";
-
-const SKIN_TONES = {
-  default: 0, light: 1, mediumLight: 2, medium: 3, mediumDark: 4, dark: 5,
-};
+import { installLiteRtHost, loadLiteRt, assertBrowserRuntime, FfiReader } from "@desert-ant-labs/core";
+import {
+  PACKAGE_NAME, HOST_GLOBAL, MODEL_FILES, SKIN_TONES, encodeOptions, decodeSuggestions,
+} from "./codec.js";
 
 // The wasm core instantiates at import time (top-level await); the model is
 // only wired in load(). The build-time-selected platform seam owns whatever is
@@ -37,6 +39,9 @@ const core = await setupCore();
  * ```
  */
 export class Emo {
+  #handle;
+  constructor(handle) { this.#handle = handle; }
+
   /**
    * Load the model and return a ready suggester. By default the model is
    * downloaded from the Hugging Face Hub at the pinned revision, verified, and
@@ -64,7 +69,7 @@ export class Emo {
     // manages tensor memory; setModel lets the modelBaseUrl branch feed the same
     // run() closure.
     const { setModel } = installLiteRtHost({
-      hostGlobal: "__EmoHost",
+      hostGlobal: HOST_GLOBAL,
       accelerator,
       loadAndCompile,
       Tensor,
@@ -72,26 +77,36 @@ export class Emo {
     });
 
     const onProgress = typeof resolved.onProgress === "function" ? resolved.onProgress : undefined;
+    let handle;
     if (resolved.modelBaseUrl != null) {
       // Self-hosted files (offline / no runtime CDN): fetch the model + sidecars
-      // from the given base URL, compile the model here, and hand the metadata +
-      // tokenizer to the wasm core, no Hub download. This is the browser's
-      // equivalent of pointing the native SDKs at a directory that already
-      // holds the model: nothing is bundled, nothing is downloaded.
-      const { metaJSON, tokenizerBytes, modelBytes } = await fetchModelFrom(resolved.modelBaseUrl);
+      // from the given base URL, compile the model here, and hand the sidecars
+      // to the wasm core, no Hub download. This is the browser's equivalent of
+      // pointing the native SDKs at a directory that already holds the model:
+      // nothing is bundled, nothing is downloaded.
+      const { sidecars, modelBytes } = await fetchModelFrom(resolved.modelBaseUrl);
       setModel(await loadAndCompile(modelBytes, { accelerator }));
-      await core.loadSelfHosted(metaJSON, tokenizerBytes);
-      onProgress?.(1);
+      handle = core.createSelfHosted(sidecars);
     } else {
-      // Default: the runtime downloads this platform's files from the HF Hub at
-      // the pinned tag (SHA-256 verified), fetched + cached by the JS host, and
+      // Default: the core downloads this platform's files from the HF Hub at the
+      // pinned tag (SHA-256 verified), fetched + cached by the JS host, and
       // wires the session through the installed host. `directory` (node) adopts
-      // a self-hosted folder. Base for the managed nested cache (node): ~/.cache;
-      // empty (in-memory) in the browser.
-      const cacheRoot = await defaultCacheRoot();
-      await core.load(cacheRoot, resolved.directory ?? "", onProgress);
+      // a folder you populated. Base for the managed nested cache (node):
+      // ~/.cache; empty (in-memory) in the browser.
+      handle = core.create(await defaultCacheRoot(), resolved.directory ?? "");
     }
-    return new Emo();
+    if (!handle) throw new Error(`${PACKAGE_NAME}: failed to create suggester`);
+    const emo = new Emo(handle);
+    // Ready the model now (downloading if needed) so the first suggestion is
+    // instant and load() surfaces any download error, as the native build does.
+    try {
+      await core.download(handle, onProgress);
+    } catch (cause) {
+      emo.dispose();
+      throw new Error(`${PACKAGE_NAME}: ${cause}`, { cause });
+    }
+    onProgress?.(1);
+    return emo;
   }
 
   /**
@@ -101,32 +116,58 @@ export class Emo {
    * `options.deviceId` (a string or a zero-arg function returning one)
    * attributes usage to a specific end-user device. It is collected per call
    * and bound to that call, so it is safe for concurrent multi-tenant hosts.
+   * `options.group` (an id from {@link withCallGroup}) bills several calls as
+   * one.
    */
   async suggestions(text, options = {}) {
-    const limit = options.limit ?? 3;
-    const skinTone = SKIN_TONES[options.skinTone ?? "default"] ?? 0;
-    return core.suggest(String(text ?? ""), limit, skinTone, options.deviceId);
+    if (!this.#handle) throw new Error(`${PACKAGE_NAME}: suggester disposed`);
+    const phrase = String(text ?? "");
+    if (phrase.trim() === "") return [];
+    const payload = encodeOptions({
+      limit: options.limit ?? 3,
+      skinTone: SKIN_TONES[options.skinTone ?? "default"] ?? 0,
+    });
+    const group = options.group != null ? String(options.group) : null;
+    const result = await core.run(this.#handle, phrase, payload, group, options.deviceId ?? null);
+    return decodeSuggestions(new FfiReader(result));
   }
 
   /**
-   * Free native resources. No-op in the WebAssembly runtime; present so the same
-   * code works against the native server build (`@desert-ant-labs/emo/native`).
+   * Run `body` with a call group, so every `suggestions({ group })` inside it
+   * bills as a single usage call rather than one per suggestion. The group is
+   * released when `body` settles.
    */
-  dispose() {}
+  async withCallGroup(body) {
+    const id = `emo-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+    try {
+      return await body(id);
+    } finally {
+      core.endCallGroup(id);
+    }
+  }
+
+  /** Release the model. The suggester is unusable afterwards. */
+  dispose() {
+    if (this.#handle) { core.destroy(this.#handle); this.#handle = null; }
+  }
 }
 
 // Fetch self-hosted model files from a base URL (the `modelBaseUrl` opt-out).
-// Accepts absolute URLs and root-relative paths (e.g. "/assets/emo/").
+// Accepts absolute URLs and root-relative paths (e.g. "/assets/emo/"). The
+// sidecars go to the wasm core keyed by their catalog names; the model bytes
+// stay here and are compiled by LiteRT.js.
 async function fetchModelFrom(baseUrl) {
   const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
   const [meta, tokenizer, model] = await Promise.all([
-    fetch(`${base}emo_meta.json`).then((r) => r.text()),
-    fetch(`${base}emo_tokenizer.bin`).then((r) => r.arrayBuffer()),
-    fetch(`${base}emo.tflite`).then((r) => r.arrayBuffer()),
+    fetch(`${base}${MODEL_FILES.meta}`).then((r) => r.text()),
+    fetch(`${base}${MODEL_FILES.tokenizer}`).then((r) => r.arrayBuffer()),
+    fetch(`${base}${MODEL_FILES.model}`).then((r) => r.arrayBuffer()),
   ]);
   return {
-    metaJSON: meta,
-    tokenizerBytes: new Uint8Array(tokenizer),
+    sidecars: {
+      [MODEL_FILES.meta]: meta,
+      [MODEL_FILES.tokenizer]: new Uint8Array(tokenizer),
+    },
     modelBytes: new Uint8Array(model),
   };
 }

--- a/packages/emo-node/codec.js
+++ b/packages/emo-node/codec.js
@@ -1,0 +1,47 @@
+// Emo's FFI payload schemas: the options a run takes and the result it returns.
+//
+// These are the only model-specific part of talking to the core, and both cores
+// speak the same payloads - the native `dal_run` (node.js) and the WebAssembly
+// `run` (browser.js) - so they live here once instead of in each entry point.
+// Mirrors the reader/writer in Sources/ModelCatalog/Emo/Binding.swift.
+import { FfiWriter } from "@desert-ant-labs/core";
+
+/** The catalog id: how both cores are asked for Emo, and the key its
+ *  WebAssembly exports are registered under. */
+export const MODEL_ID = "emo";
+
+export const PACKAGE_NAME = "@desert-ant-labs/emo";
+
+/** The host global the WebAssembly core drives its LiteRT.js session through
+ *  (matches `EmoModel.hostGlobal` in the Swift catalog). */
+export const HOST_GLOBAL = "__EmoHost";
+
+/** Sidecars + artifact under a `modelBaseUrl`, named as in the catalog. */
+export const MODEL_FILES = {
+  meta: "emo_meta.json",
+  tokenizer: "emo_tokenizer.bin",
+  model: "emo.tflite",
+};
+
+export const SKIN_TONES = {
+  default: 0, light: 1, mediumLight: 2, medium: 3, mediumDark: 4, dark: 5,
+};
+
+/** Options payload: `u32 limit`, `u32 skinTone`. */
+export function encodeOptions({ limit, skinTone }) {
+  return new FfiWriter().u32(limit).u32(skinTone).done();
+}
+
+/** Result payload: a `u32` count, then per suggestion a length-prefixed UTF-8
+ *  emoji string and an IEEE-754 `f64` confidence. `r` is an FfiReader already
+ *  positioned at the payload. */
+export function decodeSuggestions(r) {
+  const count = r.u32();
+  const out = [];
+  for (let i = 0; i < count; i++) {
+    const emoji = r.str();
+    const confidence = r.f64();
+    out.push({ emoji, confidence });
+  }
+  return out;
+}

--- a/packages/emo-node/index.d.ts
+++ b/packages/emo-node/index.d.ts
@@ -31,7 +31,7 @@ export interface SuggestOptions {
   /**
    * Bills this call as part of a shared usage call group, so a logical operation
    * made of several suggestions counts once. Get an id from
-   * {@link Emo.withCallGroup}. Native Node build only.
+   * {@link Emo.withCallGroup}.
    */
   group?: string;
 }
@@ -103,10 +103,9 @@ export declare class Emo {
   /**
    * Run `body` with a fresh call-group id, so every `suggestions({ group })`
    * inside it bills as a single usage call. The group is released when `body`
-   * settles. Native Node build only.
+   * settles.
    */
   withCallGroup<T>(body: (group: string) => Promise<T>): Promise<T>;
-  /** Free native resources (the `@desert-ant-labs/emo/native` build). No-op in
-   * the default WebAssembly build. Safe to call in both. */
+  /** Release the model. The suggester is unusable afterwards. Both builds. */
   dispose(): void;
 }

--- a/packages/emo-node/node.js
+++ b/packages/emo-node/node.js
@@ -7,46 +7,22 @@
 // The koffi harness (resolve native/<platform>-<arch>, load the LiteRT runtime
 // first, bind the generic `dal_*` C ABI, run blocking calls off the event loop)
 // and the FFI codecs live in @desert-ant-labs/core/node; this file supplies only
-// Emo's options/result payload schemas and the public API.
+// Emo's public API; the payload schemas it shares with the browser entry live
+// in codec.js.
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { loadNative, FfiWriter } from "@desert-ant-labs/core/node";
+import { loadNative } from "@desert-ant-labs/core/node";
+import { MODEL_ID, PACKAGE_NAME, SKIN_TONES, encodeOptions, decodeSuggestions } from "./codec.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-
-/** The catalog id, which is how the model-agnostic C ABI is asked for Emo. */
-const MODEL_ID = "emo";
-
-const SKIN_TONES = { default: 0, light: 1, mediumLight: 2, medium: 3, mediumDark: 4, dark: 5 };
 
 // The prebuilt native for this host lives in native/<platform>-<arch>/ next to
 // this file (built by `mise run node-natives`): the self-contained Swift core
 // (libDesertAntNode, one library for every model) plus the LiteRT runtime it
 // links (libLiteRt). The symbol table is the shared `dal_*` ABI, so it is the
 // loader's default and this call names no symbols.
-const core = loadNative({ here: HERE, packageName: "@desert-ant-labs/emo" });
+const core = loadNative({ here: HERE, packageName: PACKAGE_NAME });
 const { lib, callAsync, decodeResult, withCallGroup } = core;
-
-/** Encode Emo's `dal_run` options payload: `u32 limit`, `u32 skinTone`. Must
- *  match the reader in Sources/ModelCatalog/Emo/Binding.swift. */
-function encodeOptions({ limit, skinTone }) {
-  return new FfiWriter().u32(limit).u32(skinTone).done();
-}
-
-/** Decode the FFI buffer the core returns (via `decodeResult`, positioned at the
- *  payload): a u32 count, then per suggestion a u32-length UTF-8 emoji string
- *  and an IEEE-754 double confidence. Mirrors the writer in
- *  Sources/ModelCatalog/Emo/Binding.swift and the Kotlin FfiReader. */
-function decodeSuggestions(r) {
-  const count = r.u32();
-  const out = [];
-  for (let i = 0; i < count; i++) {
-    const emoji = r.str();
-    const confidence = r.f64();
-    out.push({ emoji, confidence });
-  }
-  return out;
-}
 
 /**
  * On-device multilingual emoji suggestion. Create one with `await Emo.load(...)`
@@ -83,14 +59,14 @@ export class Emo {
     const cacheRoot = options.cacheRoot ?? core.defaultCacheRoot();
     const directory = options.directory ?? null;
     const handle = lib.create(MODEL_ID, cacheRoot, directory);
-    if (!handle) throw new Error("@desert-ant-labs/emo: failed to create suggester");
+    if (!handle) throw new Error(`${PACKAGE_NAME}: failed to create suggester`);
     const emo = new Emo(handle);
     // Ready the model now (download if needed) so the first suggestion is instant
     // and load() surfaces any download error.
     if (lib.isDownloaded(handle) === 0) {
       onProgress?.(0);
       const rc = await callAsync(lib.download, handle);
-      if (rc !== 0) { emo.dispose(); throw new Error("@desert-ant-labs/emo: model download failed"); }
+      if (rc !== 0) { emo.dispose(); throw new Error(`${PACKAGE_NAME}: model download failed`); }
     }
     onProgress?.(1);
     return emo;
@@ -110,7 +86,7 @@ export class Emo {
    * Omit to attribute to the host device.
    */
   async suggestions(text, options = {}) {
-    if (!this.#handle) throw new Error("@desert-ant-labs/emo: suggester disposed");
+    if (!this.#handle) throw new Error(`${PACKAGE_NAME}: suggester disposed`);
     const phrase = String(text ?? "");
     if (phrase.trim() === "") return [];
     const limit = options.limit ?? 3;
@@ -121,7 +97,7 @@ export class Emo {
     const ptr = await callAsync(
       lib.run, this.#handle, phrase, payload, payload.length, group,
       deviceId != null ? String(deviceId) : null);
-    if (!ptr) throw new Error("@desert-ant-labs/emo: suggestion failed");
+    if (!ptr) throw new Error(`${PACKAGE_NAME}: suggestion failed`);
     try {
       return decodeSuggestions(decodeResult(ptr));
     } finally {

--- a/packages/emo-node/package.json
+++ b/packages/emo-node/package.json
@@ -52,6 +52,7 @@
   },
   "files": [
     "browser.js",
+    "codec.js",
     "node.js",
     "platform-browser.js",
     "platform-node.js",
@@ -63,7 +64,7 @@
   ],
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.3.0",
-    "@desert-ant-labs/core": "^0.6.0",
+    "@desert-ant-labs/core": "^0.7.0",
     "koffi": "^2.9.0"
   },
   "peerDependencies": {

--- a/packages/emo-node/platform-browser.js
+++ b/packages/emo-node/platform-browser.js
@@ -6,11 +6,12 @@
 // browser target of multi-target bundlers (Next, Remix, SvelteKit, Nuxt). The
 // shared instantiation logic lives in @desert-ant-labs/core.
 import { browserSetup, browserWasmDir, browserReadModelSource, browserCacheRoot } from "@desert-ant-labs/core";
+import { HOST_GLOBAL, MODEL_ID } from "./codec.js";
 
 export function setupCore() {
   return browserSetup({
-    hostGlobal: "__EmoHost",
-    exportsGlobal: "__EmoExports",
+    hostGlobal: HOST_GLOBAL,
+    modelId: MODEL_ID,
     init: () => import("./dist/index.js"),
   });
 }

--- a/packages/emo-node/platform-node.js
+++ b/packages/emo-node/platform-node.js
@@ -6,11 +6,12 @@
 // through the non-browser ("default") condition of `#platform`, so the browser
 // bundle never sees `node:*`.
 import { nodeSetup, nodeWasmDir, nodeReadModelSource, nodeCacheRoot } from "@desert-ant-labs/core/node";
+import { HOST_GLOBAL, MODEL_ID } from "./codec.js";
 
 export function setupCore() {
   return nodeSetup({
-    hostGlobal: "__EmoHost",
-    exportsGlobal: "__EmoExports",
+    hostGlobal: HOST_GLOBAL,
+    modelId: MODEL_ID,
     instantiate: () => import("./dist/instantiate.js"),
     nodePlatform: () => import("./dist/platforms/node.js"),
   });

--- a/packages/redact-node/browser.js
+++ b/packages/redact-node/browser.js
@@ -7,6 +7,11 @@
 // pipeline: XNNPACK-accelerated CPU ("wasm") by default, with optional WebGPU in
 // the browser.
 //
+// The WebAssembly core exposes the same model-agnostic ABI as the native core
+// (create / download / run / destroy, with options and results as FFI payloads),
+// so this file and node.js share `codec.js` and differ only in which core they
+// drive.
+//
 // All node-only code lives behind the `#platform` import, which bundlers resolve
 // at build time by condition (browser -> platform-browser.js, otherwise
 // platform-node.js). That keeps this file free of `node:*` and of any static
@@ -14,9 +19,10 @@
 // target of a multi-target bundler. For a prebuilt native server core (no
 // @litertjs/core, best server throughput), import `@desert-ant-labs/redact/native`.
 import { setupCore, defaultWasmDir, readModelSource, defaultCacheRoot } from "#platform";
-import { installLiteRtHost, loadLiteRt, assertBrowserRuntime } from "@desert-ant-labs/core";
-
-const PACKAGE_NAME = "@desert-ant-labs/redact";
+import { installLiteRtHost, loadLiteRt, assertBrowserRuntime, FfiReader } from "@desert-ant-labs/core";
+import {
+  PACKAGE_NAME, HOST_GLOBAL, MODEL_FILES, encodeOptions, decodeRedaction,
+} from "./codec.js";
 
 // The wasm core instantiates at import time (top-level await); the model is
 // only wired in load(). The build-time-selected platform seam owns whatever is
@@ -34,6 +40,9 @@ const core = await setupCore();
  * ```
  */
 export class Redact {
+  #handle;
+  constructor(handle) { this.#handle = handle; }
+
   /**
    * Load the model and return a ready redactor. By default the runtime downloads
    * the model from the Hugging Face Hub at the SDK's pinned tag (fetched +
@@ -59,7 +68,7 @@ export class Redact {
     // logits. @desert-ant-labs/core installs the host + manages tensor memory;
     // setModel lets the modelBaseUrl branch feed the same run() closure.
     const { setModel } = installLiteRtHost({
-      hostGlobal: "__RedactHost",
+      hostGlobal: HOST_GLOBAL,
       accelerator,
       loadAndCompile,
       Tensor,
@@ -67,68 +76,95 @@ export class Redact {
     });
 
     const onProgress = typeof resolved.onProgress === "function" ? resolved.onProgress : undefined;
+    let handle;
     if (resolved.modelBaseUrl != null) {
       // Self-hosted files (offline / no runtime CDN): fetch the model + sidecars
-      // from the given base URL, compile the model here, and hand the labels +
-      // tokenizer to the wasm core, no Hub download. This is the browser's
-      // equivalent of pointing the native SDKs at a directory that already
-      // holds the model: nothing is bundled, nothing is downloaded.
-      const { labelsJSON, tokenizerBytes, modelBytes } = await fetchModelFrom(resolved.modelBaseUrl);
+      // from the given base URL, compile the model here, and hand the sidecars
+      // to the wasm core, no Hub download. This is the browser's equivalent of
+      // pointing the native SDKs at a directory that already holds the model:
+      // nothing is bundled, nothing is downloaded.
+      const { sidecars, modelBytes } = await fetchModelFrom(resolved.modelBaseUrl);
       setModel(await loadAndCompile(modelBytes, { accelerator }));
-      await core.loadSelfHosted(labelsJSON, tokenizerBytes);
-      onProgress?.(1);
+      handle = core.createSelfHosted(sidecars);
     } else {
-      // Default: the runtime downloads this platform's files from the HF Hub at
-      // the pinned tag (SHA-256 verified), fetched + cached by the JS host, and
+      // Default: the core downloads this platform's files from the HF Hub at the
+      // pinned tag (SHA-256 verified), fetched + cached by the JS host, and
       // wires the session through the installed host. `directory` (node) adopts
-      // a self-hosted folder. Base for the managed nested cache (node): ~/.cache;
-      // empty (in-memory) in the browser.
-      const cacheRoot = await defaultCacheRoot();
-      await core.load(cacheRoot, resolved.directory ?? "", onProgress);
+      // a folder you populated. Base for the managed nested cache (node):
+      // ~/.cache; empty (in-memory) in the browser.
+      handle = core.create(await defaultCacheRoot(), resolved.directory ?? "");
     }
-    return new Redact();
+    if (!handle) throw new Error(`${PACKAGE_NAME}: failed to create redactor`);
+    const redact = new Redact(handle);
+    // Ready the model now (downloading if needed) so the first redaction is
+    // instant and load() surfaces any download error, as the native build does.
+    try {
+      await core.download(handle, onProgress);
+    } catch (cause) {
+      redact.dispose();
+      throw new Error(`${PACKAGE_NAME}: ${cause}`, { cause });
+    }
+    onProgress?.(1);
+    return redact;
   }
 
   /**
    * Detect and redact the PII in `text`. Each entity is replaced by a unique,
    * numbered placeholder (`[EMAIL_1]`, ...), safe to hand to an LLM and restore
    * afterwards via the returned `restore`.
+   *
+   * `options.deviceId` (a string or a zero-arg function returning one)
+   * attributes usage to a specific end-user device; `options.group` (an id from
+   * {@link withCallGroup}) bills several calls as one.
    */
   async redaction(text, options = {}) {
-    const raw = await core.redaction(
-      text, options.minimumConfidence ?? 0.6,
-      options.labels ? Array.from(options.labels) : undefined);
-    const items = Array.from(raw.items).map((i) => ({ ...i }));
-    return {
-      redactedText: raw.redactedText,
-      items,
-      restore(processed) {
-        let out = processed;
-        for (const item of items) out = out.replaceAll(item.placeholder, item.original);
-        return out;
-      },
-    };
+    if (!this.#handle) throw new Error(`${PACKAGE_NAME}: redactor disposed`);
+    const payload = encodeOptions({
+      minimumConfidence: options.minimumConfidence ?? 0.6,
+      labels: options.labels ? Array.from(options.labels) : undefined,
+    });
+    const group = options.group != null ? String(options.group) : null;
+    const result = await core.run(
+      this.#handle, String(text ?? ""), payload, group, options.deviceId ?? null);
+    return decodeRedaction(new FfiReader(result));
   }
 
   /**
-   * Free native resources. No-op in the WebAssembly runtime; present so the same
-   * code works against the native server build (`@desert-ant-labs/redact/native`).
+   * Run `body` with a call group, so every `redaction({ group })` inside it
+   * bills as a single usage call rather than one per redaction. The group is
+   * released when `body` settles.
    */
-  dispose() {}
+  async withCallGroup(body) {
+    const id = `redact-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+    try {
+      return await body(id);
+    } finally {
+      core.endCallGroup(id);
+    }
+  }
+
+  /** Release the model. The redactor is unusable afterwards. */
+  dispose() {
+    if (this.#handle) { core.destroy(this.#handle); this.#handle = null; }
+  }
 }
 
 // Fetch self-hosted model files from a base URL (the `modelBaseUrl` opt-out).
-// Accepts absolute URLs and root-relative paths (e.g. "/assets/redact/").
+// Accepts absolute URLs and root-relative paths (e.g. "/assets/redact/"). The
+// sidecars go to the wasm core keyed by their catalog names; the model bytes
+// stay here and are compiled by LiteRT.js.
 async function fetchModelFrom(baseUrl) {
   const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
-  const [labels, tokenizer, model] = await Promise.all([
-    fetch(`${base}labels.json`).then((r) => r.text()),
-    fetch(`${base}redact_tokenizer.bin`).then((r) => r.arrayBuffer()),
-    fetch(`${base}redact.tflite`).then((r) => r.arrayBuffer()),
+  const [tokenizer, labels, model] = await Promise.all([
+    fetch(`${base}${MODEL_FILES.tokenizer}`).then((r) => r.arrayBuffer()),
+    fetch(`${base}${MODEL_FILES.labels}`).then((r) => r.text()),
+    fetch(`${base}${MODEL_FILES.model}`).then((r) => r.arrayBuffer()),
   ]);
   return {
-    labelsJSON: labels,
-    tokenizerBytes: new Uint8Array(tokenizer),
+    sidecars: {
+      [MODEL_FILES.tokenizer]: new Uint8Array(tokenizer),
+      [MODEL_FILES.labels]: labels,
+    },
     modelBytes: new Uint8Array(model),
   };
 }

--- a/packages/redact-node/codec.js
+++ b/packages/redact-node/codec.js
@@ -1,0 +1,59 @@
+// Redact's FFI payload schemas: the options a run takes and the result it
+// returns.
+//
+// These are the only model-specific part of talking to the core, and both cores
+// speak the same payloads - the native `dal_run` (node.js) and the WebAssembly
+// `run` (browser.js) - so they live here once instead of in each entry point.
+// Mirrors the reader/writer in Sources/ModelCatalog/Redact/Binding.swift.
+import { FfiWriter } from "@desert-ant-labs/core";
+
+/** The catalog id: how both cores are asked for Redact, and the key its
+ *  WebAssembly exports are registered under. */
+export const MODEL_ID = "redact";
+
+export const PACKAGE_NAME = "@desert-ant-labs/redact";
+
+/** The host global the WebAssembly core drives its LiteRT.js session through
+ *  (matches `RedactModel.hostGlobal` in the Swift catalog). */
+export const HOST_GLOBAL = "__RedactHost";
+
+/** Sidecars + artifact under a `modelBaseUrl`, named as in the catalog. */
+export const MODEL_FILES = {
+  tokenizer: "redact_tokenizer.bin",
+  labels: "labels.json",
+  model: "redact.tflite",
+};
+
+/** Options payload: `f64 minimumConfidence`, then a `u32` label count and that
+ *  many length-prefixed names (an empty list means every label). */
+export function encodeOptions({ minimumConfidence, labels }) {
+  return new FfiWriter().f64(minimumConfidence).strings(labels ?? []).done();
+}
+
+/** Result payload: the redacted text, then a `u32` count and per item
+ *  label/original/placeholder strings, an `f64` confidence, and `u32`
+ *  start/end UTF-16 offsets. `r` is an FfiReader positioned at the payload.
+ *  Returns the public `Redaction` shape, including `restore`. */
+export function decodeRedaction(r) {
+  const redactedText = r.str();
+  const count = r.u32();
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    const label = r.str();
+    const original = r.str();
+    const placeholder = r.str();
+    const confidence = r.f64();
+    const start = r.u32();
+    const end = r.u32();
+    items.push({ label, original, placeholder, confidence, start, end });
+  }
+  return {
+    redactedText,
+    items,
+    restore(processed) {
+      let out = processed;
+      for (const item of items) out = out.replaceAll(item.placeholder, item.original);
+      return out;
+    },
+  };
+}

--- a/packages/redact-node/index.d.ts
+++ b/packages/redact-node/index.d.ts
@@ -40,13 +40,13 @@ export interface Options {
    * Attributes usage to a specific end-user device (multi-tenant hosts serving
    * many users). A string, or a zero-arg function returning one, collected per
    * call and bound to that call so it is safe under concurrency. Omit to use the
-   * default device. Native Node build only.
+   * default device. Honored by both the WebAssembly and native Node builds.
    */
   deviceId?: string | (() => string);
   /**
    * Bills this call as part of a shared usage call group, so a logical operation
    * made of several redactions counts once. Get an id from
-   * {@link Redact.withCallGroup}. Native Node build only.
+   * {@link Redact.withCallGroup}.
    */
   group?: string;
 }
@@ -120,10 +120,8 @@ export declare class Redact {
   /**
    * Run `body` with a fresh call-group id, so every `redaction({ group })` inside
    * it bills as a single usage call. The group is released when `body` settles.
-   * Native Node build only.
    */
   withCallGroup<T>(body: (group: string) => Promise<T>): Promise<T>;
-  /** Free native resources (the `@desert-ant-labs/redact/native` build). No-op in
-   * the default WebAssembly build. Safe to call in both. */
+  /** Release the model. The redactor is unusable afterwards. Both builds. */
   dispose(): void;
 }

--- a/packages/redact-node/node.js
+++ b/packages/redact-node/node.js
@@ -7,51 +7,22 @@
 // The koffi harness (resolve native/<platform>-<arch>, load the LiteRT runtime
 // first, bind the generic `dal_*` C ABI, run blocking calls off the event loop)
 // and the FFI codecs live in @desert-ant-labs/core/node; this file supplies only
-// Redact's options/result payload schemas and the public API.
+// Redact's public API; the payload schemas it shares with the browser entry
+// live in codec.js.
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { loadNative, FfiWriter } from "@desert-ant-labs/core/node";
+import { loadNative } from "@desert-ant-labs/core/node";
+import { MODEL_ID, PACKAGE_NAME, encodeOptions, decodeRedaction } from "./codec.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-
-/** The catalog id, which is how the model-agnostic C ABI is asked for Redact. */
-const MODEL_ID = "redact";
 
 // The prebuilt native for this host lives in native/<platform>-<arch>/ next to
 // this file (built by `mise run node-natives`): the self-contained Swift core
 // (libDesertAntNode, one library for every model) plus the LiteRT runtime it
 // links (libLiteRt). The symbol table is the shared `dal_*` ABI, so it is the
 // loader's default and this call names no symbols.
-const core = loadNative({ here: HERE, packageName: "@desert-ant-labs/redact" });
+const core = loadNative({ here: HERE, packageName: PACKAGE_NAME });
 const { lib, callAsync, decodeResult, withCallGroup } = core;
-
-/** Encode Redact's `dal_run` options payload: `f64 minimumConfidence`, then a
- *  `u32` label count and that many length-prefixed names (an empty list means
- *  every label). Must match the reader in
- *  Sources/ModelCatalog/Redact/Binding.swift. */
-function encodeOptions({ minimumConfidence, labels }) {
-  return new FfiWriter().f64(minimumConfidence).strings(labels ?? []).done();
-}
-
-/** Decode the FFI buffer the core returns: the redacted text, then a u32 count
- *  and per item label/original/placeholder (strings), an f64 confidence, and
- *  u32 start/end offsets, read off the shared FfiReader. Mirrors the writer in
- *  Sources/ModelCatalog/Redact/Binding.swift. */
-function decodeRedaction(r) {
-  const redactedText = r.str();
-  const count = r.u32();
-  const items = [];
-  for (let i = 0; i < count; i++) {
-    const label = r.str();
-    const original = r.str();
-    const placeholder = r.str();
-    const confidence = r.f64();
-    const start = r.u32();
-    const end = r.u32();
-    items.push({ label, original, placeholder, confidence, start, end });
-  }
-  return { redactedText, items };
-}
 
 /**
  * On-device multilingual PII redaction. Create one with `await Redact.load(...)`
@@ -79,7 +50,7 @@ export class Redact {
     const cacheRoot = options.cacheRoot ?? core.defaultCacheRoot();
     const directory = options.directory ?? null;
     const handle = lib.create(MODEL_ID, cacheRoot, directory);
-    if (!handle) throw new Error("@desert-ant-labs/redact: failed to create redactor");
+    if (!handle) throw new Error(`${PACKAGE_NAME}: failed to create redactor`);
     const redact = new Redact(handle);
     // Ready the model now so the first redaction is instant and load() surfaces
     // any download error, matching the browser's eager `load()`.
@@ -87,7 +58,7 @@ export class Redact {
     if (lib.isDownloaded(handle) === 0) {
       onProgress?.(0);
       const rc = await callAsync(lib.download, handle);
-      if (rc !== 0) { redact.dispose(); throw new Error("@desert-ant-labs/redact: model download failed"); }
+      if (rc !== 0) { redact.dispose(); throw new Error(`${PACKAGE_NAME}: model download failed`); }
     }
     onProgress?.(1);
     return redact;
@@ -105,27 +76,20 @@ export class Redact {
    * multi-tenant hosts.
    */
   async redaction(text, options = {}) {
-    if (!this.#handle) throw new Error("@desert-ant-labs/redact: redactor disposed");
+    if (!this.#handle) throw new Error(`${PACKAGE_NAME}: redactor disposed`);
     const minimumConfidence = options.minimumConfidence ?? 0.6;
     const deviceId = typeof options.deviceId === "function" ? options.deviceId() : options.deviceId;
     const group = options.group != null ? String(options.group) : null;
-    const payload = encodeOptions({ minimumConfidence, labels: options.labels });
+    const payload = encodeOptions({
+      minimumConfidence,
+      labels: options.labels ? Array.from(options.labels) : undefined,
+    });
     const ptr = await callAsync(
       lib.run, this.#handle, String(text ?? ""), payload, payload.length, group,
       deviceId != null ? String(deviceId) : null);
-    if (!ptr) throw new Error("@desert-ant-labs/redact: redaction failed");
+    if (!ptr) throw new Error(`${PACKAGE_NAME}: redaction failed`);
     try {
-      const raw = decodeRedaction(decodeResult(ptr));
-      const items = raw.items.map((i) => ({ ...i }));
-      return {
-        redactedText: raw.redactedText,
-        items,
-        restore(processed) {
-          let out = processed;
-          for (const item of items) out = out.replaceAll(item.placeholder, item.original);
-          return out;
-        },
-      };
+      return decodeRedaction(decodeResult(ptr));
     } finally {
       lib.bufferFree(ptr);
     }

--- a/packages/redact-node/package.json
+++ b/packages/redact-node/package.json
@@ -53,6 +53,7 @@
   },
   "files": [
     "browser.js",
+    "codec.js",
     "node.js",
     "platform-browser.js",
     "platform-node.js",
@@ -64,7 +65,7 @@
   ],
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.3.0",
-    "@desert-ant-labs/core": "^0.3.0"
+    "@desert-ant-labs/core": "^0.7.0"
   },
   "optionalDependencies": {
     "koffi": "^2.9.0"

--- a/packages/redact-node/platform-browser.js
+++ b/packages/redact-node/platform-browser.js
@@ -6,11 +6,12 @@
 // browser target of multi-target bundlers (Next, Remix, SvelteKit, Nuxt). The
 // shared instantiation logic lives in @desert-ant-labs/core.
 import { browserSetup, browserWasmDir, browserReadModelSource, browserCacheRoot } from "@desert-ant-labs/core";
+import { HOST_GLOBAL, MODEL_ID } from "./codec.js";
 
 export function setupCore() {
   return browserSetup({
-    hostGlobal: "__RedactHost",
-    exportsGlobal: "__RedactExports",
+    hostGlobal: HOST_GLOBAL,
+    modelId: MODEL_ID,
     init: () => import("./dist/index.js"),
   });
 }

--- a/packages/redact-node/platform-node.js
+++ b/packages/redact-node/platform-node.js
@@ -6,11 +6,12 @@
 // through the non-browser ("default") condition of `#platform`, so the browser
 // bundle never sees `node:*`.
 import { nodeSetup, nodeWasmDir, nodeReadModelSource, nodeCacheRoot } from "@desert-ant-labs/core/node";
+import { HOST_GLOBAL, MODEL_ID } from "./codec.js";
 
 export function setupCore() {
   return nodeSetup({
-    hostGlobal: "__RedactHost",
-    exportsGlobal: "__RedactExports",
+    hostGlobal: HOST_GLOBAL,
+    modelId: MODEL_ID,
     instantiate: () => import("./dist/instantiate.js"),
     nodePlatform: () => import("./dist/platforms/node.js"),
   });


### PR DESCRIPTION
The first of the duplication cleanups: wasm was the last place where the "one
generic binding, keyed by model id" pattern was not applied. Every model
hand-wrote its own WebAssembly entry point (a per-model exports global,
`load`/`loadSelfHosted`, a per-model run function, promise plumbing, a device-id
collector, the exports object) and every npm package hand-wrote the JS mirror of
it. That is ~130 lines per model that differ only in names, plus the same again
in each package.

The `dal_*` C ABI already solved this: options in and results out cross as
`FFIBuffer` payloads the model encodes itself, so one surface serves every model
and the host picks the model by id. This gives wasm the same shape.

## The ABI

`Sources/WasmBindings` installs, per model:

```js
globalThis.__DesertAntExports.emo = {
  create(cacheRoot?, directory?), createSelfHosted(files),   // -> handle
  isDownloaded(handle), download(handle, onProgress?),
  run(handle, text, options?, group?, deviceId?),            // -> Uint8Array
  endCallGroup(id), destroy(handle), flushTelemetry(),
}
```

Keyed by model id rather than one flat global, so two SDK packages on the same
page register side by side instead of racing to overwrite `__XExports` (the old
setups captured the global right after `init`, which two concurrent setups could
interleave).

## What shrinks

- `Sources/ModelCatalog/Emo/Web/main.swift`: 159 -> 28 lines.
  `Sources/ModelCatalog/Redact/Web/main.swift`: 129 -> 29. What is left is the
  model's declaration plus the one genuinely model-specific piece: how the JS
  host's self-hosted files (`modelBaseUrl`) become an instance.
- Each npm package gains a `codec.js` (model id, host global, file names, option
  encoder, result decoder) that its browser **and** native entries share, so a
  payload schema is written once per model instead of once per entry point.
- `ModelDeclaration.hostGlobal` is derived from the product (`__EmoHost`), so the
  Swift side and the JS package cannot disagree about the name; the loaders use
  it instead of a literal.
- `BoundModel.download` now takes a progress closure (the concrete models already
  had one with a default), which both gives wasm real download progress through
  the shared ABI and deletes each model's forwarding shim.

## Behavior changes (all improvements)

- The self-hosted browser session is built through the tracked session factory
  with the model's SDK identity. Previously Emo's went through
  `inferenceSession(hostGlobal:)` with the default identity and Redact's used a
  raw `JSInferenceSession`, i.e. untracked - so `modelBaseUrl` users were
  mis-attributed or invisible.
- The browser build gains call groups (`withCallGroup`), per-call `deviceId`, and
  a real `dispose()` (it was a no-op), matching the native entry. The `.d.ts`
  files no longer say "native Node build only" for those.
- `browserSetup`/`nodeSetup` take `modelId` instead of `exportsGlobal` and return
  the registered core; `wasmExports(modelId)` resolves it directly. npm core
  bumped to 0.7.0 (breaking seam) and both packages pinned to it.

## Verification

Local box OOMs building swift-syntax, so the Swift work was verified on
pv-studio:

- `swift build`, `swift build --swift-sdk ..._wasm --product EmoWeb --product
  RedactWeb`, and `swift test`: 79/81 pass; the 2 failures are the pre-existing
  `HTTPClientTests` ones that need the local echo server `mise run test-macos`
  starts.
- End-to-end through the **real** `packages/emo-node/browser.js` in Node with the
  built wasm and a fake `@litertjs/core` (LiteRT.js cannot initialize outside a
  browser, so only it is faked): the model downloads from the Hub through the
  wasm store with progress, `run` round-trips the options/result payloads,
  `limit`/`skinTone` are honored, ranking holds, empty input short-circuits, call
  groups and device ids pass through, `dispose()` invalidates the handle, and a
  second suggester loads from cache without downloading.
- Same harness for the `modelBaseUrl` path: files served over localhost, the host
  compiles the model itself, `createSelfHosted` takes only the sidecars, and
  junk files return a null handle instead of a broken model.
- `node --test js/test/*.test.mjs`: 19/19 (4 new, covering the registry seam).

Also added `mise run build-wasm-entries` and a step in `wasi.yml`: `test-wasi`
builds test targets only, so the model wasm entry points were never compiled in
this repo's CI.

## Follow-ups

The next slice is collapsing `browser.js`/`node.js` themselves into a shared
`createModelSdk` in `@desert-ant-labs/core` (now that both cores expose the same
shape, the two entries differ only in which core they bind), then the Swift SDK
shell and the Kotlin handle base.
