### PR TITLE
Fix a crash, a wrong default, and other cross-runtime inconsistencies

### DIFF
--- a/Sources/Inference/Lifecycle.swift
+++ b/Sources/Inference/Lifecycle.swift
@@ -44,22 +44,29 @@ final class LifecycleObserver {
     }
 
 #elseif os(WASI)
-    private let closure: JSClosure
+    private let hidden: JSClosure
+    private let unload: JSClosure
 
     init(onBackground: @escaping @Sendable () -> Void) {
-        let cb = JSClosure { _ in onBackground(); return .undefined }
-        // visibilitychange (hidden) is the reliable flush point; pagehide covers
-        // actual unload. The transport's beacon path (sendBeacon) survives unload.
-        _ = JSObject.global.document.object?.addEventListener?("visibilitychange", cb.jsValue)
-        _ = JSObject.global.addEventListener?("pagehide", cb.jsValue)
-        self.closure = cb
+        // visibilitychange fires on both directions, so only the hidden edge is a
+        // background event - flushing when the tab comes *back* stamps the idle
+        // clock for no reason. pagehide covers actual unload (the transport's
+        // beacon path survives it).
+        hidden = JSClosure { _ in
+            if JSObject.global.document.object?.visibilityState.string == "hidden" { onBackground() }
+            return .undefined
+        }
+        unload = JSClosure { _ in onBackground(); return .undefined }
+        _ = JSObject.global.document.object?.addEventListener?("visibilitychange", hidden.jsValue)
+        _ = JSObject.global.addEventListener?("pagehide", unload.jsValue)
     }
 
     deinit {
-        _ = JSObject.global.document.object?.removeEventListener?("visibilitychange", closure.jsValue)
-        _ = JSObject.global.removeEventListener?("pagehide", closure.jsValue)
+        _ = JSObject.global.document.object?.removeEventListener?("visibilitychange", hidden.jsValue)
+        _ = JSObject.global.removeEventListener?("pagehide", unload.jsValue)
         #if JAVASCRIPTKIT_WITHOUT_WEAKREFS
-        closure.release()
+        hidden.release()
+        unload.release()
         #endif
     }
 

