### PR TITLE
Write a model package's SDK once, not once per runtime

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -3,8 +3,8 @@
 Shared JavaScript runtime for [Desert Ant Labs](https://desertant.com) on-device
 model SDKs. The per-model node packages (`@desert-ant-labs/shapes`,
 `@desert-ant-labs/emo`, `@desert-ant-labs/redact`, ...) build their browser and
-Node entries on these model-agnostic pieces, so each model ships only its own
-decode + public API.
+Node entries on these model-agnostic pieces, so each model ships only its payload
+codecs and its public class - both entry points are a couple of lines of wiring.
 
 Not meant to be used directly; it is the common core the model packages depend
 on.
@@ -13,13 +13,23 @@ on.
 
 Browser-safe entry (`@desert-ant-labs/core`, no `node:*`):
 
+- `createWasmSdk({ platform, packageName, modelId, hostGlobal, files })` - the
+  whole browser/WebAssembly half of a model package: instantiate the core through
+  the package's `#platform` seam, set up the LiteRT.js session, then
+  `open(options)` either downloads the model from the Hub or adopts the files a
+  `modelBaseUrl` serves, and returns a ready `LoadedModel`.
+- `LoadedModel` - a loaded model behind an opaque core handle: `run(text,
+  options, { group, deviceId })` returning an `FfiReader`, plus `isDownloaded`,
+  `withCallGroup`, and `dispose`. The same object on both runtimes, so a package
+  writes its public class once.
 - `installLiteRtHost(...)` - installs the LiteRT.js host the wasm core drives
   through `globalThis[hostGlobal]`: named-tensor `createSession` / `run` with the
   correct dtype marshalling and LiteRT.js manual memory management.
 - `loadLiteRt(...)` / `assertBrowserRuntime(...)` - load `@litertjs/core` once
   per process (with an install hint) and guard against running the wasm runtime
   in plain Node.
-- `fetchModelFrom(baseUrl, files)` - the self-hosted (`modelBaseUrl`) opt-out.
+- `fetchSelfHostedModel(baseUrl, files)` - fetch the files a `modelBaseUrl`
+  serves: sidecars keyed by catalog name, artifact bytes for the host to compile.
 - `browserSetup` / `browserWasmDir` / `browserReadModelSource` /
   `browserCacheRoot` - the browser half of a model's `#platform` seam.
 - `wasmExports(modelId)` - the model-agnostic WebAssembly ABI a Swift core
@@ -35,10 +45,13 @@ Browser-safe entry (`@desert-ant-labs/core`, no `node:*`):
 
 Node entry (`@desert-ant-labs/core/node`, uses `node:*` + koffi):
 
-- `loadNative({ here, packageName, coreName, symbols })` - resolves the prebuilt
-  Swift core under `native/<platform>-<arch>`, loads the LiteRT runtime first,
-  binds the model's C ABI with koffi, and returns `callAsync` + `decodeResult` +
-  cache-path helpers.
+- `createNativeSdk({ here, packageName, modelId })` - the native half of a model
+  package, mirroring `createWasmSdk`: binds the prebuilt core and returns an SDK
+  whose `open(options)` yields the same `LoadedModel`.
+- `loadNative({ here, packageName, coreName, symbols })` - the loader under it:
+  resolves the prebuilt Swift core under `native/<platform>-<arch>`, loads the
+  LiteRT runtime first, binds the `dal_*` C ABI with koffi, and returns
+  `callAsync` + `decodeResult` + cache-path helpers.
 - `nodeSetup` / `nodeWasmDir` / `nodeReadModelSource` / `nodeCacheRoot` - the
   Node half of the `#platform` seam.
 

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -50,10 +50,99 @@ export function installLiteRtHost(options: {
   readModelSource: (source: any) => Promise<any>;
 }): { setModel: (model: any) => void };
 
-export function fetchModelFrom(
+/** Names a `modelBaseUrl` must serve, as in the model catalog. */
+export interface ModelFileNames {
+  /** The runnable artifact, compiled by the host (never crosses into the core). */
+  model: string;
+  /** Sidecars handed to the core, keyed by these names. */
+  sidecars: string[];
+}
+
+export function fetchSelfHostedModel(
   baseUrl: string,
-  files: { meta: string; model: string },
-): Promise<{ metaJSON: string; modelBytes: Uint8Array }>;
+  files: ModelFileNames,
+): Promise<{ sidecars: Record<string, Uint8Array>; modelBytes: Uint8Array }>;
+
+/** How a call is billed and attributed. */
+export interface CallOptions {
+  /** Bills this call as part of a group from {@link LoadedModel.withCallGroup}. */
+  group?: string;
+  /** Attributes usage to an end-user device; resolved per call. */
+  deviceId?: string | (() => string);
+}
+
+/** A loaded model behind an opaque core handle: what a model package's public
+ *  class delegates to, identical on both runtimes. */
+export class LoadedModel {
+  run(text: string, options: Uint8Array, call?: CallOptions): Promise<FfiReader>;
+  isDownloaded(): boolean;
+  withCallGroup<T>(body: (group: string) => Promise<T>): Promise<T>;
+  dispose(): void;
+}
+
+/** How a model is loaded, shared by both runtimes. A model package extends this
+ *  with its own inference options. */
+export interface ModelLoadOptions {
+  directory?: string;
+  modelBaseUrl?: string;
+  cacheRoot?: string;
+  onProgress?: (fraction: number) => void;
+  litert?: unknown;
+  litertWasmDir?: string;
+  accelerator?: "wasm" | "webgpu" | "webnn";
+}
+
+/** A bound SDK: `open(options)` resolves the model and returns it ready. */
+export interface ModelSdk {
+  core: NormalizedCore;
+  open(options?: ModelLoadOptions): Promise<LoadedModel>;
+}
+
+/** Either core, normalized to what {@link LoadedModel} drives. */
+export interface NormalizedCore {
+  create(cacheRoot: string, directory: string | null): number;
+  createSelfHosted?(files: Record<string, Uint8Array>): number;
+  isDownloaded(handle: number): boolean;
+  download(handle: number, onProgress?: (fraction: number) => void): Promise<void | boolean>;
+  run(
+    handle: number,
+    text: string,
+    options: Uint8Array | null,
+    group: string | null,
+    deviceId: string | null,
+  ): Promise<FfiReader>;
+  destroy(handle: number): void;
+  withCallGroup<T>(body: (group: string) => Promise<T>): Promise<T>;
+}
+
+/** Wrap the WebAssembly ABI in the normalized core shape. */
+export function wasmCore(exports: WasmCore): NormalizedCore;
+
+/** Download/load a fresh handle and wrap it, so `load()` surfaces failures. */
+export function readyModel(options: {
+  core: NormalizedCore;
+  packageName: string;
+  handle: number;
+  onProgress?: (fraction: number) => void;
+}): Promise<LoadedModel>;
+
+/** The browser/WebAssembly half of a model package: instantiate the core through
+ *  the package's `#platform` seam and return a bound SDK. */
+export function createWasmSdk(options: {
+  platform: any;
+  packageName: string;
+  modelId: string;
+  hostGlobal: string;
+  files: ModelFileNames;
+}): Promise<ModelSdk>;
+
+/** Mint a call-group id, run the body, release the group. */
+export function makeCallGroups(endGroup: (id: string) => void): {
+  withCallGroup: <T>(body: (group: string) => Promise<T>) => Promise<T>;
+};
+
+/** The generic C prototype every SDK core exports to release a call group. */
+export const CALL_GROUP_END_SYMBOL: string;
 
 /** The model-agnostic WebAssembly ABI a Desert Ant core installs, the twin of
  *  the native `dal_*` symbols. Handles are opaque numbers. */

--- a/js/index.js
+++ b/js/index.js
@@ -1,14 +1,18 @@
 // @desert-ant-labs/core: shared JavaScript runtime for Desert Ant Labs on-device
-// model SDKs. This entry is browser-safe (no `node:*`): the LiteRT.js host and
+// model SDKs. This entry is browser-safe (no `node:*`): the shared model-SDK
+// runtime (load / run / dispose over either core), the LiteRT.js host and
 // session contract, the LiteRT loader/guards, the self-hosted-model fetch
-// helper, the browser platform seam, and the FFI reader. The node-only native
-// loader and node platform seam live in the "./node" subpath.
+// helper, the browser platform seam, and the FFI codecs. The node-only native
+// loader, native SDK factory, and node platform seam live in the "./node"
+// subpath.
 export { FfiReader, FfiWriter } from "./src/ffi.js";
+export { makeCallGroups, CALL_GROUP_END_SYMBOL } from "./src/callgroup.js";
+export { createWasmSdk, LoadedModel, readyModel, wasmCore } from "./src/sdk.js";
 export {
   loadLiteRt,
   assertBrowserRuntime,
   installLiteRtHost,
-  fetchModelFrom,
+  fetchSelfHostedModel,
   browserSetup,
   wasmExports,
   browserWasmDir,

--- a/js/node.d.ts
+++ b/js/node.d.ts
@@ -35,6 +35,16 @@ export function loadNative(options: {
   targets?: string[];
 }): NativeCore;
 
+/** The native (server-side Node) half of a model package: bind the prebuilt
+ *  Swift core with koffi and return a bound SDK with the same shape as
+ *  `createWasmSdk`, so a package's public class is written once. */
+export function createNativeSdk(options: {
+  here: string;
+  packageName: string;
+  modelId: string;
+  coreName?: string;
+}): import("./index.js").ModelSdk;
+
 export function nodeSetup(options: {
   hostGlobal: string;
   modelId: string;

--- a/js/node.js
+++ b/js/node.js
@@ -1,7 +1,9 @@
 // @desert-ant-labs/core/node: the node-only pieces for a model package's native
-// server-side entry. The native koffi loader (loadNative, callAsync,
-// decodeResult) plus the node half of the platform seam. Importing this pulls in
-// `node:*`, so browser bundles must import from "@desert-ant-labs/core" instead.
+// server-side entry. The native SDK factory (createNativeSdk) and the koffi
+// loader under it (loadNative, callAsync, decodeResult), plus the node half of
+// the platform seam. Importing this pulls in `node:*`, so browser bundles must
+// import from "@desert-ant-labs/core" instead.
+export { createNativeSdk } from "./src/native-sdk.js";
 export { loadNative, DAL_SYMBOLS, DEFAULT_CORE_NAME } from "./src/native.js";
 export { makeCallGroups, CALL_GROUP_END_SYMBOL } from "./src/callgroup.js";
 export {

--- a/js/src/litert.js
+++ b/js/src/litert.js
@@ -147,21 +147,29 @@ export function installLiteRtHost({ hostGlobal, accelerator = "wasm", loadAndCom
 }
 
 /**
- * Fetch self-hosted model files from a base URL (the `modelBaseUrl` opt-out).
- * Accepts absolute URLs and root-relative paths (e.g. "/assets/shapes/").
+ * Fetch model files an app serves itself (the `modelBaseUrl` option). Accepts
+ * absolute URLs and root-relative paths (e.g. "/assets/shapes/").
+ *
+ * The sidecars come back keyed by their catalog file names, which is what the
+ * wasm core's `createSelfHosted` expects; text sidecars stay bytes because the
+ * Swift side decodes them itself. The model bytes stay here, for the caller to
+ * compile in LiteRT.js: the multi-MB artifact never crosses into wasm.
  *
  * @param {string} baseUrl
- * @param {{ meta: string, model: string }} files file names under baseUrl,
- *   e.g. { meta: "shapes_meta.json", model: "shapes.tflite" }
- * @returns {Promise<{ metaJSON: string, modelBytes: Uint8Array }>}
+ * @param {{ model: string, sidecars: string[] }} files names under baseUrl, e.g.
+ *   { model: "shapes.tflite", sidecars: ["shapes_meta.json"] }
+ * @returns {Promise<{ sidecars: Record<string, Uint8Array>, modelBytes: Uint8Array }>}
  */
-export async function fetchModelFrom(baseUrl, files) {
+export async function fetchSelfHostedModel(baseUrl, files) {
   const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
-  const [meta, model] = await Promise.all([
-    fetch(`${base}${files.meta}`).then((r) => r.text()),
-    fetch(`${base}${files.model}`).then((r) => r.arrayBuffer()),
+  const get = async (name) => new Uint8Array(await fetch(`${base}${name}`).then((r) => r.arrayBuffer()));
+  const [modelBytes, ...sidecarBytes] = await Promise.all([
+    get(files.model),
+    ...files.sidecars.map(get),
   ]);
-  return { metaJSON: meta, modelBytes: new Uint8Array(model) };
+  const sidecars = {};
+  files.sidecars.forEach((name, i) => { sidecars[name] = sidecarBytes[i]; });
+  return { sidecars, modelBytes };
 }
 
 // ------------------------------------------------------------- browser seam

--- a/js/src/native-sdk.js
+++ b/js/src/native-sdk.js
@@ -1,0 +1,67 @@
+// The native (server-side Node) half of a model package, mirroring
+// `createWasmSdk`: bind the prebuilt Swift core with koffi, normalize its
+// `dal_*` symbols to the core shape `LoadedModel` uses, and hand back an
+// `open(options)` that returns a ready model.
+//
+// The normalization is the whole point: after it, a package's native entry and
+// its browser entry drive an identical object, so the public class is written
+// once per model instead of once per runtime.
+//
+// Node-only (loadNative uses node:* + koffi).
+import { loadNative } from "./native.js";
+import { readyModel } from "./sdk.js";
+
+/**
+ * @param {object} o
+ * @param {string} o.here directory of the package's node.js (import.meta dir)
+ * @param {string} o.packageName consumer package (for error messages)
+ * @param {string} o.modelId catalog id, e.g. "emo"
+ * @param {string} [o.coreName] C core base name; defaults to "DesertAntNode"
+ */
+export function createNativeSdk({ here, packageName, modelId, coreName }) {
+  // The prebuilt native for this host lives in native/<platform>-<arch>/ next to
+  // the package's node.js (built by `mise run node-natives`): the self-contained
+  // Swift core (one library for every model) plus the LiteRT runtime it links.
+  // The symbol table is the shared `dal_*` ABI, so no symbol is named here.
+  const native = loadNative({ here, packageName, coreName });
+  const { lib, callAsync, decodeResult, withCallGroup } = native;
+
+  const core = {
+    // Managed nested cache under ~/.cache by default (matching the browser
+    // host); an explicit `directory` is adopted when it holds the files, else
+    // downloaded into.
+    create: (cacheRoot, directory) => lib.create(modelId, cacheRoot, directory || null),
+    isDownloaded: (handle) => lib.isDownloaded(handle) !== 0,
+    async download(handle, onProgress) {
+      // The C ABI has no progress channel: report the endpoints so a caller's
+      // onProgress behaves the same on both runtimes.
+      if (this.isDownloaded(handle)) return;
+      onProgress?.(0);
+      const rc = await callAsync(lib.download, handle);
+      if (rc !== 0) throw new Error("the native core reported a download failure");
+    },
+    async run(handle, text, options, group, deviceId) {
+      const payload = options ?? new Uint8Array();
+      const ptr = await callAsync(
+        lib.run, handle, text, payload, payload.length, group, deviceId);
+      if (!ptr) throw new Error(`${packageName}: the model failed to run`);
+      try {
+        return decodeResult(ptr);
+      } finally {
+        lib.bufferFree(ptr);
+      }
+    },
+    destroy: (handle) => lib.destroy(handle),
+    withCallGroup,
+  };
+
+  return {
+    core,
+    async open(options = {}) {
+      const onProgress = typeof options.onProgress === "function" ? options.onProgress : undefined;
+      const cacheRoot = options.cacheRoot ?? native.defaultCacheRoot();
+      const handle = core.create(cacheRoot, options.directory ?? null);
+      return readyModel({ core, packageName, handle, onProgress });
+    },
+  };
+}

--- a/js/src/sdk.js
+++ b/js/src/sdk.js
@@ -1,0 +1,175 @@
+// The shared model-SDK runtime: one implementation of "load a model, run it,
+// dispose it" for both cores a Desert Ant package ships.
+//
+// The two cores now expose the same surface - the WebAssembly ABI installed by
+// Swift's WasmBindings and the native `dal_*` C ABI bound with koffi - so the
+// only difference between a package's browser entry and its native entry is
+// which core it binds and, for the browser, the LiteRT.js session it has to set
+// up first. Everything after that (create or adopt, download with progress,
+// encode options, run, decode, group calls, dispose) is identical for every
+// model on every runtime, so it lives here once.
+//
+// A model package is then: its payload codecs, its public class over
+// `LoadedModel`, and two lines of wiring per entry point.
+import { makeCallGroups } from "./callgroup.js";
+import { FfiReader } from "./ffi.js";
+import {
+  assertBrowserRuntime,
+  fetchSelfHostedModel,
+  installLiteRtHost,
+  loadLiteRt,
+} from "./litert.js";
+
+/**
+ * A loaded model behind an opaque core handle: the object a package's public
+ * class delegates to. `core` is a normalized core (see `wasmCore` /
+ * `createNativeSdk`), so this class never knows which runtime it is on.
+ */
+export class LoadedModel {
+  #core;
+  #packageName;
+  #handle;
+
+  constructor({ core, packageName, handle }) {
+    this.#core = core;
+    this.#packageName = packageName;
+    this.#handle = handle;
+  }
+
+  /**
+   * Run the model over `text` with the model's own options payload, returning an
+   * `FfiReader` over its result payload for the caller's decoder.
+   *
+   * @param {string} text
+   * @param {Uint8Array} options the model's encoded options
+   * @param {{ group?: string, deviceId?: string | (() => string) }} [call]
+   */
+  async run(text, options, call = {}) {
+    if (this.#handle == null) throw new Error(`${this.#packageName}: model disposed`);
+    const group = call.group != null ? String(call.group) : null;
+    const deviceId = typeof call.deviceId === "function" ? call.deviceId() : call.deviceId;
+    return this.#core.run(
+      this.#handle, text, options, group, deviceId != null ? String(deviceId) : null);
+  }
+
+  /** Whether the model is usable with no network. */
+  isDownloaded() {
+    return this.#handle != null && this.#core.isDownloaded(this.#handle);
+  }
+
+  /**
+   * Run `body(group)` with a fresh call-group id, so every call inside that
+   * passes `{ group }` bills as a single usage call. Released when `body`
+   * settles.
+   */
+  withCallGroup(body) {
+    return this.#core.withCallGroup(body);
+  }
+
+  /** Release the model. Calls afterwards throw. */
+  dispose() {
+    if (this.#handle == null) return;
+    this.#core.destroy(this.#handle);
+    this.#handle = null;
+  }
+}
+
+/**
+ * Turn a fresh handle into a ready `LoadedModel`: download and load the model
+ * now (a no-op when it is already available), so the first call is instant and
+ * `load()` surfaces a download failure instead of the first inference doing so.
+ */
+export async function readyModel({ core, packageName, handle, onProgress }) {
+  if (!handle) throw new Error(`${packageName}: failed to create the model`);
+  const model = new LoadedModel({ core, packageName, handle });
+  try {
+    await core.download(handle, onProgress);
+  } catch (cause) {
+    model.dispose();
+    throw new Error(`${packageName}: model download failed: ${cause}`, { cause });
+  }
+  onProgress?.(1);
+  return model;
+}
+
+/**
+ * Normalize the WebAssembly ABI (`globalThis.__DesertAntExports[modelId]`) to
+ * the core shape `LoadedModel` uses: a run that yields an `FfiReader`, plus the
+ * call-group helper.
+ */
+export function wasmCore(exports) {
+  return {
+    create: (cacheRoot, directory) => exports.create(cacheRoot, directory),
+    createSelfHosted: (files) => exports.createSelfHosted(files),
+    isDownloaded: (handle) => exports.isDownloaded(handle),
+    download: (handle, onProgress) => exports.download(handle, onProgress),
+    run: async (handle, text, options, group, deviceId) =>
+      new FfiReader(await exports.run(handle, text, options ?? null, group, deviceId)),
+    destroy: (handle) => exports.destroy(handle),
+    ...makeCallGroups((id) => exports.endCallGroup(id)),
+  };
+}
+
+/**
+ * The browser/WebAssembly half of a model package: instantiate the core through
+ * the package's `#platform` seam, then hand back an `open(options)` that
+ * resolves the model and returns a ready `LoadedModel`.
+ *
+ * Both load paths live here because neither is model-specific: the default
+ * downloads this platform's files from the Hub (verified and cached by the Swift
+ * core), and `modelBaseUrl` fetches files the app serves itself, compiles the
+ * model in LiteRT.js, and passes only the sidecars into wasm - the browser's
+ * equivalent of pointing a native SDK at a directory that already holds the
+ * model.
+ *
+ * @param {object} o
+ * @param {any} o.platform the package's `#platform` module
+ * @param {string} o.packageName consumer package (for error messages)
+ * @param {string} o.modelId catalog id, e.g. "emo"
+ * @param {string} o.hostGlobal e.g. "__EmoHost"
+ * @param {{ model: string, sidecars: string[] }} o.files names under a
+ *   `modelBaseUrl`, as in the model catalog
+ */
+export async function createWasmSdk({ platform, packageName, modelId, hostGlobal, files }) {
+  // The core instantiates at import time (the package's entry top-level awaits
+  // this); the model is only wired in open().
+  const core = wasmCore(await platform.setupCore());
+
+  return {
+    core,
+    async open(options = {}) {
+      assertBrowserRuntime({ packageName, litert: options.litert });
+      const lrt = await loadLiteRt({
+        litert: options.litert,
+        wasmDir: options.litertWasmDir,
+        defaultWasmDir: platform.defaultWasmDir,
+        packageName,
+      });
+      const accelerator = options.accelerator ?? "wasm";
+      // Generic tensor I/O with the wasm core (JSInferenceSession): the core
+      // installs the host and manages tensor memory; setModel lets the
+      // modelBaseUrl branch feed the same run() closure.
+      const { setModel } = installLiteRtHost({
+        hostGlobal,
+        accelerator,
+        loadAndCompile: lrt.loadAndCompile,
+        Tensor: lrt.Tensor,
+        readModelSource: platform.readModelSource,
+      });
+
+      const onProgress = typeof options.onProgress === "function" ? options.onProgress : undefined;
+      let handle;
+      if (options.modelBaseUrl != null) {
+        const { sidecars, modelBytes } = await fetchSelfHostedModel(options.modelBaseUrl, files);
+        setModel(await lrt.loadAndCompile(modelBytes, { accelerator }));
+        handle = core.createSelfHosted(sidecars);
+      } else {
+        // `directory` (node) adopts a folder you populated. Base for the managed
+        // nested cache (node): ~/.cache; empty (in-memory) in the browser.
+        const cacheRoot = options.cacheRoot ?? (await platform.defaultCacheRoot());
+        handle = core.create(cacheRoot, options.directory ?? "");
+      }
+      return readyModel({ core, packageName, handle, onProgress });
+    },
+  };
+}

--- a/js/test/entries.test.mjs
+++ b/js/test/entries.test.mjs
@@ -9,8 +9,12 @@ test("browser-safe entry exports the expected surface", async () => {
     "loadLiteRt",
     "assertBrowserRuntime",
     "installLiteRtHost",
-    "fetchModelFrom",
+    "fetchSelfHostedModel",
+    "createWasmSdk",
+    "readyModel",
+    "wasmCore",
     "browserSetup",
+    "wasmExports",
     "browserWasmDir",
     "browserReadModelSource",
     "browserCacheRoot",
@@ -22,6 +26,7 @@ test("browser-safe entry exports the expected surface", async () => {
 test("node entry exports the native loader + node seam", async () => {
   const node = await import("../node.js");
   for (const name of [
+    "createNativeSdk",
     "loadNative",
     "nodeSetup",
     "nodeWasmDir",

--- a/js/test/litert.test.mjs
+++ b/js/test/litert.test.mjs
@@ -4,7 +4,7 @@ import {
   installLiteRtHost,
   loadLiteRt,
   assertBrowserRuntime,
-  fetchModelFrom,
+  fetchSelfHostedModel,
 } from "../src/litert.js";
 
 // A fake LiteRT.js: records compiled models and tensor lifecycle so we can
@@ -90,22 +90,29 @@ test("assertBrowserRuntime throws in plain Node, passes with injected litert", (
   assert.doesNotThrow(() => assertBrowserRuntime({ packageName: "@x/y", litert: {} }));
 });
 
-test("fetchModelFrom fetches the configured file names and normalizes the base", async () => {
+test("fetchSelfHostedModel fetches the catalog file names and normalizes the base", async () => {
   const seen = [];
   const orig = globalThis.fetch;
   globalThis.fetch = async (url) => {
     seen.push(url);
-    if (url.endsWith(".json")) return { text: async () => '{"ok":true}' };
-    return { arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer };
+    const byte = url.endsWith(".tflite") ? 9 : 1;
+    return { arrayBuffer: async () => new Uint8Array([byte, byte, byte]).buffer };
   };
   try {
-    const { metaJSON, modelBytes } = await fetchModelFrom("/assets/shapes", {
-      meta: "shapes_meta.json",
+    const { sidecars, modelBytes } = await fetchSelfHostedModel("/assets/shapes", {
       model: "shapes.tflite",
+      sidecars: ["shapes_meta.json", "shapes_tokenizer.bin"],
     });
-    assert.equal(metaJSON, '{"ok":true}');
-    assert.deepEqual(Array.from(modelBytes), [1, 2, 3]);
-    assert.deepEqual(seen.sort(), ["/assets/shapes/shapes.tflite", "/assets/shapes/shapes_meta.json"]);
+    assert.deepEqual(Array.from(modelBytes), [9, 9, 9]);
+    // Sidecars come back keyed by catalog name, as bytes: the core decodes the
+    // text ones itself, so the caller needs no per-file handling.
+    assert.deepEqual(Object.keys(sidecars).sort(), ["shapes_meta.json", "shapes_tokenizer.bin"]);
+    assert.ok(sidecars["shapes_meta.json"] instanceof Uint8Array);
+    assert.deepEqual(seen.sort(), [
+      "/assets/shapes/shapes.tflite",
+      "/assets/shapes/shapes_meta.json",
+      "/assets/shapes/shapes_tokenizer.bin",
+    ]);
   } finally {
     globalThis.fetch = orig;
   }

--- a/js/test/sdk.test.mjs
+++ b/js/test/sdk.test.mjs
@@ -1,0 +1,198 @@
+// The shared model-SDK runtime: load / run / group / dispose, written once for
+// both cores. Driven here through a fake core with the normalized shape, which
+// is exactly what `wasmCore` and `createNativeSdk` produce - so this covers the
+// logic every model package now inherits instead of hand-writing.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { LoadedModel, readyModel, wasmCore, createWasmSdk } from "../src/sdk.js";
+import { FfiReader, FfiWriter } from "../src/ffi.js";
+
+/** A core in the normalized shape, recording what it was asked to do. */
+function fakeCore({ downloaded = false, failDownload = false } = {}) {
+  const calls = [];
+  let live = new Set();
+  let next = 1;
+  return {
+    calls,
+    isLive: (h) => live.has(h),
+    create(cacheRoot, directory) {
+      calls.push(["create", cacheRoot, directory]);
+      const handle = next++;
+      live.add(handle);
+      return handle;
+    },
+    createSelfHosted(files) {
+      calls.push(["createSelfHosted", Object.keys(files).sort()]);
+      const handle = next++;
+      live.add(handle);
+      return handle;
+    },
+    isDownloaded: () => downloaded,
+    async download(handle, onProgress) {
+      calls.push(["download", handle]);
+      if (failDownload) throw new Error("network is down");
+      onProgress?.(0.5);
+    },
+    async run(handle, text, options, group, deviceId) {
+      calls.push(["run", handle, text, options, group, deviceId]);
+      return new FfiReader(new FfiWriter().str(`ran:${text}`).done());
+    },
+    destroy(handle) {
+      calls.push(["destroy", handle]);
+      live.delete(handle);
+    },
+    withCallGroup: async (body) => {
+      const id = "group-1";
+      calls.push(["groupStart", id]);
+      try { return await body(id); } finally { calls.push(["groupEnd", id]); }
+    },
+  };
+}
+
+test("readyModel downloads before returning, so load() surfaces failures", async () => {
+  const core = fakeCore();
+  const progress = [];
+  const model = await readyModel({
+    core, packageName: "@x/y", handle: core.create("/cache", ""),
+    onProgress: (f) => progress.push(f),
+  });
+  assert.deepEqual(core.calls.map((c) => c[0]), ["create", "download"]);
+  assert.deepEqual(progress, [0.5, 1], "progress ends at 1");
+  assert.ok(model instanceof LoadedModel);
+});
+
+test("a failed download disposes the handle and names the package", async () => {
+  const core = fakeCore({ failDownload: true });
+  const handle = core.create("/cache", "");
+  await assert.rejects(
+    () => readyModel({ core, packageName: "@desert-ant-labs/emo", handle }),
+    /@desert-ant-labs\/emo: model download failed.*network is down/s,
+  );
+  assert.equal(core.isLive(handle), false, "the handle is released, not leaked");
+});
+
+test("a null handle is a create failure, not a download attempt", async () => {
+  const core = fakeCore();
+  await assert.rejects(
+    () => readyModel({ core, packageName: "@x/y", handle: 0 }),
+    /@x\/y: failed to create the model/,
+  );
+  assert.deepEqual(core.calls, []);
+});
+
+test("run passes the options payload, group, and resolved device id through", async () => {
+  const core = fakeCore();
+  const model = await readyModel({ core, packageName: "@x/y", handle: core.create("/c", "") });
+  const options = new FfiWriter().u32(3).done();
+  const r = await model.run("hello", options, { group: 7, deviceId: () => "device-42" });
+  assert.equal(r.str(), "ran:hello");
+  const run = core.calls.find((c) => c[0] === "run");
+  assert.deepEqual(run.slice(2), ["hello", options, "7", "device-42"]);
+});
+
+test("dispose releases the handle once and makes later calls throw", async () => {
+  const core = fakeCore();
+  const model = await readyModel({ core, packageName: "@x/y", handle: core.create("/c", "") });
+  model.dispose();
+  model.dispose(); // idempotent
+  assert.equal(core.calls.filter((c) => c[0] === "destroy").length, 1);
+  await assert.rejects(() => model.run("x", new Uint8Array()), /@x\/y: model disposed/);
+});
+
+test("withCallGroup opens and releases a group around the body", async () => {
+  const core = fakeCore();
+  const model = await readyModel({ core, packageName: "@x/y", handle: core.create("/c", "") });
+  const seen = await model.withCallGroup(async (group) => {
+    await model.run("a", new Uint8Array(), { group });
+    return group;
+  });
+  assert.equal(seen, "group-1");
+  assert.deepEqual(
+    core.calls.map((c) => c[0]).filter((n) => n.startsWith("group") || n === "run"),
+    ["groupStart", "run", "groupEnd"],
+  );
+});
+
+test("wasmCore adapts the wasm ABI to the shared core shape", async () => {
+  const payload = new FfiWriter().str("hi").done();
+  const seen = [];
+  const core = wasmCore({
+    create: (...a) => { seen.push(["create", ...a]); return 5; },
+    createSelfHosted: () => 6,
+    isDownloaded: () => true,
+    download: async () => true,
+    run: async (...a) => { seen.push(["run", ...a]); return payload; },
+    endCallGroup: (id) => seen.push(["endCallGroup", id]),
+    destroy: (h) => seen.push(["destroy", h]),
+  });
+  core.create("/cache", "");
+  const reader = await core.run(5, "hi", null, null, null);
+  assert.equal(reader.str(), "hi", "run yields a reader over the payload");
+  await core.withCallGroup(async () => {});
+  assert.deepEqual(seen.map((c) => c[0]), ["create", "run", "endCallGroup"]);
+});
+
+// The wasm SDK's two load paths, with a fake `#platform` seam and LiteRT.js.
+function fakePlatform(exports) {
+  return {
+    setupCore: async () => exports,
+    defaultWasmDir: async () => "/wasm/",
+    readModelSource: async (s) => s,
+    defaultCacheRoot: async () => "/home/.cache",
+  };
+}
+
+function fakeExports() {
+  return {
+    create: (cacheRoot, directory) => (cacheRoot === "/home/.cache" && directory === "" ? 11 : 12),
+    createSelfHosted: () => 13,
+    isDownloaded: () => false,
+    download: async () => true,
+    run: async () => new FfiWriter().str("ok").done(),
+    endCallGroup: () => {},
+    destroy: () => {},
+  };
+}
+
+const litert = {
+  Tensor: class { delete() {} },
+  loadLiteRt: async () => {},
+  loadAndCompile: async () => ({ run: async () => ({}) }),
+};
+
+test("createWasmSdk downloads by default and adopts a directory when given one", async () => {
+  const sdk = await createWasmSdk({
+    platform: fakePlatform(fakeExports()), packageName: "@x/y",
+    modelId: "y", hostGlobal: "__YHost", files: { model: "y.tflite", sidecars: ["y.json"] },
+  });
+  const model = await sdk.open({ litert, litertWasmDir: "/wasm/" });
+  assert.equal(model.isDownloaded(), false);
+  // The LiteRT.js host is installed for the core to drive.
+  assert.equal(typeof globalThis.__YHost?.run, "function");
+  const withDirectory = await sdk.open({ litert, litertWasmDir: "/wasm/", directory: "/models/y" });
+  assert.ok(withDirectory instanceof LoadedModel);
+});
+
+test("createWasmSdk's modelBaseUrl path compiles the model and passes only sidecars", async () => {
+  const exports = fakeExports();
+  let sidecarNames;
+  exports.createSelfHosted = (files) => { sidecarNames = Object.keys(files); return 13; };
+  let compiled = 0;
+  const orig = globalThis.fetch;
+  globalThis.fetch = async () => ({ arrayBuffer: async () => new Uint8Array([1]).buffer });
+  try {
+    const sdk = await createWasmSdk({
+      platform: fakePlatform(exports), packageName: "@x/y",
+      modelId: "y", hostGlobal: "__YHost", files: { model: "y.tflite", sidecars: ["y.json"] },
+    });
+    await sdk.open({
+      litert: { ...litert, loadAndCompile: async () => { compiled += 1; return { run: async () => ({}) }; } },
+      litertWasmDir: "/wasm/",
+      modelBaseUrl: "/assets/y",
+    });
+  } finally {
+    globalThis.fetch = orig;
+  }
+  assert.equal(compiled, 1, "the host compiled the model itself");
+  assert.deepEqual(sidecarNames, ["y.json"], "the artifact never crosses into the core");
+});

--- a/packages/emo-node/browser.js
+++ b/packages/emo-node/browser.js
@@ -1,173 +1,30 @@
-// On-device emoji suggestion for JavaScript. This is the universal entry: it
-// resolves model assets, owns the LiteRT.js session (via @desert-ant-labs/core),
-// and exposes the public typed API (an `Emo` class with an async `load`
-// factory). It runs in the browser and, via the platform seam below,
-// server-side in Node (the Client-Component SSR pass frameworks render in Node),
-// both on the same WebAssembly + @litertjs/core (LiteRT.js) pipeline:
-// XNNPACK-accelerated CPU ("wasm") by default, with optional WebGPU in the
-// browser.
+// On-device emoji suggestion for JavaScript: the universal entry. It runs in the
+// browser and, via the platform seam, server-side in Node (the Client-Component
+// SSR pass frameworks render in Node), both on the same WebAssembly +
+// @litertjs/core (LiteRT.js) pipeline: XNNPACK-accelerated CPU ("wasm") by
+// default, with optional WebGPU in the browser.
 //
-// The WebAssembly core exposes the same model-agnostic ABI as the native core
-// (create / download / run / destroy, with options and results as FFI payloads),
-// so this file and node.js share `codec.js` and differ only in which core they
-// drive.
+// There is nothing model-specific left in the wiring: @desert-ant-labs/core owns
+// the LiteRT.js session, the Hub download, and the `modelBaseUrl` opt-out, and
+// the public API is `emo.js` (shared with the native entry). For a prebuilt
+// native server core (no @litertjs/core, best server throughput), import
+// `@desert-ant-labs/emo/native`.
 //
 // All node-only code lives behind the `#platform` import, which bundlers resolve
 // at build time by condition (browser -> platform-browser.js, otherwise
-// platform-node.js). That keeps this file free of `node:*` and of any static
-// reference to node-only chunks, so a single import builds cleanly for every
-// target of a multi-target bundler. For a prebuilt native server core (no
-// @litertjs/core, best server throughput), import `@desert-ant-labs/emo/native`.
-import { setupCore, defaultWasmDir, readModelSource, defaultCacheRoot } from "#platform";
-import { installLiteRtHost, loadLiteRt, assertBrowserRuntime, FfiReader } from "@desert-ant-labs/core";
-import {
-  PACKAGE_NAME, HOST_GLOBAL, MODEL_FILES, SKIN_TONES, encodeOptions, decodeSuggestions,
-} from "./codec.js";
+// platform-node.js), so this file never references `node:*` and one import
+// builds cleanly for every target of a multi-target bundler.
+import * as platform from "#platform";
+import { createWasmSdk } from "@desert-ant-labs/core";
+import { HOST_GLOBAL, MODEL_FILES, MODEL_ID, PACKAGE_NAME } from "./codec.js";
+import { makeEmo } from "./emo.js";
 
-// The wasm core instantiates at import time (top-level await); the model is
-// only wired in load(). The build-time-selected platform seam owns whatever is
-// node- or browser-specific about instantiation.
-const core = await setupCore();
-
-/**
- * On-device emoji suggestion. Create one with `await Emo.load(...)` and reuse
- * it, mirroring the iOS/Swift SDK.
- *
- * ```js
- * const emo = await Emo.load();                 // downloads the model on first use, cached
- * const suggestions = await emo.suggestions("Pay my bills");  // [{ emoji, confidence }, ...]
- * ```
- */
-export class Emo {
-  #handle;
-  constructor(handle) { this.#handle = handle; }
-
-  /**
-   * Load the model and return a ready suggester. By default the model is
-   * downloaded from the Hugging Face Hub at the pinned revision, verified, and
-   * cached by the runtime (Cache API / IndexedDB in the browser);
-   * @desert-ant-labs/core owns the LiteRT.js session behind the generic tensor
-   * contract (createSession + run). Pass a `modelBaseUrl` to fetch self-hosted
-   * files from your own origin (offline / no runtime CDN) instead. The repo and
-   * revision are pinned to the SDK.
-   */
-  static async load(options = {}) {
-    const resolved = options;
-    assertBrowserRuntime({ packageName: PACKAGE_NAME, litert: resolved.litert });
-    const lrt = await loadLiteRt({
-      litert: resolved.litert,
-      wasmDir: resolved.litertWasmDir,
-      defaultWasmDir,
-      packageName: PACKAGE_NAME,
-    });
-    const { loadAndCompile, Tensor } = lrt;
-    const accelerator = resolved.accelerator ?? "wasm";
-
-    // Generic tensor I/O with the WebAssembly runtime (JSInferenceSession): the
-    // emo tflite takes the n-gram/semantic int32/float32 inputs and returns a
-    // float32 `probabilities` tensor. @desert-ant-labs/core installs the host +
-    // manages tensor memory; setModel lets the modelBaseUrl branch feed the same
-    // run() closure.
-    const { setModel } = installLiteRtHost({
-      hostGlobal: HOST_GLOBAL,
-      accelerator,
-      loadAndCompile,
-      Tensor,
-      readModelSource,
-    });
-
-    const onProgress = typeof resolved.onProgress === "function" ? resolved.onProgress : undefined;
-    let handle;
-    if (resolved.modelBaseUrl != null) {
-      // Self-hosted files (offline / no runtime CDN): fetch the model + sidecars
-      // from the given base URL, compile the model here, and hand the sidecars
-      // to the wasm core, no Hub download. This is the browser's equivalent of
-      // pointing the native SDKs at a directory that already holds the model:
-      // nothing is bundled, nothing is downloaded.
-      const { sidecars, modelBytes } = await fetchModelFrom(resolved.modelBaseUrl);
-      setModel(await loadAndCompile(modelBytes, { accelerator }));
-      handle = core.createSelfHosted(sidecars);
-    } else {
-      // Default: the core downloads this platform's files from the HF Hub at the
-      // pinned tag (SHA-256 verified), fetched + cached by the JS host, and
-      // wires the session through the installed host. `directory` (node) adopts
-      // a folder you populated. Base for the managed nested cache (node):
-      // ~/.cache; empty (in-memory) in the browser.
-      handle = core.create(await defaultCacheRoot(), resolved.directory ?? "");
-    }
-    if (!handle) throw new Error(`${PACKAGE_NAME}: failed to create suggester`);
-    const emo = new Emo(handle);
-    // Ready the model now (downloading if needed) so the first suggestion is
-    // instant and load() surfaces any download error, as the native build does.
-    try {
-      await core.download(handle, onProgress);
-    } catch (cause) {
-      emo.dispose();
-      throw new Error(`${PACKAGE_NAME}: ${cause}`, { cause });
-    }
-    onProgress?.(1);
-    return emo;
-  }
-
-  /**
-   * Suggest emojis for a phrase, most likely first. Returns up to `limit`
-   * `{ emoji, confidence }` suggestions; empty input returns `[]`.
-   *
-   * `options.deviceId` (a string or a zero-arg function returning one)
-   * attributes usage to a specific end-user device. It is collected per call
-   * and bound to that call, so it is safe for concurrent multi-tenant hosts.
-   * `options.group` (an id from {@link withCallGroup}) bills several calls as
-   * one.
-   */
-  async suggestions(text, options = {}) {
-    if (!this.#handle) throw new Error(`${PACKAGE_NAME}: suggester disposed`);
-    const phrase = String(text ?? "");
-    if (phrase.trim() === "") return [];
-    const payload = encodeOptions({
-      limit: options.limit ?? 3,
-      skinTone: SKIN_TONES[options.skinTone ?? "default"] ?? 0,
-    });
-    const group = options.group != null ? String(options.group) : null;
-    const result = await core.run(this.#handle, phrase, payload, group, options.deviceId ?? null);
-    return decodeSuggestions(new FfiReader(result));
-  }
-
-  /**
-   * Run `body` with a call group, so every `suggestions({ group })` inside it
-   * bills as a single usage call rather than one per suggestion. The group is
-   * released when `body` settles.
-   */
-  async withCallGroup(body) {
-    const id = `emo-${Math.random().toString(36).slice(2)}-${Date.now()}`;
-    try {
-      return await body(id);
-    } finally {
-      core.endCallGroup(id);
-    }
-  }
-
-  /** Release the model. The suggester is unusable afterwards. */
-  dispose() {
-    if (this.#handle) { core.destroy(this.#handle); this.#handle = null; }
-  }
-}
-
-// Fetch self-hosted model files from a base URL (the `modelBaseUrl` opt-out).
-// Accepts absolute URLs and root-relative paths (e.g. "/assets/emo/"). The
-// sidecars go to the wasm core keyed by their catalog names; the model bytes
-// stay here and are compiled by LiteRT.js.
-async function fetchModelFrom(baseUrl) {
-  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
-  const [meta, tokenizer, model] = await Promise.all([
-    fetch(`${base}${MODEL_FILES.meta}`).then((r) => r.text()),
-    fetch(`${base}${MODEL_FILES.tokenizer}`).then((r) => r.arrayBuffer()),
-    fetch(`${base}${MODEL_FILES.model}`).then((r) => r.arrayBuffer()),
-  ]);
-  return {
-    sidecars: {
-      [MODEL_FILES.meta]: meta,
-      [MODEL_FILES.tokenizer]: new Uint8Array(tokenizer),
-    },
-    modelBytes: new Uint8Array(model),
-  };
-}
+// The wasm core instantiates at import time (top-level await); the model is only
+// wired in Emo.load().
+export const Emo = makeEmo(await createWasmSdk({
+  platform,
+  packageName: PACKAGE_NAME,
+  modelId: MODEL_ID,
+  hostGlobal: HOST_GLOBAL,
+  files: MODEL_FILES,
+}));

--- a/packages/emo-node/codec.js
+++ b/packages/emo-node/codec.js
@@ -16,11 +16,11 @@ export const PACKAGE_NAME = "@desert-ant-labs/emo";
  *  (matches `EmoModel.hostGlobal` in the Swift catalog). */
 export const HOST_GLOBAL = "__EmoHost";
 
-/** Sidecars + artifact under a `modelBaseUrl`, named as in the catalog. */
+/** What a `modelBaseUrl` must serve, named as in the catalog: the artifact the
+ *  host compiles itself, and the sidecars that cross into the core. */
 export const MODEL_FILES = {
-  meta: "emo_meta.json",
-  tokenizer: "emo_tokenizer.bin",
   model: "emo.tflite",
+  sidecars: ["emo_meta.json", "emo_tokenizer.bin"],
 };
 
 export const SKIN_TONES = {

--- a/packages/emo-node/emo.js
+++ b/packages/emo-node/emo.js
@@ -1,0 +1,70 @@
+// Emo's public API, over whichever core the entry point bound: the browser's
+// WebAssembly + LiteRT.js core (browser.js) or the prebuilt native core
+// (node.js). Both expose the same ABI, and @desert-ant-labs/core turns either
+// one into the same `LoadedModel`, so the API is written once here instead of
+// once per runtime.
+import { decodeSuggestions, encodeOptions, SKIN_TONES } from "./codec.js";
+
+/**
+ * Build the `Emo` class over a bound SDK (`createWasmSdk` / `createNativeSdk`).
+ * The entry points do nothing but call this.
+ */
+export function makeEmo(sdk) {
+  /**
+   * On-device multilingual emoji suggestion. Create one with
+   * `await Emo.load(...)` and reuse it, mirroring the iOS/Swift SDK.
+   *
+   * ```js
+   * const emo = await Emo.load();                 // downloads the model on first use, cached
+   * const suggestions = await emo.suggestions("Pay my bills");  // [{ emoji, confidence }, ...]
+   * emo.dispose();
+   * ```
+   */
+  return class Emo {
+    #model;
+    constructor(model) { this.#model = model; }
+
+    /**
+     * Load the model and return a ready suggester. By default the model is
+     * downloaded from the Hugging Face Hub at the pinned revision, verified, and
+     * cached (the filesystem under Node, the runtime's cache in the browser).
+     * Pass `directory` (Node) or `modelBaseUrl` (browser) to use files you host
+     * yourself. The repo and revision are pinned to the SDK.
+     */
+    static async load(options = {}) {
+      return new Emo(await sdk.open(options));
+    }
+
+    /**
+     * Suggest emojis for a phrase, most likely first. Returns up to `limit`
+     * `{ emoji, confidence }` suggestions; empty input returns `[]`.
+     *
+     * `options.deviceId` (a string or a zero-arg function returning one)
+     * attributes usage to a specific end-user device; it is collected per call,
+     * so it is safe for concurrent multi-tenant hosts. `options.group` (an id
+     * from {@link withCallGroup}) bills several calls as one.
+     */
+    async suggestions(text, options = {}) {
+      const phrase = String(text ?? "");
+      if (phrase.trim() === "") return [];
+      const payload = encodeOptions({
+        limit: options.limit ?? 3,
+        skinTone: SKIN_TONES[options.skinTone ?? "default"] ?? 0,
+      });
+      return decodeSuggestions(await this.#model.run(phrase, payload, options));
+    }
+
+    /** Whether the model is usable with no network. */
+    isDownloaded() { return this.#model.isDownloaded(); }
+
+    /**
+     * Run `body(group)` with a fresh call-group id, so every
+     * `suggestions({ group })` inside it bills as a single usage call. The group
+     * is released when `body` settles.
+     */
+    withCallGroup(body) { return this.#model.withCallGroup(body); }
+
+    /** Release the model. The suggester is unusable afterwards. */
+    dispose() { this.#model.dispose(); }
+  };
+}

--- a/packages/emo-node/node.js
+++ b/packages/emo-node/node.js
@@ -1,130 +1,23 @@
-// On-device multilingual emoji suggestion for JavaScript, server-side (Node).
-// This is the `node` conditional-exports entry: it runs the same Emo pipeline as
-// the browser build, but natively via the prebuilt Swift core (LiteRT under the
-// hood) instead of WebAssembly + LiteRT.js. Consumers just `import { Emo }` —
-// Node resolves this file, browsers resolve `browser.js`. No flags, no setup.
+// On-device emoji suggestion for JavaScript, server-side (Node). This is the
+// `node` conditional-exports entry: the same Emo API as the browser build, but
+// natively via the prebuilt Swift core (LiteRT/Core ML under the hood) instead
+// of WebAssembly + LiteRT.js. Consumers just `import { Emo }` - Node resolves
+// this file, browsers resolve `browser.js`. No flags, no setup.
 //
-// The koffi harness (resolve native/<platform>-<arch>, load the LiteRT runtime
-// first, bind the generic `dal_*` C ABI, run blocking calls off the event loop)
-// and the FFI codecs live in @desert-ant-labs/core/node; this file supplies only
-// Emo's public API; the payload schemas it shares with the browser entry live
-// in codec.js.
+// The koffi harness (resolve native/<platform>-<arch>, load the runtime, bind
+// the generic `dal_*` C ABI, run blocking calls off the event loop) lives in
+// @desert-ant-labs/core/node, and the public API is `emo.js`, shared with the
+// browser entry; this file only binds the two together.
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { loadNative } from "@desert-ant-labs/core/node";
-import { MODEL_ID, PACKAGE_NAME, SKIN_TONES, encodeOptions, decodeSuggestions } from "./codec.js";
+import { createNativeSdk } from "@desert-ant-labs/core/node";
+import { MODEL_ID, PACKAGE_NAME } from "./codec.js";
+import { makeEmo } from "./emo.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
-// The prebuilt native for this host lives in native/<platform>-<arch>/ next to
-// this file (built by `mise run node-natives`): the self-contained Swift core
-// (libDesertAntNode, one library for every model) plus the LiteRT runtime it
-// links (libLiteRt). The symbol table is the shared `dal_*` ABI, so it is the
-// loader's default and this call names no symbols.
-const core = loadNative({ here: HERE, packageName: PACKAGE_NAME });
-const { lib, callAsync, decodeResult, withCallGroup } = core;
-
-/**
- * On-device multilingual emoji suggestion. Create one with `await Emo.load(...)`
- * and reuse it, mirroring the browser SDK and the iOS/Swift SDK.
- *
- * ```js
- * const emo = await Emo.load();                        // downloads the model on first use, cached
- * const suggestions = await emo.suggestions("Pay my bills");  // [{ emoji, confidence }, ...]
- * emo.dispose();                                       // free the native handle when done
- * ```
- */
-export class Emo {
-  #handle;
-  constructor(handle) { this.#handle = handle; }
-
-  /**
-   * Load the model and return a ready suggester. By default the model is
-   * downloaded from the Hugging Face Hub at the pinned revision, SHA-256
-   * verified, and cached under the OS cache dir by the native core; the repo
-   * and revision are pinned to the SDK. Pass a `directory` to adopt self-hosted
-   * files (offline) instead of downloading.
-   *
-   * The server-side native runs LiteRT on Linux (from the `.tflite`) and Core ML
-   * on macOS (from the compiled `.mlmodelc` directory); the core downloads only
-   * this host's artifact and loads it by path - one primitive, both runtimes.
-   */
-  static async load(options = {}) {
-    const onProgress = typeof options.onProgress === "function" ? options.onProgress : undefined;
-    // Directory is null by default: the native core (built without the bundled-
-    // model trait) downloads into the single managed cache layout that
-    // desert-ant-core owns - <cacheRoot>/desert-ant-models/<repo>/<revision> -
-    // shared by every Desert Ant SDK and by the browser/wasm path. An explicit
-    // `directory` adopts a consumer-provided folder for offline use.
-    const cacheRoot = options.cacheRoot ?? core.defaultCacheRoot();
-    const directory = options.directory ?? null;
-    const handle = lib.create(MODEL_ID, cacheRoot, directory);
-    if (!handle) throw new Error(`${PACKAGE_NAME}: failed to create suggester`);
-    const emo = new Emo(handle);
-    // Ready the model now (download if needed) so the first suggestion is instant
-    // and load() surfaces any download error.
-    if (lib.isDownloaded(handle) === 0) {
-      onProgress?.(0);
-      const rc = await callAsync(lib.download, handle);
-      if (rc !== 0) { emo.dispose(); throw new Error(`${PACKAGE_NAME}: model download failed`); }
-    }
-    onProgress?.(1);
-    return emo;
-  }
-
-  /**
-   * Suggest emojis for `text`, most likely first. Returns up to `limit`
-   * `{ emoji, confidence }` suggestions; empty input returns `[]`.
-   *
-   * Usage is tracked automatically. By default each call is its own billed
-   * usage call. Pass `options.group` (an id from {@link withCallGroup}) to bill
-   * several calls as one — a logical operation made of multiple suggestions.
-   *
-   * Pass `options.deviceId` (a string, or a zero-arg function returning one) to
-   * attribute usage to a specific end-user device on multi-tenant hosts. It is
-   * collected per call and bound to that call, so it is safe under concurrency.
-   * Omit to attribute to the host device.
-   */
-  async suggestions(text, options = {}) {
-    if (!this.#handle) throw new Error(`${PACKAGE_NAME}: suggester disposed`);
-    const phrase = String(text ?? "");
-    if (phrase.trim() === "") return [];
-    const limit = options.limit ?? 3;
-    const skinTone = SKIN_TONES[options.skinTone ?? "default"] ?? 0;
-    const deviceId = typeof options.deviceId === "function" ? options.deviceId() : options.deviceId;
-    const group = options.group != null ? String(options.group) : null;
-    const payload = encodeOptions({ limit, skinTone });
-    const ptr = await callAsync(
-      lib.run, this.#handle, phrase, payload, payload.length, group,
-      deviceId != null ? String(deviceId) : null);
-    if (!ptr) throw new Error(`${PACKAGE_NAME}: suggestion failed`);
-    try {
-      return decodeSuggestions(decodeResult(ptr));
-    } finally {
-      lib.bufferFree(ptr);
-    }
-  }
-
-  /**
-   * Run `body` with a call group, so every `suggestions({ group })` inside it
-   * bills as a single usage call (rather than one per suggestion). Use it for a
-   * logical operation that issues several suggestions but should count once:
-   *
-   * ```js
-   * await emo.withCallGroup(async (group) => {
-   *   await emo.suggestions("a", { group });
-   *   await emo.suggestions("b", { group });  // same group -> counted as one call
-   * });
-   * ```
-   *
-   * The group is released when `body` settles.
-   */
-  withCallGroup(body) {
-    return withCallGroup(body);
-  }
-
-  /** Free the native handle. Call when you are done with the suggester. */
-  dispose() {
-    if (this.#handle) { lib.destroy(this.#handle); this.#handle = null; }
-  }
-}
+export const Emo = makeEmo(createNativeSdk({
+  here: HERE,
+  packageName: PACKAGE_NAME,
+  modelId: MODEL_ID,
+}));

--- a/packages/emo-node/package.json
+++ b/packages/emo-node/package.json
@@ -53,6 +53,7 @@
   "files": [
     "browser.js",
     "codec.js",
+    "emo.js",
     "node.js",
     "platform-browser.js",
     "platform-node.js",

--- a/packages/redact-node/browser.js
+++ b/packages/redact-node/browser.js
@@ -1,170 +1,30 @@
-// On-device multilingual PII redaction for JavaScript. This is the universal
-// entry: it resolves model assets, owns the LiteRT.js session (via
-// @desert-ant-labs/core), and exposes the public typed API (a `Redact` class
-// with an async `load` factory). It runs in the browser and, via the platform
-// seam below, server-side in Node (the Client-Component SSR pass frameworks
-// render in Node), both on the same WebAssembly + @litertjs/core (LiteRT.js)
-// pipeline: XNNPACK-accelerated CPU ("wasm") by default, with optional WebGPU in
-// the browser.
+// On-device multilingual PII redaction for JavaScript: the universal entry. It
+// runs in the browser and, via the platform seam, server-side in Node (the
+// Client-Component SSR pass frameworks render in Node), both on the same
+// WebAssembly + @litertjs/core (LiteRT.js) pipeline: XNNPACK-accelerated CPU
+// ("wasm") by default, with optional WebGPU in the browser.
 //
-// The WebAssembly core exposes the same model-agnostic ABI as the native core
-// (create / download / run / destroy, with options and results as FFI payloads),
-// so this file and node.js share `codec.js` and differ only in which core they
-// drive.
+// There is nothing model-specific left in the wiring: @desert-ant-labs/core owns
+// the LiteRT.js session, the Hub download, and the `modelBaseUrl` opt-out, and
+// the public API is `redact.js` (shared with the native entry). For a prebuilt
+// native server core (no @litertjs/core, best server throughput), import
+// `@desert-ant-labs/redact/native`.
 //
 // All node-only code lives behind the `#platform` import, which bundlers resolve
 // at build time by condition (browser -> platform-browser.js, otherwise
-// platform-node.js). That keeps this file free of `node:*` and of any static
-// reference to node-only chunks, so a single import builds cleanly for every
-// target of a multi-target bundler. For a prebuilt native server core (no
-// @litertjs/core, best server throughput), import `@desert-ant-labs/redact/native`.
-import { setupCore, defaultWasmDir, readModelSource, defaultCacheRoot } from "#platform";
-import { installLiteRtHost, loadLiteRt, assertBrowserRuntime, FfiReader } from "@desert-ant-labs/core";
-import {
-  PACKAGE_NAME, HOST_GLOBAL, MODEL_FILES, encodeOptions, decodeRedaction,
-} from "./codec.js";
+// platform-node.js), so this file never references `node:*` and one import
+// builds cleanly for every target of a multi-target bundler.
+import * as platform from "#platform";
+import { createWasmSdk } from "@desert-ant-labs/core";
+import { HOST_GLOBAL, MODEL_FILES, MODEL_ID, PACKAGE_NAME } from "./codec.js";
+import { makeRedact } from "./redact.js";
 
-// The wasm core instantiates at import time (top-level await); the model is
-// only wired in load(). The build-time-selected platform seam owns whatever is
-// node- or browser-specific about instantiation.
-const core = await setupCore();
-
-/**
- * On-device multilingual PII redaction. Create one with `await Redact.load(...)`
- * and reuse it, mirroring the iOS/Swift SDK.
- *
- * ```js
- * const redact = await Redact.load();               // download on demand, cached
- * const r = await redact.redaction("Email Anna at anna@example.com.");
- * r.redactedText; r.items; r.restore(reply);
- * ```
- */
-export class Redact {
-  #handle;
-  constructor(handle) { this.#handle = handle; }
-
-  /**
-   * Load the model and return a ready redactor. By default the runtime downloads
-   * the model from the Hugging Face Hub at the SDK's pinned tag (fetched +
-   * cached by the browser) and @desert-ant-labs/core owns the LiteRT.js session
-   * behind the generic tensor contract (createSession + run). Pass `modelBaseUrl`
-   * (a base URL you serve the files from) to self-host / run without the Hub.
-   * The repo and revision are pinned to the SDK.
-   */
-  static async load(options = {}) {
-    const resolved = options;
-    assertBrowserRuntime({ packageName: PACKAGE_NAME, litert: resolved.litert });
-    const lrt = await loadLiteRt({
-      litert: resolved.litert,
-      wasmDir: resolved.litertWasmDir,
-      defaultWasmDir,
-      packageName: PACKAGE_NAME,
-    });
-    const { loadAndCompile, Tensor } = lrt;
-    const accelerator = resolved.accelerator ?? "wasm";
-
-    // Generic tensor I/O with the WebAssembly runtime (JSInferenceSession): the
-    // redact tflite takes int32 input_ids + attention_mask and returns the token
-    // logits. @desert-ant-labs/core installs the host + manages tensor memory;
-    // setModel lets the modelBaseUrl branch feed the same run() closure.
-    const { setModel } = installLiteRtHost({
-      hostGlobal: HOST_GLOBAL,
-      accelerator,
-      loadAndCompile,
-      Tensor,
-      readModelSource,
-    });
-
-    const onProgress = typeof resolved.onProgress === "function" ? resolved.onProgress : undefined;
-    let handle;
-    if (resolved.modelBaseUrl != null) {
-      // Self-hosted files (offline / no runtime CDN): fetch the model + sidecars
-      // from the given base URL, compile the model here, and hand the sidecars
-      // to the wasm core, no Hub download. This is the browser's equivalent of
-      // pointing the native SDKs at a directory that already holds the model:
-      // nothing is bundled, nothing is downloaded.
-      const { sidecars, modelBytes } = await fetchModelFrom(resolved.modelBaseUrl);
-      setModel(await loadAndCompile(modelBytes, { accelerator }));
-      handle = core.createSelfHosted(sidecars);
-    } else {
-      // Default: the core downloads this platform's files from the HF Hub at the
-      // pinned tag (SHA-256 verified), fetched + cached by the JS host, and
-      // wires the session through the installed host. `directory` (node) adopts
-      // a folder you populated. Base for the managed nested cache (node):
-      // ~/.cache; empty (in-memory) in the browser.
-      handle = core.create(await defaultCacheRoot(), resolved.directory ?? "");
-    }
-    if (!handle) throw new Error(`${PACKAGE_NAME}: failed to create redactor`);
-    const redact = new Redact(handle);
-    // Ready the model now (downloading if needed) so the first redaction is
-    // instant and load() surfaces any download error, as the native build does.
-    try {
-      await core.download(handle, onProgress);
-    } catch (cause) {
-      redact.dispose();
-      throw new Error(`${PACKAGE_NAME}: ${cause}`, { cause });
-    }
-    onProgress?.(1);
-    return redact;
-  }
-
-  /**
-   * Detect and redact the PII in `text`. Each entity is replaced by a unique,
-   * numbered placeholder (`[EMAIL_1]`, ...), safe to hand to an LLM and restore
-   * afterwards via the returned `restore`.
-   *
-   * `options.deviceId` (a string or a zero-arg function returning one)
-   * attributes usage to a specific end-user device; `options.group` (an id from
-   * {@link withCallGroup}) bills several calls as one.
-   */
-  async redaction(text, options = {}) {
-    if (!this.#handle) throw new Error(`${PACKAGE_NAME}: redactor disposed`);
-    const payload = encodeOptions({
-      minimumConfidence: options.minimumConfidence ?? 0.6,
-      labels: options.labels ? Array.from(options.labels) : undefined,
-    });
-    const group = options.group != null ? String(options.group) : null;
-    const result = await core.run(
-      this.#handle, String(text ?? ""), payload, group, options.deviceId ?? null);
-    return decodeRedaction(new FfiReader(result));
-  }
-
-  /**
-   * Run `body` with a call group, so every `redaction({ group })` inside it
-   * bills as a single usage call rather than one per redaction. The group is
-   * released when `body` settles.
-   */
-  async withCallGroup(body) {
-    const id = `redact-${Math.random().toString(36).slice(2)}-${Date.now()}`;
-    try {
-      return await body(id);
-    } finally {
-      core.endCallGroup(id);
-    }
-  }
-
-  /** Release the model. The redactor is unusable afterwards. */
-  dispose() {
-    if (this.#handle) { core.destroy(this.#handle); this.#handle = null; }
-  }
-}
-
-// Fetch self-hosted model files from a base URL (the `modelBaseUrl` opt-out).
-// Accepts absolute URLs and root-relative paths (e.g. "/assets/redact/"). The
-// sidecars go to the wasm core keyed by their catalog names; the model bytes
-// stay here and are compiled by LiteRT.js.
-async function fetchModelFrom(baseUrl) {
-  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
-  const [tokenizer, labels, model] = await Promise.all([
-    fetch(`${base}${MODEL_FILES.tokenizer}`).then((r) => r.arrayBuffer()),
-    fetch(`${base}${MODEL_FILES.labels}`).then((r) => r.text()),
-    fetch(`${base}${MODEL_FILES.model}`).then((r) => r.arrayBuffer()),
-  ]);
-  return {
-    sidecars: {
-      [MODEL_FILES.tokenizer]: new Uint8Array(tokenizer),
-      [MODEL_FILES.labels]: labels,
-    },
-    modelBytes: new Uint8Array(model),
-  };
-}
+// The wasm core instantiates at import time (top-level await); the model is only
+// wired in Redact.load().
+export const Redact = makeRedact(await createWasmSdk({
+  platform,
+  packageName: PACKAGE_NAME,
+  modelId: MODEL_ID,
+  hostGlobal: HOST_GLOBAL,
+  files: MODEL_FILES,
+}));

--- a/packages/redact-node/codec.js
+++ b/packages/redact-node/codec.js
@@ -17,11 +17,11 @@ export const PACKAGE_NAME = "@desert-ant-labs/redact";
  *  (matches `RedactModel.hostGlobal` in the Swift catalog). */
 export const HOST_GLOBAL = "__RedactHost";
 
-/** Sidecars + artifact under a `modelBaseUrl`, named as in the catalog. */
+/** What a `modelBaseUrl` must serve, named as in the catalog: the artifact the
+ *  host compiles itself, and the sidecars that cross into the core. */
 export const MODEL_FILES = {
-  tokenizer: "redact_tokenizer.bin",
-  labels: "labels.json",
   model: "redact.tflite",
+  sidecars: ["redact_tokenizer.bin", "labels.json"],
 };
 
 /** Options payload: `f64 minimumConfidence`, then a `u32` label count and that

--- a/packages/redact-node/node.js
+++ b/packages/redact-node/node.js
@@ -1,111 +1,23 @@
 // On-device multilingual PII redaction for JavaScript, server-side (Node). This
-// is the `node` conditional-exports entry: it runs the same Redact pipeline as
-// the browser build, but natively via the prebuilt Swift core (LiteRT under the
-// hood) instead of WebAssembly + LiteRT.js. Consumers just `import { Redact }` —
+// is the `node` conditional-exports entry: the same Redact API as the browser
+// build, but natively via the prebuilt Swift core (LiteRT/Core ML under the
+// hood) instead of WebAssembly + LiteRT.js. Consumers just `import { Redact }` -
 // Node resolves this file, browsers resolve `browser.js`. No flags, no setup.
 //
-// The koffi harness (resolve native/<platform>-<arch>, load the LiteRT runtime
-// first, bind the generic `dal_*` C ABI, run blocking calls off the event loop)
-// and the FFI codecs live in @desert-ant-labs/core/node; this file supplies only
-// Redact's public API; the payload schemas it shares with the browser entry
-// live in codec.js.
+// The koffi harness (resolve native/<platform>-<arch>, load the runtime, bind
+// the generic `dal_*` C ABI, run blocking calls off the event loop) lives in
+// @desert-ant-labs/core/node, and the public API is `redact.js`, shared with the
+// browser entry; this file only binds the two together.
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { loadNative } from "@desert-ant-labs/core/node";
-import { MODEL_ID, PACKAGE_NAME, encodeOptions, decodeRedaction } from "./codec.js";
+import { createNativeSdk } from "@desert-ant-labs/core/node";
+import { MODEL_ID, PACKAGE_NAME } from "./codec.js";
+import { makeRedact } from "./redact.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
-// The prebuilt native for this host lives in native/<platform>-<arch>/ next to
-// this file (built by `mise run node-natives`): the self-contained Swift core
-// (libDesertAntNode, one library for every model) plus the LiteRT runtime it
-// links (libLiteRt). The symbol table is the shared `dal_*` ABI, so it is the
-// loader's default and this call names no symbols.
-const core = loadNative({ here: HERE, packageName: PACKAGE_NAME });
-const { lib, callAsync, decodeResult, withCallGroup } = core;
-
-/**
- * On-device multilingual PII redaction. Create one with `await Redact.load(...)`
- * and reuse it, mirroring the browser SDK and the iOS/Swift SDK.
- *
- * ```js
- * const redact = await Redact.load();                 // downloads the model on demand, cached
- * const r = await redact.redaction("Email Anna at anna@example.com.");
- * r.redactedText; r.items; r.restore(reply);
- * redact.dispose();                                   // free the native handle when done
- * ```
- */
-export class Redact {
-  #handle;
-  constructor(handle) { this.#handle = handle; }
-
-  /**
-   * Load the model and return a ready redactor. Download, SHA-256 verification,
-   * and caching are handled by the native core; the repo and revision are
-   * pinned to the SDK.
-   */
-  static async load(options = {}) {
-    // Managed nested cache under ~/.cache by default (matches the browser host);
-    // an explicit `directory` is adopted if it holds the files, else downloaded.
-    const cacheRoot = options.cacheRoot ?? core.defaultCacheRoot();
-    const directory = options.directory ?? null;
-    const handle = lib.create(MODEL_ID, cacheRoot, directory);
-    if (!handle) throw new Error(`${PACKAGE_NAME}: failed to create redactor`);
-    const redact = new Redact(handle);
-    // Ready the model now so the first redaction is instant and load() surfaces
-    // any download error, matching the browser's eager `load()`.
-    const onProgress = typeof options.onProgress === "function" ? options.onProgress : undefined;
-    if (lib.isDownloaded(handle) === 0) {
-      onProgress?.(0);
-      const rc = await callAsync(lib.download, handle);
-      if (rc !== 0) { redact.dispose(); throw new Error(`${PACKAGE_NAME}: model download failed`); }
-    }
-    onProgress?.(1);
-    return redact;
-  }
-
-  /**
-   * Detect and redact the PII in `text`. Each entity is replaced by a unique,
-   * numbered placeholder (`[EMAIL_1]`, ...), safe to hand to an LLM and restore
-   * afterwards via `Redaction.restore`.
-   *
-   * Usage is tracked automatically. By default each call is its own billed usage
-   * call. Pass `options.group` (an id from {@link withCallGroup}) to bill several
-   * calls as one, and `options.deviceId` (a string, or a zero-arg function
-   * returning one) to attribute usage to a specific end-user device on
-   * multi-tenant hosts.
-   */
-  async redaction(text, options = {}) {
-    if (!this.#handle) throw new Error(`${PACKAGE_NAME}: redactor disposed`);
-    const minimumConfidence = options.minimumConfidence ?? 0.6;
-    const deviceId = typeof options.deviceId === "function" ? options.deviceId() : options.deviceId;
-    const group = options.group != null ? String(options.group) : null;
-    const payload = encodeOptions({
-      minimumConfidence,
-      labels: options.labels ? Array.from(options.labels) : undefined,
-    });
-    const ptr = await callAsync(
-      lib.run, this.#handle, String(text ?? ""), payload, payload.length, group,
-      deviceId != null ? String(deviceId) : null);
-    if (!ptr) throw new Error(`${PACKAGE_NAME}: redaction failed`);
-    try {
-      return decodeRedaction(decodeResult(ptr));
-    } finally {
-      lib.bufferFree(ptr);
-    }
-  }
-
-  /**
-   * Run `body` with a call group, so every `redaction({ group })` inside it bills
-   * as a single usage call rather than one per redaction. The group is released
-   * when `body` settles.
-   */
-  withCallGroup(body) {
-    return withCallGroup(body);
-  }
-
-  /** Free the native handle. Call when you are done with the redactor. */
-  dispose() {
-    if (this.#handle) { lib.destroy(this.#handle); this.#handle = null; }
-  }
-}
+export const Redact = makeRedact(createNativeSdk({
+  here: HERE,
+  packageName: PACKAGE_NAME,
+  modelId: MODEL_ID,
+}));

--- a/packages/redact-node/package.json
+++ b/packages/redact-node/package.json
@@ -54,6 +54,7 @@
   "files": [
     "browser.js",
     "codec.js",
+    "redact.js",
     "node.js",
     "platform-browser.js",
     "platform-node.js",

--- a/packages/redact-node/redact.js
+++ b/packages/redact-node/redact.js
@@ -1,0 +1,70 @@
+// Redact's public API, over whichever core the entry point bound: the browser's
+// WebAssembly + LiteRT.js core (browser.js) or the prebuilt native core
+// (node.js). Both expose the same ABI, and @desert-ant-labs/core turns either
+// one into the same `LoadedModel`, so the API is written once here instead of
+// once per runtime.
+import { decodeRedaction, encodeOptions } from "./codec.js";
+
+/**
+ * Build the `Redact` class over a bound SDK (`createWasmSdk` /
+ * `createNativeSdk`). The entry points do nothing but call this.
+ */
+export function makeRedact(sdk) {
+  /**
+   * On-device multilingual PII redaction. Create one with
+   * `await Redact.load(...)` and reuse it, mirroring the iOS/Swift SDK.
+   *
+   * ```js
+   * const redact = await Redact.load();               // download on demand, cached
+   * const r = await redact.redaction("Email Anna at anna@example.com.");
+   * r.redactedText; r.items; r.restore(reply);
+   * redact.dispose();
+   * ```
+   */
+  return class Redact {
+    #model;
+    constructor(model) { this.#model = model; }
+
+    /**
+     * Load the model and return a ready redactor. By default the model is
+     * downloaded from the Hugging Face Hub at the pinned revision, verified, and
+     * cached (the filesystem under Node, the runtime's cache in the browser).
+     * Pass `directory` (Node) or `modelBaseUrl` (browser) to use files you host
+     * yourself. The repo and revision are pinned to the SDK.
+     */
+    static async load(options = {}) {
+      return new Redact(await sdk.open(options));
+    }
+
+    /**
+     * Detect and redact the PII in `text`. Each entity is replaced by a unique,
+     * numbered placeholder (`[EMAIL_1]`, ...), safe to hand to an LLM and
+     * restore afterwards via the returned `restore`.
+     *
+     * `options.deviceId` (a string or a zero-arg function returning one)
+     * attributes usage to a specific end-user device; it is collected per call,
+     * so it is safe for concurrent multi-tenant hosts. `options.group` (an id
+     * from {@link withCallGroup}) bills several calls as one.
+     */
+    async redaction(text, options = {}) {
+      const payload = encodeOptions({
+        minimumConfidence: options.minimumConfidence ?? 0.6,
+        labels: options.labels ? Array.from(options.labels) : undefined,
+      });
+      return decodeRedaction(await this.#model.run(String(text ?? ""), payload, options));
+    }
+
+    /** Whether the model is usable with no network. */
+    isDownloaded() { return this.#model.isDownloaded(); }
+
+    /**
+     * Run `body(group)` with a fresh call-group id, so every
+     * `redaction({ group })` inside it bills as a single usage call. The group
+     * is released when `body` settles.
+     */
+    withCallGroup(body) { return this.#model.withCallGroup(body); }
+
+    /** Release the model. The redactor is unusable afterwards. */
+    dispose() { this.#model.dispose(); }
+  };
+}


### PR DESCRIPTION
Follow-up to #40. Now that both cores expose the same ABI, a package's browser
entry and its native entry were literally the same program written twice:
create-or-adopt a model, download with progress, encode options, run, decode,
group calls, dispose. That was ~300 lines per model spread over two files that
could drift apart (and had: `dispose()` did nothing in the browser, call groups
were Node-only, error messages differed).

`@desert-ant-labs/core` now owns that runtime.

## What moved into core

- **`LoadedModel`** - a loaded model behind an opaque core handle:
  `run(text, options, { group, deviceId })` returning an `FfiReader`, plus
  `isDownloaded`, `withCallGroup`, `dispose`. Identical on both runtimes.
- **`readyModel(...)`** - turns a fresh handle into a loaded model: download and
  load now, so `load()` surfaces a failure instead of the first inference doing
  so, and a failed download disposes the handle instead of leaking it.
- **`createWasmSdk({ platform, packageName, modelId, hostGlobal, files })`** -
  the whole browser half: instantiate through the package's `#platform` seam,
  set up the LiteRT.js host, then either download from the Hub or fetch what a
  `modelBaseUrl` serves, compile it in LiteRT.js, and pass only the sidecars into
  wasm.
- **`createNativeSdk({ here, packageName, modelId })`** (node subpath) -
  normalizes the koffi `dal_*` core to the same shape, so both runtimes hand back
  the same `LoadedModel`.
- **`fetchModelFrom` -> `fetchSelfHostedModel`** - takes
  `{ model, sidecars: [...] }` and returns sidecars keyed by catalog name, so it
  works for any model instead of a fixed meta+model pair. (Breaking, but the core
  seam already broke in #40 and 0.7.0 is unpublished.)

## What a model package is now

| file | what it holds |
|---|---|
| `codec.js` | ids, host global, file names, options encoder, result decoder |
| `emo.js` / `redact.js` | the public class, over `LoadedModel` |
| `browser.js` | 30 lines: bind `createWasmSdk`, export the class |
| `node.js` | 23 lines: bind `createNativeSdk`, export the class |

`browser.js` went 165 -> 30 lines and `node.js` 150 -> 23, and the public class
is written once per model instead of once per model per runtime. Net -605/+847
lines with the tests and the shared runtime included; the per-model surface drops
by ~215 lines each.

## Verification

The JS suite is now 28 tests (9 new, driving the shared runtime through a fake
core: progress, failed-download cleanup, null handle, options/group/deviceId
pass-through, idempotent dispose, use-after-dispose, group open/close, the
wasm-core adapter, and both `createWasmSdk` load paths).

End-to-end on pv-studio against the **real** cores, driving the real package
entries:

- wasm: built the EmoWeb package, loaded `packages/emo-node/browser.js` in Node
  with only `@litertjs/core` faked (it cannot init outside a browser). Real Hub
  download with progress, `isDownloaded`, run with limit/skinTone, ranking,
  empty-input short circuit, call groups, device ids, idempotent `dispose()` and
  use-after-dispose rejection, then the `modelBaseUrl` path against a localhost
  file server (host compiles the artifact, only sidecars cross in).
- native: built `libDesertAntNode.dylib` and ran `packages/emo-node/node.js` with
  **real Core ML inference** - `"Pay my bills"` -> 💰 0.634 📄 0.120 💳 0.046,
  `"犬の散歩"` -> 🐕, `skinTone: "medium"` -> 🏃🏽 - plus groups, device ids,
  dispose, and adopting a pre-populated `directory`.
- `packages/emo-node`'s own suite: 4 passed, 1 skipped (the opt-in network test).

Scratch dirs on pv-studio cleaned up. No Swift changed in this PR.

## Known pre-existing wart (not touched)

Passing a `directory` that cannot be created makes the wasm store's
`fs.mkdirSync` throw across the JS boundary as an uncaught host exception rather
than a rejected promise (`JSFileSystem.makeDirectory` does not guard, and the
JavaScriptKit call path is non-throwing). Same before and after this change;
worth a separate fix.

## Next

The Swift SDK shell (`Emo.swift` / `Redact.swift` share ~120 lines of loader,
inits, `isDownloaded`, `download`, `waitUntilLoaded`) and the Kotlin handle base
class (~55 lines each).
