### PR TITLE
Give model SDKs one loader instead of one each

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,8 @@ import Foundation
 // and consumers that want a narrower dependency.
 //
 //   DesertAnt    re-exports everything below (`import DesertAnt`)
-//   ModelCatalog every model in the monorepo: coordinates + per-platform files
+//   ModelCatalog every model in the monorepo: coordinates + per-platform files,
+//                plus the `LoadedModel` shell an SDK's public class wraps
 //   Regex        stdlib-`Regex`-shaped matching, type `Pattern`
 //                (NSRegularExpression | java.util.regex | JS RegExp)
 //   JSON         Codable decoding (Foundation.JSONDecoder | host JSON tree | JS JSON.parse)
@@ -269,7 +270,13 @@ let libraryTargets: [Target] = [
         // modelTargets), so it is excluded here.
         // `Usage` is here for the SDK identity each declaration derives (product +
         // sdkVersion), so a model's telemetry cannot be misattributed or go stale.
-        .target(name: "ModelCatalog", dependencies: ["ModelStore", "Usage"], exclude: ["Emo", "Redact"]),
+        // `PlatformSupport` is here for `LazyLoader`, which backs the shared
+        // `LoadedModel` shell every model SDK is built on.
+        .target(
+            name: "ModelCatalog",
+            dependencies: ["ModelStore", "Usage", "PlatformSupport"],
+            exclude: ["Emo", "Redact"]
+        ),
         .target(
             name: "ModelStore",
             dependencies: [

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ importable for consumers that want a narrower dependency:
 
 | Module | API | Apple / Linux | Android | WebAssembly |
 |---|---|---|---|---|
-| `ModelCatalog` | every model in the monorepo: coordinates + per-platform file manifest | same on every platform | | |
+| `ModelCatalog` | every model's coordinates + per-platform file manifest, and the `LoadedModel` shell an SDK wraps | same on every platform | | |
 | `Regex` (type `Pattern`) | stdlib-`Regex`-shaped matching | `NSRegularExpression` | `java.util.regex` (via `CHostBridge`) | JS `RegExp` |
 | `JSON` | `Codable` decode + encode | `Foundation.JSONDecoder`/`Encoder` | host JSON parser (via `CHostBridge`) + tree encoder | JS `JSON.parse` + tree encoder |
 | `TextNormalization` | `String.nfkc` | Foundation `precomposed...` | platform ICU `unorm2` (`libicu`) | JS `String.normalize` |
@@ -97,6 +97,42 @@ strings); the host reads it with its own standard library (see the matching
 `FfiReader` in `kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt`, a thin
 `java.nio.ByteBuffer` cursor) and
 frees it with `ffiFree`. The payload *schema* is the model's own concern.
+
+## LoadedModel (the SDK shell)
+
+Resolving a model's files, building it once, sharing that single load with every
+concurrent caller, and answering "is it available offline?" are the same for
+every model, so an SDK does not write them. It wraps a `LoadedModel` and adds
+only its public API and how a resolved directory becomes its runtime:
+
+```swift
+public final class Emo: @unchecked Sendable {
+    private let model: LoadedModel<Model>
+
+    public convenience init(directory: String? = nil) {
+        self.init(directory: directory, cacheRoot: nil)
+    }
+
+    public init(directory: String?, cacheRoot: String?) {
+        model = LoadedModel(EmoModel.self, directory: directory, cacheRoot: cacheRoot) { files in
+            try Model(assets: await .emo(files: files))
+        }
+    }
+
+    public func isDownloaded() -> Bool { model.isDownloaded() }
+    public func download(progress: ...) async throws { try await model.download(progress: progress) }
+    public func suggestions(...) async throws -> [EmoSuggestion] {
+        try await model.value().suggestions(...)
+    }
+}
+```
+
+Construction starts nothing; the first `value()` or `download(progress:)`
+resolves the files (adopting `directory`, else downloading into it or into the
+managed cache) and builds the runtime. A failed load is not cached, so a later
+call retries. `LoadedModel { ... }` wraps a runtime whose inputs the caller
+already has (the cross-language bindings and the wasm host's self-hosted files),
+with nothing to resolve or download.
 
 ## WasmBindings (the wasm ABI)
 

--- a/Sources/ModelCatalog/Emo/Emo.swift
+++ b/Sources/ModelCatalog/Emo/Emo.swift
@@ -50,12 +50,10 @@ public enum EmoError: MessageError, Sendable {
 /// // "🏃🏽"
 /// ```
 public final class Emo: @unchecked Sendable {
-    /// Resolve the model's assets (downloading/adopting as needed), reporting
-    /// progress `0...1`.
-    typealias ResolveAssets = @Sendable (@escaping @Sendable (Double) -> Void) async throws -> ModelAssets
-
-    private let loader: LazyLoader<Model>
-    private let availability: @Sendable () -> Bool
+    // Resolving the files, loading once, sharing that load, and reporting
+    // availability are the same for every model, so they live in the core's
+    // `LoadedModel`; Emo adds only how a resolved directory becomes its model.
+    private let model: LoadedModel<Model>
 
     /// Creates a suggester. Construction does no work and starts no download;
     /// the model loads on the first ``suggestions(for:limit:skinTone:)`` or
@@ -78,28 +76,22 @@ public final class Emo: @unchecked Sendable {
     /// `~/.cache` on the web). On Apple/Linux FileManager provides it, so the
     /// public `init(directory:)` passes `nil`.
     @_spi(EmoBindings)
-    public convenience init(directory: String?, cacheRoot: String?) {
-        self.init(
-            resolve: { try await Emo.resolvedAssets(directory: directory, cacheRoot: cacheRoot, progress: $0) },
-            isAvailable: { Emo.isModelAvailable(directory: directory, cacheRoot: cacheRoot) }
-        )
+    public init(directory: String?, cacheRoot: String?) {
+        model = LoadedModel(EmoModel.self, directory: directory, cacheRoot: cacheRoot) { files in
+            try Model(assets: await .emo(files: files))
+        }
     }
 
     /// Creates a suggester from explicitly provided assets (used by the
     /// Android/JNI and custom-deployment paths).
     @_spi(EmoBindings)
-    public convenience init(assets: ModelAssets) {
-        self.init(resolve: { _ in assets }, isAvailable: { true })
-    }
-
-    init(resolve: @escaping ResolveAssets, isAvailable: @escaping @Sendable () -> Bool) {
-        loader = LazyLoader { progress in try Model(assets: await resolve(progress)) }
-        availability = isAvailable
+    public init(assets: ModelAssets) {
+        model = LoadedModel { try Model(assets: assets) }
     }
 
     /// Whether the model is available for this suggester with no network:
     /// cached (for the managed location) or already present in `directory`.
-    public func isDownloaded() -> Bool { availability() }
+    public func isDownloaded() -> Bool { model.isDownloaded() }
 
     /// Download and load the model ahead of time, so the first
     /// ``suggestions(for:limit:skinTone:)`` is instant. Reports download
@@ -107,14 +99,14 @@ public final class Emo: @unchecked Sendable {
     /// suggestion, share one download. A no-op once loaded (see
     /// ``isDownloaded()``).
     public func download(progress: @Sendable @escaping (Double) -> Void = { _ in }) async throws {
-        try await loader.run(progress: progress)
+        try await model.download(progress: progress)
     }
 
     /// Await model readiness. The bindings use this to surface load errors
     /// eagerly; apps can just call ``suggestions(for:limit:skinTone:)``.
     @_spi(EmoBindings)
     public func waitUntilLoaded() async throws {
-        _ = try await loader.value()
+        _ = try await model.value()
     }
 
     /// Returns up to `limit` emoji suggestions for `text`, most likely first.
@@ -127,8 +119,7 @@ public final class Emo: @unchecked Sendable {
     public func suggestions(for text: String, limit: Int = 3, skinTone: EmojiSkinTone = .default) async throws -> [EmoSuggestion] {
         let trimmed = text.trimmed
         guard !trimmed.isEmpty else { return [] }
-        let model = try await loader.value()
-        return try await model.suggestions(for: trimmed, limit: limit, skinTone: skinTone)
+        return try await model.value().suggestions(for: trimmed, limit: limit, skinTone: skinTone)
     }
 }
 

--- a/Sources/ModelCatalog/Emo/ModelLoading.swift
+++ b/Sources/ModelCatalog/Emo/ModelLoading.swift
@@ -50,24 +50,6 @@ public extension Emo {
     static var modelRepo: String { EmoModel.repo }
     /// The model revision this SDK is built against (pinned; not configurable).
     static var modelRevision: String { EmoModel.revision }
-
-    /// Resolve the model for `directory` (adopt your files, or download there),
-    /// then build loadable assets. `nil` uses the managed cache.
-    internal static func resolvedAssets(
-        directory: String?,
-        cacheRoot: String? = nil,
-        progress: @Sendable @escaping (Double) -> Void
-    ) async throws -> ModelAssets {
-        let files = try await distribution().resolve(cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction) }
-        return try await .emo(files: files)
-    }
-
-    /// Whether the model is available offline for `directory`.
-    internal static func isModelAvailable(directory: String?, cacheRoot: String? = nil) -> Bool {
-        distribution().isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot)
-    }
-
-    private static func distribution() -> ModelDistribution { EmoModel.distribution }
 }
 
 // MARK: shipping the model with your app

--- a/Sources/ModelCatalog/LoadedModel.swift
+++ b/Sources/ModelCatalog/LoadedModel.swift
@@ -1,0 +1,92 @@
+// The shell every model SDK wraps: resolve the model's files, build the model
+// once, share that single load, and answer "is it available offline?".
+//
+// Each SDK used to write this itself - a `LazyLoader`, three initializers, an
+// availability closure, `isDownloaded`, `download`, `waitUntilLoaded`, and a
+// pair of resolve/availability helpers over its `ModelDistribution` - about 120
+// lines that differed only in the model type they built. It is also where a
+// model could go subtly wrong: forgetting the binding initializer that takes a
+// `cacheRoot` silently breaks Android and Node, where the platform has no cache
+// base of its own.
+//
+// So it lives here once, and an SDK keeps only what is genuinely its own: its
+// public API, and how a resolved directory becomes its runtime.
+//
+//     public final class Emo: @unchecked Sendable {
+//         private let model: LoadedModel<Model>
+//         public convenience init(directory: String? = nil) {
+//             self.init(directory: directory, cacheRoot: nil)
+//         }
+//         public init(directory: String?, cacheRoot: String?) {
+//             model = LoadedModel(EmoModel.self, directory: directory, cacheRoot: cacheRoot) {
+//                 try Model(assets: await .emo(files: $0))
+//             }
+//         }
+//         public func suggestions(...) async throws -> [EmoSuggestion] {
+//             try await model.value().suggestions(...)
+//         }
+//     }
+
+import ModelStore
+import PlatformSupport
+
+/// A model SDK's loaded runtime: `StoredModel` is the files on disk, this is the
+/// thing built from them. Construction starts nothing; the first ``value()`` or
+/// ``download(progress:)`` resolves the files (adopting `directory`, else
+/// downloading into it or into the managed cache) and builds the runtime once,
+/// sharing that single load with every concurrent caller. A failed load is not
+/// cached, so a later call retries.
+public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
+    private let loader: LazyLoader<Runtime>
+    private let availability: @Sendable () -> Bool
+
+    /// Load from the model's own files.
+    ///
+    /// - Parameters:
+    ///   - declaration: the model's catalog entry, which supplies the repo,
+    ///     pinned revision, and this platform's file list.
+    ///   - directory: where the model lives. Files already there are adopted and
+    ///     used offline; otherwise the model is downloaded into it. `nil` uses
+    ///     the managed per-model/revision cache.
+    ///   - cacheRoot: the platform base the managed cache lives under (the app
+    ///     cache dir on Android, `~/.cache` on Node). `nil` on Apple/Linux, where
+    ///     the platform provides one.
+    ///   - build: turn the resolved files into the runtime.
+    public init<Declaration: ModelDeclaration>(
+        _ declaration: Declaration.Type,
+        directory: String? = nil,
+        cacheRoot: String? = nil,
+        build: @escaping @Sendable (StoredModel) async throws -> Runtime
+    ) {
+        let distribution = Declaration.distribution
+        loader = LazyLoader { progress in
+            let files = try await distribution.resolve(
+                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction) }
+            return try await build(files)
+        }
+        availability = { distribution.isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot) }
+    }
+
+    /// Wrap a runtime the caller already has the inputs for (the cross-language
+    /// bindings' assets path, and the wasm host's self-hosted files): nothing to
+    /// resolve or download, but still built lazily and only once, so a failure
+    /// surfaces from the same calls as the downloading path.
+    public init(_ build: @escaping @Sendable () throws -> Runtime) {
+        loader = LazyLoader { _ in try build() }
+        availability = { true }
+    }
+
+    /// Whether the model is usable with no network: present in its directory, or
+    /// cached and intact.
+    public func isDownloaded() -> Bool { availability() }
+
+    /// Resolve and build ahead of time, so the first ``value()`` is instant.
+    /// Reports progress `0...1`. Concurrent calls, and an implicit load from a
+    /// first use, share one download.
+    public func download(progress: @Sendable @escaping (Double) -> Void = { _ in }) async throws {
+        try await loader.run(progress: progress)
+    }
+
+    /// The runtime, loading it on first use.
+    public func value() async throws -> Runtime { try await loader.value() }
+}

--- a/Sources/ModelCatalog/Redact/ModelLoading.swift
+++ b/Sources/ModelCatalog/Redact/ModelLoading.swift
@@ -48,24 +48,6 @@ public extension Redact {
     static var modelRepo: String { RedactModel.repo }
     /// The model revision this SDK is built against (pinned; not configurable).
     static var modelRevision: String { RedactModel.revision }
-
-    /// Resolve the model for `directory` (adopt your files, or download there),
-    /// then build loadable assets. `nil` uses the managed cache.
-    internal static func resolvedAssets(
-        directory: String?,
-        cacheRoot: String? = nil,
-        progress: @Sendable @escaping (Double) -> Void
-    ) async throws -> ModelAssets {
-        let files = try await distribution().resolve(cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction) }
-        return try await .redact(files: files)
-    }
-
-    /// Whether the model is available offline for `directory`.
-    internal static func isModelAvailable(directory: String?, cacheRoot: String? = nil) -> Bool {
-        distribution().isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot)
-    }
-
-    private static func distribution() -> ModelDistribution { RedactModel.distribution }
 }
 
 // MARK: shipping the model with your app

--- a/Sources/ModelCatalog/Redact/Redact.swift
+++ b/Sources/ModelCatalog/Redact/Redact.swift
@@ -85,12 +85,10 @@ public enum RedactError: MessageError, Sendable {
 /// r.items.first?.original   // "Anna"
 /// ```
 public final class Redact: @unchecked Sendable {
-    /// Resolve the model's assets (downloading/adopting as needed), reporting
-    /// progress `0...1`.
-    typealias ResolveAssets = @Sendable (@escaping @Sendable (Double) -> Void) async throws -> ModelAssets
-
-    private let loader: LazyLoader<Model>
-    private let availability: @Sendable () -> Bool
+    // Resolving the files, loading once, sharing that load, and reporting
+    // availability are the same for every model, so they live in the core's
+    // `LoadedModel`; Redact adds only how a resolved directory becomes its model.
+    private let model: LoadedModel<Model>
 
     /// Creates a redactor. Construction does no work and starts no download; the
     /// model loads on the first ``redaction(of:options:)`` or ``download(progress:)``,
@@ -118,42 +116,36 @@ public final class Redact: @unchecked Sendable {
     /// `~/.cache` on the web). On Apple/Linux FileManager provides it, so the
     /// public `init(directory:)` passes `nil`.
     @_spi(RedactBindings)
-    public convenience init(directory: String?, cacheRoot: String?) {
-        self.init(
-            resolve: { try await Redact.resolvedAssets(directory: directory, cacheRoot: cacheRoot, progress: $0) },
-            isAvailable: { Redact.isModelAvailable(directory: directory, cacheRoot: cacheRoot) }
-        )
+    public init(directory: String?, cacheRoot: String?) {
+        model = LoadedModel(RedactModel.self, directory: directory, cacheRoot: cacheRoot) { files in
+            try Model(assets: await .redact(files: files))
+        }
     }
 
     /// Creates a redactor from explicitly provided assets (used by the
     /// Android/JNI and custom-deployment paths).
     @_spi(RedactBindings)
-    public convenience init(assets: ModelAssets) {
-        self.init(resolve: { _ in assets }, isAvailable: { true })
-    }
-
-    init(resolve: @escaping ResolveAssets, isAvailable: @escaping @Sendable () -> Bool) {
-        loader = LazyLoader { progress in try Model(assets: await resolve(progress)) }
-        availability = isAvailable
+    public init(assets: ModelAssets) {
+        model = LoadedModel { try Model(assets: assets) }
     }
 
     /// Whether the model is available for this redactor with no network: cached
     /// (for the managed location) or already present in `directory`.
-    public func isDownloaded() -> Bool { availability() }
+    public func isDownloaded() -> Bool { model.isDownloaded() }
 
     /// Download and load the model ahead of time, so the first
     /// ``redaction(of:options:)`` is instant. Reports download progress `0...1`.
     /// Concurrent calls, and an implicit load from a redaction, share one
     /// download. A no-op once loaded (see ``isDownloaded()``).
     public func download(progress: @Sendable @escaping (Double) -> Void = { _ in }) async throws {
-        try await loader.run(progress: progress)
+        try await model.download(progress: progress)
     }
 
     /// Await model readiness. The bindings use this to surface load errors
     /// eagerly; apps can just call ``redaction(of:options:)``.
     @_spi(RedactBindings)
     public func waitUntilLoaded() async throws {
-        _ = try await loader.value()
+        _ = try await model.value()
     }
 
     /// Detect and redact the PII in `text`.
@@ -189,9 +181,8 @@ public final class Redact: @unchecked Sendable {
     }
 
     private func spans(in text: String, options: Options) async throws -> [Span] {
-        let model = try await loader.value()
         let allowed = options.labels.map { Set($0.map(\.rawValue)) }
-        return try await model.detect(text, minScore: options.minimumConfidence)
+        return try await model.value().detect(text, minScore: options.minimumConfidence)
             .filter { allowed?.contains($0.label) ?? true }
             .sorted { $0.start != $1.start ? $0.start < $1.start : $0.end < $1.end }
     }

--- a/Tests/ModelCatalogTests/LoadedModelTests.swift
+++ b/Tests/ModelCatalogTests/LoadedModelTests.swift
@@ -1,0 +1,102 @@
+// The shell every model SDK is built on. The download path needs the Hub, so
+// what is pinned here is the behaviour an SDK used to hand-write and could get
+// wrong: laziness, single-flight loading, progress, retry after failure, and
+// offline availability.
+import Testing
+import DesertAnt
+
+/// A model declaration that exists only here, pointing at a repo/revision no
+/// test ever resolves - enough for the availability path, which is answered from
+/// the filesystem alone.
+private enum FakeModel: ModelDeclaration {
+    static let id = "fake"
+    static let product = "Fake"
+    static let revision = "v0.0.1"
+    static let sdkVersion = "0.0.1"
+    static let summary = "A model that only exists in this test."
+    static let files: [ModelPlatform: [String]] = Dictionary(
+        uniqueKeysWithValues: ModelPlatform.allCases.map { ($0, ["fake.bin", "fake.json"]) })
+    static func artifact(for platform: ModelPlatform) -> String { "fake.bin" }
+}
+
+private struct Runtime: Sendable, Hashable { let id: Int }
+
+private struct LoadFailed: Error, Equatable {}
+
+struct LoadedModelTests {
+    @Test func constructionLoadsNothing() async throws {
+        let builds = Counter()
+        let model = LoadedModel<Runtime> {
+            builds.increment()
+            return Runtime(id: 1)
+        }
+        #expect(builds.value == 0, "construction must not build the runtime")
+        _ = try await model.value()
+        #expect(builds.value == 1)
+    }
+
+    @Test func theRuntimeIsBuiltOnceAndShared() async throws {
+        let builds = Counter()
+        let model = LoadedModel<Runtime> {
+            builds.increment()
+            return Runtime(id: builds.value)
+        }
+        // Concurrent first uses join one load rather than racing to build.
+        let values = try await withThrowingTaskGroup(of: Runtime.self) { group in
+            for _ in 0..<8 { group.addTask { try await model.value() } }
+            var out: [Runtime] = []
+            for try await value in group { out.append(value) }
+            return out
+        }
+        #expect(builds.value == 1, "eight callers, one build")
+        #expect(Set(values) == [Runtime(id: 1)])
+        // A later call reuses it too.
+        #expect(try await model.value() == Runtime(id: 1))
+        #expect(builds.value == 1)
+    }
+
+    @Test func aFailedLoadIsNotCached() async throws {
+        let attempts = Counter()
+        let model = LoadedModel<Runtime> {
+            attempts.increment()
+            if attempts.value == 1 { throw LoadFailed() }
+            return Runtime(id: attempts.value)
+        }
+        await #expect(throws: LoadFailed.self) { try await model.value() }
+        // The failure must not be remembered: a retry gets a real value.
+        #expect(try await model.value() == Runtime(id: 2))
+        #expect(attempts.value == 2)
+    }
+
+    @Test func downloadReportsProgressAndEndsAtOne() async throws {
+        let model = LoadedModel<Runtime> { Runtime(id: 1) }
+        let fractions = Fractions()
+        try await model.download { fractions.append($0) }
+        #expect(fractions.values.last == 1)
+        #expect(fractions.values == fractions.values.sorted(), "progress is monotonic")
+        // Already loaded: a second download is a no-op that still reports done.
+        try await model.download()
+        #expect(model.isDownloaded(), "a supplied runtime needs no network")
+    }
+
+    @Test func availabilityIsAnsweredOfflineFromTheDirectory() async throws {
+        // A directory with none of the model's files is not available, and asking
+        // must not download anything.
+        let model = LoadedModel(FakeModel.self, directory: "/desert-ant-tests/does-not-exist") { _ in
+            Runtime(id: 1)
+        }
+        #expect(model.isDownloaded() == false)
+    }
+}
+
+/// Minimal shared counters (the closures are `@Sendable`, so they cannot capture
+/// a local `var`).
+private final class Counter: @unchecked Sendable {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}
+
+private final class Fractions: @unchecked Sendable {
+    private(set) var values: [Double] = []
+    func append(_ value: Double) { values.append(value) }
+}


### PR DESCRIPTION
The Swift half of the same cleanup we did for JS in #41. `Emo.swift` and
`Redact.swift` each carried ~120 lines of identical shell: a `LazyLoader`, three
initializers, an availability closure, `isDownloaded`, `download(progress:)`,
`waitUntilLoaded`, and a pair of resolve/availability helpers over their
`ModelDistribution`. Only the type they built differed.

It is also the part of an SDK that can go quietly wrong. The `@_spi`
`init(directory:cacheRoot:)` looks redundant next to `init(directory:)`, but
Android and Node have no cache base of their own - a model that forgets it
silently breaks both.

## What moved

`LoadedModel<Runtime>` in the catalog's shared half:

- resolves the model's files (adopt `directory`, else download into it, else the
  managed per-model/revision cache),
- builds the runtime once and shares that single load with every concurrent
  caller, reporting monotonic progress,
- does not cache a failed load, so a later call retries,
- answers `isDownloaded()` offline from the declaration + directory,
- and has a second initializer that wraps a runtime whose inputs the caller
  already has (the cross-language bindings' assets path, the wasm host's
  self-hosted files), so that path is lazy and single-flight too rather than a
  special case.

## What an SDK keeps

Its public API, and how a resolved directory becomes its runtime:

```swift
public final class Emo: @unchecked Sendable {
    private let model: LoadedModel<Model>

    public convenience init(directory: String? = nil) {
        self.init(directory: directory, cacheRoot: nil)
    }

    @_spi(EmoBindings)
    public init(directory: String?, cacheRoot: String?) {
        model = LoadedModel(EmoModel.self, directory: directory, cacheRoot: cacheRoot) { files in
            try Model(assets: await .emo(files: files))
        }
    }

    public func isDownloaded() -> Bool { model.isDownloaded() }
    public func suggestions(...) async throws -> [EmoSuggestion] {
        try await model.value().suggestions(...)
    }
}
```

`Emo.swift` and `Redact.swift` lose 27 lines each, `ModelLoading.swift` 18 each
(`resolvedAssets`, `isModelAvailable`, `distribution()` are gone; `modelRepo` /
`modelRevision` stay). **The public API is unchanged** - same initializers, same
methods, same `@_spi` surface; `init(directory:cacheRoot:)` and `init(assets:)`
are now designated rather than convenience initializers, which callers cannot
see.

`ModelCatalog` gains a `PlatformSupport` dependency for `LazyLoader` (no cycle:
`PlatformSupport` depends on neither).

## Tests

Five new tests pin exactly the behaviour each SDK used to hand-write, and got to
choose independently:

- construction builds nothing,
- eight concurrent first uses trigger one build and all get the same value,
- a failed load is not cached (the retry succeeds),
- `download(progress:)` reports monotonic progress ending at 1, and a second
  download is a no-op,
- availability is answered offline, with no download attempt.

## Verification

On pv-studio: host build, wasm build of `EmoWeb` + `RedactWeb`, and `swift test`
- 87 tests, the only 2 failures being the pre-existing `HTTPClientTests` ones
that need the echo server `mise run test-macos` starts. The model-backed Emo and
Redact suites ran real inference through the new loader. Scratch dir cleaned up.

## Next

The Kotlin handle base class (~55 lines/model), a generic `HubDownloadTests`, and
deriving `Package.swift`'s four per-model lists from one array.