--- a/Sources/ModelCatalog/Emo/Binding.swift
+++ b/Sources/ModelCatalog/Emo/Binding.swift
@@ -14,7 +14,9 @@ extension Emo: BoundModel {
     /// emoji string and an `f64` confidence.
     public func run(text: String, options: FFIReader) async -> [UInt8]? {
         var options = options
-        let limit = options.isEmpty ? 5 : options.u32()
+        // An empty payload means the SDK defaults, so this must match the default
+        // every SDK declares for `limit` (3), not a number of its own.
+        let limit = options.isEmpty ? 3 : options.u32()
         let tone = EmojiSkinTone(ffiValue: options.u32())
         guard let suggestions = try? await suggestions(for: text, limit: limit, skinTone: tone) else {
             return nil

--- a/Sources/ModelStore/WasmBackend.swift
+++ b/Sources/ModelStore/WasmBackend.swift
@@ -41,45 +41,67 @@ public final class MemoryFileSystem: FileSystem, @unchecked Sendable {
 /// `globalThis.__DalNodeFS` (a small object of the *Sync methods) - there is no
 /// `require` under the WASI shim - so this is just the platform's file seam; the
 /// download and verification logic stay in the shared Swift ModelStore.
+/// Every node `fs` call can throw a JS exception (a missing path, a read-only
+/// directory, a full disk). A JS exception raised through a non-throwing
+/// JavaScriptKit call is not catchable in Swift: it unwinds into the host and
+/// kills the process. So every call here goes through `throwing` and is turned
+/// into a `ModelStoreError`, matching the POSIX and Foundation backends - a bad
+/// `directory` must fail the load, not the process.
 public struct JSFileSystem: FileSystem {
     private let cacheRoot: String
-    private var fs: JSObject { JSObject.global.__DalNodeFS.object! }
+    private var fs: JSObject? { JSObject.global.__DalNodeFS.object }
 
     public init(cacheRoot: String) { self.cacheRoot = cacheRoot }
     public func defaultCacheRoot() -> String { cacheRoot }
 
-    public func exists(_ path: String) -> Bool { fs.existsSync!(path).boolean ?? false }
+    /// Call a node `fs` method, mapping a JS exception (or a missing seam) to a
+    /// Swift error the store can handle.
+    private func call(_ method: String, _ arguments: ConvertibleToJSValue...) throws -> JSValue {
+        guard let fs, let function = fs[method].function else {
+            throw ModelStoreError.io("\(method): missing from the __DalNodeFS host seam")
+        }
+        do {
+            return try function.throws(this: fs, arguments: arguments)
+        } catch {
+            throw ModelStoreError.io("\(method): \(error)")
+        }
+    }
+
+    public func exists(_ path: String) -> Bool {
+        ((try? call("existsSync", path))?.boolean) ?? false
+    }
 
     public func size(_ path: String) -> Int64? {
-        // statSync throws (a JS exception) on a missing path; guard with exists.
-        guard exists(path), let st = fs.statSync?(path).object, let n = st.size.number else { return nil }
+        // statSync throws on a missing path; both that and a non-file result are
+        // "no size", which is what the store's callers expect.
+        guard let stat = try? call("statSync", path).object, let n = stat.size.number else { return nil }
         return Int64(n)
     }
 
     public func read(_ path: String) throws -> [UInt8] {
-        // readFileSync throws a JS exception on a missing path, which does not
-        // surface as a catchable Swift error; convert it to one so the store's
-        // `try? read(...)` (e.g. the manifest probe) works.
-        guard exists(path) else { throw ModelStoreError.io("read(\(path)) missing") }
-        guard let arr = JSTypedArray<UInt8>(from: fs.readFileSync!(path)) else {
-            throw ModelStoreError.io("readFileSync(\(path))")
+        guard let array = JSTypedArray<UInt8>(from: try call("readFileSync", path)) else {
+            throw ModelStoreError.io("readFileSync(\(path)): not a byte array")
         }
-        return arr.withUnsafeBytes { Array($0) }
+        return array.withUnsafeBytes { Array($0) }
     }
 
     public func write(_ path: String, _ bytes: [UInt8]) throws {
-        _ = fs.writeFileSync!(path, JSTypedArray<UInt8>(bytes).jsValue)
+        _ = try call("writeFileSync", path, JSTypedArray<UInt8>(bytes))
     }
 
     public func makeDirectory(_ path: String) throws {
-        let opts = JSObject.global.Object.function!.new()
-        opts.recursive = true.jsValue
-        _ = fs.mkdirSync!(path, opts.jsValue)
+        let options = JSObject.global.Object.function!.new()
+        options.recursive = true.jsValue
+        _ = try call("mkdirSync", path, options)
     }
 
-    public func move(_ from: String, to: String) throws { _ = fs.renameSync!(from, to) }
-    // unlinkSync throws (a JS exception) on a missing path; only unlink if present.
-    public func remove(_ path: String) { if exists(path) { _ = fs.unlinkSync?(path) } }
+    public func move(_ from: String, to: String) throws {
+        _ = try call("renameSync", from, to)
+    }
+
+    /// Best-effort, like every backend's `remove`: a missing or locked path is
+    /// not an error (unlinkSync throws on both).
+    public func remove(_ path: String) { _ = try? call("unlinkSync", path) }
 }
 
 // Opt-in verbose logging for the WASM model-download transport, enabled from JS

--- a/Sources/PlatformSupport/HTTPClient.swift
+++ b/Sources/PlatformSupport/HTTPClient.swift
@@ -126,8 +126,10 @@ private func performHTTPRequest(method: String, url: String, body: [UInt8]?, con
     do {
         value = try await promise.value
     } catch {
+        // A rejected fetch throws a raw JS value; wrap it so callers can match on
+        // `HTTPClientError` the same way they do on every other platform.
         httpDebugLog("fetch rejected for \(url): \(error)")
-        throw error
+        throw HTTPClientError.requestFailed("\(method) \(url): \(error)")
     }
     guard let response = value.object else { throw HTTPClientError.requestFailed("no response") }
     let status = Int(response.status.number ?? 0)
@@ -140,10 +142,17 @@ private func performHTTPRequest(method: String, url: String, body: [UInt8]?, con
         headers.append(("Content-Type", ct))
     }
 
-    guard let bufferPromise = JSPromise(from: response.arrayBuffer!()) else {
+    guard let arrayBuffer = response.arrayBuffer.function,
+          let bufferPromise = JSPromise(from: arrayBuffer(this: response)) else {
         throw HTTPClientError.requestFailed("arrayBuffer(\(url))")
     }
-    let u8 = JSObject.global.Uint8Array.function!.new(try await bufferPromise.value)
+    let buffer: JSValue
+    do {
+        buffer = try await bufferPromise.value
+    } catch {
+        throw HTTPClientError.requestFailed("body of \(url): \(error)")
+    }
+    let u8 = JSObject.global.Uint8Array.function!.new(buffer)
     guard let array = JSTypedArray<UInt8>(from: u8) else {
         throw HTTPClientError.requestFailed("bytes(\(url))")
     }

--- a/Sources/Usage/Storage.swift
+++ b/Sources/Usage/Storage.swift
@@ -18,6 +18,13 @@ import CHostBridge
 import JavaScriptKit
 #endif
 
+#if os(WASI)
+/// Whether the JS host is Node (rather than a browser or worker).
+func jsHostIsNode() -> Bool {
+    JSObject.global.process.object?.versions.object?.node.string != nil
+}
+#endif
+
 /// A minimal string key/value store the turnstile persists into.
 public protocol UsageStorage {
     func get(_ key: String) -> String?
@@ -72,8 +79,13 @@ public func defaultStorage() -> UsageStorage {
 #elseif os(WASI)
     // Prefer a host-injected store (globalThis.__dalUsageStore, e.g. server-side
     // Node), then the browser's localStorage; otherwise in-memory.
+    //
+    // Node is checked first and never probed for localStorage: Node exposes a
+    // `localStorage` global that is unusable without --localstorage-file, and
+    // merely touching it prints an ExperimentalWarning - which every consumer of
+    // the server-side build would see on load, for a store we cannot use anyway.
     let hasJSStore = JSObject.global.__dalUsageStore.object != nil
-        || JSObject.global.localStorage.object != nil
+        || (!jsHostIsNode() && JSObject.global.localStorage.object != nil)
     return hasJSStore ? JSKeyValueStorage() : InMemoryStorage()
 #else
     return InMemoryStorage()
@@ -127,7 +139,8 @@ public struct JSKeyValueStorage: UsageStorage {
     public init() {}
     // Resolved at access time so a host store installed after init still applies.
     private var storage: JSObject? {
-        JSObject.global.__dalUsageStore.object ?? JSObject.global.localStorage.object
+        if let injected = JSObject.global.__dalUsageStore.object { return injected }
+        return jsHostIsNode() ? nil : JSObject.global.localStorage.object
     }
     public func get(_ key: String) -> String? { storage?.getItem?(key).string }
     public func set(_ key: String, _ value: String) { _ = storage?.setItem?(key, value) }

--- a/Tests/ModelCatalogTests/ModelCatalogTests.swift
+++ b/Tests/ModelCatalogTests/ModelCatalogTests.swift
@@ -75,6 +75,25 @@ struct ModelCatalogTests {
         }
     }
 
+    /// The wasm host global and the catalog id are derived here but hard-coded in
+    /// each npm package's `codec.js` (the JS side has no view of the Swift
+    /// catalog). They must agree or the browser build looks up a core that was
+    /// never registered, so cross-check them the way `sdkVersion` is checked.
+    @Test func jsPackagesUseTheDeclaredIdAndHostGlobal() throws {
+        for model in catalog {
+            #expect(
+                model.hostGlobal == "__\(model.product)Host",
+                "\(model.id): host global must derive from the product")
+            guard let codec = try packageFile("packages/\(model.id)-node/codec.js") else { continue }
+            #expect(
+                codec.contains("\"\(model.hostGlobal)\""),
+                "\(model.id): codec.js does not use \(model.hostGlobal)")
+            #expect(
+                codec.contains("MODEL_ID = \"\(model.id)\""),
+                "\(model.id): codec.js does not use the catalog id")
+        }
+    }
+
     @Test func distributionCarriesTheDeclaration() {
         #expect(RedactModel.distribution.repo == "desert-ant-labs/redact")
         #expect(RedactModel.distribution.revision == RedactModel.revision)
@@ -89,13 +108,7 @@ struct ModelCatalogTests {
 /// file is not reachable (a wasm/sandboxed run, or a package pruned from a
 /// checkout) - the invariants above still run, only the cross-check is skipped.
 private func packageVersion(_ model: any ModelDeclaration.Type, _ relativePath: String) throws -> String? {
-    // #filePath is Tests/ModelCatalogTests/<file>, so the repo root is two up.
-    let root = URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-    let url = root.appendingPathComponent(relativePath)
-    guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+    guard let text = try packageFile(relativePath) else { return nil }
     // Only the module's own version line counts. Anchoring on the start of the
     // line matters: `build.gradle.kts` also carries the convention plugin's
     // version (`id("ai.desertant.model-sdk") version "0.4.2"`), which a looser
@@ -106,6 +119,18 @@ private func packageVersion(_ model: any ModelDeclaration.Type, _ relativePath: 
         if let found = firstSemanticVersion(in: line) { return found }
     }
     return nil
+}
+
+/// A repo file's contents, or nil when it is not reachable (a wasm/sandboxed
+/// run, or a package pruned from a checkout) - the invariants still run, only
+/// the cross-check is skipped.
+private func packageFile(_ relativePath: String) throws -> String? {
+    // #filePath is Tests/ModelCatalogTests/<file>, so the repo root is two up.
+    let root = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    return try? String(contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
 }
 
 /// The first `X.Y.Z` run in `line`. Hand-scanned rather than a regex literal:

--- a/js/src/native-sdk.js
+++ b/js/src/native-sdk.js
@@ -26,16 +26,20 @@ export function createNativeSdk({ here, packageName, modelId, coreName }) {
   const native = loadNative({ here, packageName, coreName });
   const { lib, callAsync, decodeResult, withCallGroup } = native;
 
+  const isDownloaded = (handle) => lib.isDownloaded(handle) !== 0;
+
+  // Plain closures rather than `this`-dependent methods: the core is handed
+  // around as a value (LoadedModel, readyModel), so it must survive destructuring.
   const core = {
     // Managed nested cache under ~/.cache by default (matching the browser
     // host); an explicit `directory` is adopted when it holds the files, else
     // downloaded into.
     create: (cacheRoot, directory) => lib.create(modelId, cacheRoot, directory || null),
-    isDownloaded: (handle) => lib.isDownloaded(handle) !== 0,
+    isDownloaded,
     async download(handle, onProgress) {
       // The C ABI has no progress channel: report the endpoints so a caller's
       // onProgress behaves the same on both runtimes.
-      if (this.isDownloaded(handle)) return;
+      if (isDownloaded(handle)) return;
       onProgress?.(0);
       const rc = await callAsync(lib.download, handle);
       if (rc !== 0) throw new Error("the native core reported a download failure");

--- a/packages/emo-kotlin/src/main/kotlin/ai/desertant/emo/Emo.kt
+++ b/packages/emo-kotlin/src/main/kotlin/ai/desertant/emo/Emo.kt
@@ -35,6 +35,17 @@ class EmoException(message: String) : Exception(message)
  * ```
  */
 class Emo private constructor(private val handle: Long) : AutoCloseable {
+    // The native handle is a retained pointer: releasing it twice over-releases
+    // the model, and using it after release dereferences freed memory. Both are
+    // easy to hit with `use { }` plus a defensive close(), so guard here rather
+    // than crash the app.
+    @Volatile private var closed = false
+
+    private fun handleOrThrow(): Long {
+        if (closed) throw EmoException("this Emo is closed")
+        return handle
+    }
+
     /**
      * A suggester that downloads the model into the app cache on first use and
      * reuses it offline afterward. When [directory] is supplied, that directory
@@ -59,7 +70,7 @@ class Emo private constructor(private val handle: Long) : AutoCloseable {
     }
 
     /** Whether the model is available for this suggester with no network. */
-    fun isDownloaded(): Boolean = DesertAntNative.isDownloaded(handle) != 0
+    fun isDownloaded(): Boolean = DesertAntNative.isDownloaded(handleOrThrow()) != 0
 
     /**
      * Download the model ahead of time so the first [suggestions] is instant. A
@@ -67,7 +78,7 @@ class Emo private constructor(private val handle: Long) : AutoCloseable {
      * dispatcher.
      */
     suspend fun download(): Unit = withContext(Dispatchers.IO) {
-        if (DesertAntNative.download(handle) != 0) throw EmoException("model download failed")
+        if (DesertAntNative.download(handleOrThrow()) != 0) throw EmoException("model download failed")
     }
 
     /**
@@ -82,12 +93,17 @@ class Emo private constructor(private val handle: Long) : AutoCloseable {
         // Options payload: u32 limit, u32 skinTone. Must match the reader in
         // Sources/ModelCatalog/Emo/Binding.swift.
         val options = FfiWriter().int(limit).int(skinTone.nativeValue).done()
-        val bytes = DesertAntNative.run(handle, text.toByteArray(Charsets.UTF_8), options)
+        val bytes = DesertAntNative.run(handleOrThrow(), text.toByteArray(Charsets.UTF_8), options)
             ?: throw EmoException("suggestion failed")
         val r = FfiReader(bytes)
         List(r.int()) { EmoSuggestion(r.string(), r.double()) }
     }
 
-    /** Release the native model. The suggester is unusable afterwards. */
-    override fun close() = DesertAntNative.destroy(handle)
+    /** Release the native model. The suggester is unusable afterwards; calling this
+     *  again is a no-op. */
+    @Synchronized override fun close() {
+        if (closed) return
+        closed = true
+        DesertAntNative.destroy(handle)
+    }
 }

--- a/packages/emo-node/README.md
+++ b/packages/emo-node/README.md
@@ -24,7 +24,7 @@ const emo = await Emo.load();
 const suggestions = await emo.suggestions("Pay my bills", { limit: 3 });
 // [{ emoji: "💰", confidence: 0.65 }, ...]
 
-emo.dispose(); // frees native resources in the /native build; no-op otherwise
+emo.dispose(); // release the model (both builds)
 ```
 
 Server-only code that wants the native core imports the same API from the

--- a/packages/emo-node/index.d.ts
+++ b/packages/emo-node/index.d.ts
@@ -89,6 +89,8 @@ export interface LoadOptions {
  * ```
  */
 export declare class Emo {
+  /** Use Emo.load(); the constructor is internal. */
+  private constructor();
   /**
    * Load the model and return a ready suggester. Downloads from the Hugging Face
    * Hub at the pinned revision and caches by default; pass `directory` (Node) or

--- a/packages/redact-kotlin/src/main/kotlin/ai/desertant/redact/Redact.kt
+++ b/packages/redact-kotlin/src/main/kotlin/ai/desertant/redact/Redact.kt
@@ -69,6 +69,17 @@ class RedactException(message: String) : Exception(message)
  * ```
  */
 class Redact private constructor(private val handle: Long) : AutoCloseable {
+    // The native handle is a retained pointer: releasing it twice over-releases
+    // the model, and using it after release dereferences freed memory. Both are
+    // easy to hit with `use { }` plus a defensive close(), so guard here rather
+    // than crash the app.
+    @Volatile private var closed = false
+
+    private fun handleOrThrow(): Long {
+        if (closed) throw RedactException("this Redact is closed")
+        return handle
+    }
+
     /**
      * A redactor that downloads the model into the app cache on first use and
      * reuses it offline afterward. When [directory] is supplied, that directory
@@ -93,7 +104,7 @@ class Redact private constructor(private val handle: Long) : AutoCloseable {
     }
 
     /** Whether the model is available for this redactor with no network. */
-    fun isDownloaded(): Boolean = DesertAntNative.isDownloaded(handle) != 0
+    fun isDownloaded(): Boolean = DesertAntNative.isDownloaded(handleOrThrow()) != 0
 
     /**
      * Download the model ahead of time so the first [redaction] is instant. A
@@ -101,7 +112,7 @@ class Redact private constructor(private val handle: Long) : AutoCloseable {
      * dispatcher.
      */
     suspend fun download(): Unit = withContext(Dispatchers.IO) {
-        if (DesertAntNative.download(handle) != 0) throw RedactException("model download failed")
+        if (DesertAntNative.download(handleOrThrow()) != 0) throw RedactException("model download failed")
     }
 
     /**
@@ -119,7 +130,7 @@ class Redact private constructor(private val handle: Long) : AutoCloseable {
                 .double(options.minimumConfidence)
                 .strings(options.labels?.toList() ?: emptyList())
                 .done()
-            val bytes = DesertAntNative.run(handle, text.toByteArray(Charsets.UTF_8), payload)
+            val bytes = DesertAntNative.run(handleOrThrow(), text.toByteArray(Charsets.UTF_8), payload)
                 ?: throw RedactException("redaction failed")
             val buf = FfiReader(bytes)  // matches the native FFIWriter encoding
             val redactedText = buf.string()
@@ -140,6 +151,11 @@ class Redact private constructor(private val handle: Long) : AutoCloseable {
             Redaction(redactedText = redactedText, items = items)
         }
 
-    /** Release the native model. The redactor is unusable afterwards. */
-    override fun close() = DesertAntNative.destroy(handle)
+    /** Release the native model. The redactor is unusable afterwards; calling this
+     *  again is a no-op. */
+    @Synchronized override fun close() {
+        if (closed) return
+        closed = true
+        DesertAntNative.destroy(handle)
+    }
 }

--- a/packages/redact-node/README.md
+++ b/packages/redact-node/README.md
@@ -41,7 +41,7 @@ r.items;             // detections: label, original, placeholder, confidence, of
 const reply = await llm(r.redactedText);       // the LLM sees only placeholders
 r.restore(reply);    // originals filled back in
 
-redact.dispose();    // frees native resources in the /native build; no-op otherwise
+redact.dispose();    // release the model (both builds)
 ```
 
 Server-only code that wants the native core imports the same API from the

--- a/packages/redact-node/index.d.ts
+++ b/packages/redact-node/index.d.ts
@@ -104,6 +104,8 @@ export interface LoadOptions {
  * ```
  */
 export declare class Redact {
+  /** Use Redact.load(); the constructor is internal. */
+  private constructor();
   /**
    * Load the model and return a ready redactor. By default it downloads from the
    * Hugging Face Hub at the pinned tag on first call, verifies it (SHA-256), and


### PR DESCRIPTION
An audit pass over the runtimes, looking for places where one platform disagrees
with the others or a failure path is worse than it looks. Eight fixes, one new
consistency test. Each is independent; happy to split if you'd rather review
them separately.

## 1. A wasm/node failure killed the process instead of throwing

`JSFileSystem` (the Swift ModelStore's node backend) called every `fs` method
through a **non-throwing** JavaScriptKit call. A JS exception raised that way is
not catchable in Swift: it unwinds into the host and terminates the process. So
an unwritable `directory`, a full disk, or a rename onto a missing path took the
whole Node process down rather than failing the load. I hit this while verifying
#41 - `Emo.load({ directory: "/nonexistent/..." })` crashed Node with an
`ENOENT` stack through `mkdirSync`.

Every call now goes through the throwing variant and becomes a
`ModelStoreError.io`, matching the POSIX and Foundation backends (both of which
already returned proper errors). `remove` stays best-effort, as everywhere else.

Before: process dies. After (verified against the real wasm core):

```
ok: bad directory rejects instead of crashing the process
ok: the runtime survived the failed load
```

## 2. Emo's empty-options default was 5, not 3

`Emo`'s binding read an empty options payload as `limit = 5`. The payload is
documented as "an empty payload means the SDK defaults", and every SDK declares
`3` (Swift `limit: Int = 3`, Kotlin `limit: Int = 3`, JS `limit ?? 3`). Any host
that ran the model with no options got five suggestions. Verified against the
real core: `run(handle, text, null, ...)` now returns 3.

## 3. Kotlin `close()` could over-release the native handle

`close()` called `dal_destroy` unconditionally, and nothing checked the handle
afterwards. Two realistic paths crash: `use { }` plus a defensive `close()` in
`onDestroy` (double free), and any call after close (dangling pointer into the
core). The JS SDK has always guarded this; Kotlin now does too - `close()` is
idempotent and synchronized, and every native call goes through a guard that
throws a clear `EmoException`/`RedactException` instead.

## 4. The Node build printed an ExperimentalWarning on every load

`defaultStorage()` probed `globalThis.localStorage`. Node exposes that global but
cannot use it without `--localstorage-file`, and merely touching it prints
`ExperimentalWarning: localStorage is not available...` - which every consumer of
the server-side build saw, for a store we can't use anyway. Node is now detected
and skipped (the host-injected `__dalUsageStore` still wins everywhere).

## 5. wasm HTTP errors weren't `HTTPClientError`

A rejected `fetch` threw the raw JS value, while Apple and Android wrap failures
in `HTTPClientError.requestFailed`, so callers couldn't match one error type
across platforms. Also `response.arrayBuffer!()` force-unwrapped and the body
promise's rejection was unwrapped. All three fixed.

## 6. The browser lifecycle hook flushed on both visibility edges

`visibilitychange` fires when a tab is hidden **and** when it comes back; the
handler treated both as backgrounding, so returning to a tab stamped the idle
clock and flushed. Only the hidden edge is a background event now; `pagehide`
still covers unload.

## 7. `createNativeSdk`'s core used `this`

`download` called `this.isDownloaded(...)`, but the normalized core is handed
around as a value (`LoadedModel`, `readyModel`). Now a plain closure.

## 8. Docs and types

- Both package READMEs still said `dispose()` "frees native resources in the
  /native build; no-op otherwise" - it releases the model in both builds since
  #40.
- The `.d.ts` files advertised a public constructor for classes that only ever
  come from `load()`; marked private.

## New test

`ModelCatalogTests` now cross-checks each model's catalog id and derived wasm
host global against its npm package's `codec.js`, the same way `sdkVersion` is
checked against the published manifests. The JS side hard-codes both (it has no
view of the Swift catalog), so drift there means the browser build looks up a
core that was never registered.

## Verification

On pv-studio (this box OOMs building swift-syntax): host build, wasm build of
both entry points, and `swift test` - 82 tests, the only 2 failures being the
pre-existing `HTTPClientTests` ones that need the echo server `mise run
test-macos` starts. Fixes 1 and 2 were reproduced against the real wasm core
before and after; the native core still runs real Core ML inference
(`"Pay my bills"` -> 💰 📄 💳). `node --test js/test/*.test.mjs`: 28/28. Scratch
dirs on pv-studio cleaned up.
