### PR TITLE
Give Android model SDKs one handle owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,13 @@ plumbing:
 
 ## HostBridge (Android JNI)
 
-The reusable Swift JNI harness every Android model SDK repeats: byte-array
-marshalling (`hostCopyBytes` / `hostMakeBytes` / `withHostCText` /
-`hostTakeBuffer`), the `GetEnv`-checked thread attach, and `installHostBridge`,
-which wires the `CHostBridge` regex/JSON callbacks to a host class's static
-`regexMatches` / `jsonParseTree` methods. The Kotlin counterpart
-(`kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt`) ships as the
-`ai.desertant:core` Android artifact, so a model SDK depends on it rather than
-vendoring the file:
+The reusable Swift JNI harness provides byte-array marshalling
+(`hostCopyBytes` / `hostMakeBytes` / `withHostCText` / `hostTakeBuffer`), the
+`GetEnv`-checked thread attach, and `installHostBridge`, which wires the
+`CHostBridge` callbacks to Kotlin. Its Kotlin counterpart ships in the
+`ai.desertant:core` Android artifact alongside the generic `DesertAntNative`
+JNI surface and `LoadedModel` SDK shell, so a model SDK depends on them rather
+than implementing any of that lifecycle itself:
 
 ```kotlin
 dependencies {
@@ -280,8 +279,13 @@ dependencies {
 }
 ```
 
-A model keeps only its own `@_cdecl("Java_...")` entry points and thin
-`@JvmStatic` forwarders to `HostBridge`. Empty off-Android.
+The native ABI takes a catalog `modelId`, so adding a model adds no JNI symbol
+or Kotlin native class. Its Android SDK wraps one `LoadedModel(modelId, name,
+context, directory, exceptionFactory)`, then keeps only its typed API plus the
+options/result payload codec. The shared shell creates the opaque handle,
+checks offline availability, moves download and inference off the main thread,
+preserves each SDK's exception type, guards use after close, and releases the
+handle exactly once.
 
 Build and publish the artifact with mise (reproducible; provisions the Android
 SDK on first run): `mise run build-android`, `mise run publish-android`

--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -33,8 +33,8 @@ version = "1.2.3"                        // single-sourced for mise set-version/
 desertAntSdk { description = "On-device ... for Android." }
 ```
 
-Everything else (namespace, coordinates, POM name/url/license/scm, the core +
-coroutines dependencies, the `buildSwiftNatives` task) is derived
+Everything else (namespace, coordinates, POM name/url/license/scm, the core
+and instrumentation-test dependencies, the `buildSwiftNatives` task) is derived
 from the Gradle root project name (`rootProject.name = "<model>"`). Override the
 core dependency version with `desertAntSdk { coreVersion = "X.Y.Z" }`.
 

--- a/gradle-plugin/src/main/kotlin/ai/desertant/gradle/ModelSdkPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ai/desertant/gradle/ModelSdkPlugin.kt
@@ -63,8 +63,9 @@ class ModelSdkPlugin : Plugin<Project> {
         }
 
         val deps = project.dependencies
+        // Core owns LoadedModel's coroutine runtime, so model modules need no
+        // second direct dependency.
         deps.add("implementation", "ai.desertant:core:${ext.coreVersion.get()}")
-        deps.add("implementation", "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
         deps.add("androidTestImplementation", "androidx.test.ext:junit:1.2.1")
         deps.add("androidTestImplementation", "androidx.test:runner:1.6.2")
         deps.add("androidTestImplementation", "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -2,8 +2,10 @@ import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 // Publishable Android library for `ai.desertant:core`: the reusable Android host
-// side of desert-ant-core's Swift JNI harness (HostBridge.kt). Model SDKs used
-// to vendor this file verbatim; they now depend on this artifact instead.
+// side of desert-ant-core's Swift JNI harness (HostBridge.kt), the JNI surface
+// itself (DesertAntNative.kt), and the shared model shell every SDK wraps
+// (LoadedModel.kt). Model SDKs used to vendor this verbatim; they now depend on
+// this artifact instead.
 //
 // It is pure Kotlin (no native code, no prebuilt .so), so unlike the model SDKs
 // this AAR could build from source anywhere. We still publish it to Maven
@@ -52,6 +54,9 @@ dependencies {
     // HostBridge.kt parses the Hugging Face tree JSON and emits the binary value
     // tree with kotlinx.serialization; the model SDKs already pull the same lib.
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    // LoadedModel uses Dispatchers internally for download and inference.
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    testImplementation("junit:junit:4.13.2")
 }
 
 mavenPublishing {

--- a/kotlin/src/main/kotlin/ai/desertant/core/LoadedModel.kt
+++ b/kotlin/src/main/kotlin/ai/desertant/core/LoadedModel.kt
@@ -1,0 +1,152 @@
+package ai.desertant.core
+
+import android.content.Context
+import ai.desertant.DesertAntNative
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * A model loaded through the shared native core, behind its opaque handle - the
+ * Android counterpart of the Swift SDK's `LoadedModel` and the JS SDK's.
+ *
+ * Every model SDK used to write this itself: load the libraries, create the
+ * handle, check availability, download off the main thread, run and hand back a
+ * reader, and release exactly once. Only the exception type differed. It is also
+ * where an SDK could go quietly wrong - the handle is a retained pointer, so
+ * releasing it twice over-releases the model and using it after release
+ * dereferences freed memory, both easy to hit with `use { }` plus a defensive
+ * `close()`.
+ *
+ * So it lives here once, and a model SDK keeps only its public API and its
+ * payload schemas:
+ *
+ * ```kotlin
+ * class Emo(context: Context, directory: String? = null) : AutoCloseable {
+ *     private val model = LoadedModel(MODEL_ID, "Emo", context, directory, ::EmoException)
+ *
+ *     suspend fun suggestions(text: String, limit: Int = 3): List<EmoSuggestion> {
+ *         return model.run(text, FfiWriter().int(limit).done()) { r ->
+ *             List(r.int()) { EmoSuggestion(r.string(), r.double()) }
+ *         }
+ *     }
+ *
+ *     override fun close() = model.close()
+ * }
+ * ```
+ *
+ * @param modelId the catalog id (`"emo"`, `"redact"`, ...), which is how the
+ *   model-agnostic native ABI is asked for this model.
+ * @param name the public SDK name, used in its existing creation/closed errors.
+ * @param context used only for its cache dir, the base of the managed model
+ *   cache.
+ * @param directory the model's home. Files already there are adopted (so an app
+ *   that ships the model points at the folder it unpacked it into), otherwise
+ *   the model is downloaded into it. Null uses the managed cache.
+ * @param fail builds the SDK's own exception type, so callers keep catching
+ *   `EmoException` / `RedactException` rather than something generic.
+ */
+class LoadedModel internal constructor(
+    modelId: String,
+    private val name: String,
+    cacheRoot: String,
+    directory: String?,
+    private val fail: (String) -> Exception,
+    private val native: NativeModelApi,
+) : AutoCloseable {
+    private val handle: Long
+
+    @Volatile private var closed = false
+
+    constructor(
+        modelId: String,
+        name: String,
+        context: Context,
+        directory: String? = null,
+        fail: (String) -> Exception,
+    ) : this(modelId, name, context.cacheDir.absolutePath, directory, fail, JniModelApi)
+
+    init {
+        native.ensureLoaded()
+        // Construction is cheap: the native side is lazy, so nothing is
+        // downloaded or loaded until download() or the first run().
+        handle = native.create(
+            modelId.toByteArray(Charsets.UTF_8),
+            cacheRoot.toByteArray(Charsets.UTF_8),
+            directory?.toByteArray(Charsets.UTF_8),
+        )
+        if (handle == 0L) throw fail("failed to create $name")
+    }
+
+    /**
+     * Hold the same monitor close() uses until the native operation returns, so
+     * another thread cannot destroy the retained pointer between checking
+     * `closed` and using it. It also serializes inference on one model handle.
+     */
+    private inline fun <T> withHandle(operation: (Long) -> T): T = synchronized(this) {
+        if (closed) throw fail("this $name is closed")
+        operation(handle)
+    }
+
+    /** Whether the model is usable with no network. */
+    fun isDownloaded(): Boolean = withHandle { native.isDownloaded(it) != 0 }
+
+    /**
+     * Fetch and load the model ahead of time so the first [run] is instant. A
+     * no-op once available (see [isDownloaded]). Blocking work runs on the IO
+     * dispatcher.
+     */
+    suspend fun download(): Unit = withContext(Dispatchers.IO) {
+        if (withHandle { native.download(it) } != 0) throw fail("model download failed")
+    }
+
+    /**
+     * Run the model over [text] with the model's own [options] payload (null for
+     * its defaults), then [decode] the model's result payload. Both inference
+     * and decoding run on the default dispatcher.
+     */
+    suspend fun <Result> run(
+        text: String,
+        options: ByteArray? = null,
+        failureMessage: String = "model run failed",
+        decode: (FfiReader) -> Result,
+    ): Result = withContext(Dispatchers.Default) {
+        val bytes = withHandle {
+            native.run(it, text.toByteArray(Charsets.UTF_8), options)
+        } ?: throw fail(failureMessage)
+        // Decode here too, rather than returning to a possibly-main caller with
+        // the model's binary result still to process.
+        decode(FfiReader(bytes))
+    }
+
+    /**
+     * Release the native model. It is unusable afterwards, and calling this again
+     * is a no-op.
+     */
+    @Synchronized override fun close() {
+        if (closed) return
+        closed = true
+        native.destroy(handle)
+    }
+}
+
+/** The native operations are injectable only so the lifecycle can be tested on
+ * the host JVM without loading Android's native libraries. */
+internal interface NativeModelApi {
+    fun ensureLoaded()
+    fun create(modelId: ByteArray, cacheRoot: ByteArray?, directory: ByteArray?): Long
+    fun destroy(handle: Long)
+    fun isDownloaded(handle: Long): Int
+    fun download(handle: Long): Int
+    fun run(handle: Long, text: ByteArray, options: ByteArray?): ByteArray?
+}
+
+private object JniModelApi : NativeModelApi {
+    override fun ensureLoaded() = DesertAntNative.ensureLoaded()
+    override fun create(modelId: ByteArray, cacheRoot: ByteArray?, directory: ByteArray?) =
+        DesertAntNative.create(modelId, cacheRoot, directory)
+    override fun destroy(handle: Long) = DesertAntNative.destroy(handle)
+    override fun isDownloaded(handle: Long) = DesertAntNative.isDownloaded(handle)
+    override fun download(handle: Long) = DesertAntNative.download(handle)
+    override fun run(handle: Long, text: ByteArray, options: ByteArray?) =
+        DesertAntNative.run(handle, text, options)
+}

--- a/kotlin/src/test/kotlin/ai/desertant/core/LoadedModelTest.kt
+++ b/kotlin/src/test/kotlin/ai/desertant/core/LoadedModelTest.kt
@@ -1,0 +1,143 @@
+package ai.desertant.core
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LoadedModelTest {
+    @Test fun createsTheRightCatalogHandleWithoutLoadingTheRuntime() {
+        val native = FakeNative()
+        model(native, directory = "/models/emo")
+
+        assertTrue(native.loaded)
+        assertEquals("emo", native.modelId.decodeToString())
+        assertEquals("/cache", native.cacheRoot.decodeToString())
+        assertEquals("/models/emo", native.directory?.decodeToString())
+        assertEquals(1, native.creates)
+        assertEquals(0, native.downloads)
+        assertEquals(0, native.runs)
+    }
+
+    @Test fun availabilityDownloadAndRunUseOneHandle() = runBlocking {
+        val native = FakeNative().apply {
+            available = 1
+            result = FfiWriter().int(42).done()
+        }
+        val model = model(native)
+
+        assertTrue(model.isDownloaded())
+        model.download()
+        val options = byteArrayOf(1, 2, 3)
+        val result = model.run("hello", options) { it.int() }
+
+        assertEquals(42, result)
+        assertEquals(listOf(73L, 73L, 73L), native.usedHandles)
+        assertEquals("hello", native.text.decodeToString())
+        assertArrayEquals(options, native.options)
+    }
+
+    @Test fun nativeFailuresBecomeTheModelsException() {
+        val unavailable = FakeNative().apply { createResult = 0 }
+        val create = assertThrows(TestModelException::class.java) { model(unavailable) }
+        assertEquals("failed to create Emo", create.message)
+
+        val downloadNative = FakeNative().apply { downloadResult = 1 }
+        val download = assertThrows(TestModelException::class.java) {
+            runBlocking { model(downloadNative).download() }
+        }
+        assertEquals("model download failed", download.message)
+
+        val runNative = FakeNative().apply { result = null }
+        val run = assertThrows(TestModelException::class.java) {
+            runBlocking {
+                model(runNative).run("hello", failureMessage = "suggestion failed") { it.int() }
+            }
+        }
+        assertEquals("suggestion failed", run.message)
+    }
+
+    @Test fun closeReleasesExactlyOnceAndGuardsEveryOperation() {
+        val native = FakeNative()
+        val model = model(native)
+        model.close()
+        model.close()
+
+        assertEquals(1, native.destroys)
+        assertEquals(73L, native.destroyedHandle)
+        val availability = assertThrows(TestModelException::class.java) { model.isDownloaded() }
+        assertEquals("this Emo is closed", availability.message)
+        assertThrows(TestModelException::class.java) { runBlocking { model.download() } }
+        assertThrows(TestModelException::class.java) {
+            runBlocking { model.run("hello") { it.int() } }
+        }
+        assertFalse(native.usedHandles.isNotEmpty())
+    }
+
+    private fun model(native: FakeNative, directory: String? = null) = LoadedModel(
+        modelId = "emo",
+        name = "Emo",
+        cacheRoot = "/cache",
+        directory = directory,
+        fail = ::TestModelException,
+        native = native,
+    )
+}
+
+private class TestModelException(message: String) : Exception(message)
+
+private class FakeNative : NativeModelApi {
+    var loaded = false
+    var creates = 0
+    var createResult = 73L
+    var modelId = byteArrayOf()
+    var cacheRoot = byteArrayOf()
+    var directory: ByteArray? = null
+    var available = 0
+    var downloads = 0
+    var downloadResult = 0
+    var runs = 0
+    var text = byteArrayOf()
+    var options: ByteArray? = null
+    var result: ByteArray? = byteArrayOf()
+    val usedHandles = mutableListOf<Long>()
+    var destroys = 0
+    var destroyedHandle = 0L
+
+    override fun ensureLoaded() { loaded = true }
+
+    override fun create(modelId: ByteArray, cacheRoot: ByteArray?, directory: ByteArray?): Long {
+        creates += 1
+        this.modelId = modelId
+        this.cacheRoot = checkNotNull(cacheRoot)
+        this.directory = directory
+        return createResult
+    }
+
+    override fun destroy(handle: Long) {
+        destroys += 1
+        destroyedHandle = handle
+    }
+
+    override fun isDownloaded(handle: Long): Int {
+        usedHandles += handle
+        return available
+    }
+
+    override fun download(handle: Long): Int {
+        usedHandles += handle
+        downloads += 1
+        return downloadResult
+    }
+
+    override fun run(handle: Long, text: ByteArray, options: ByteArray?): ByteArray? {
+        usedHandles += handle
+        runs += 1
+        this.text = text
+        this.options = options
+        return result
+    }
+}

--- a/packages/emo-kotlin/src/main/kotlin/ai/desertant/emo/Emo.kt
+++ b/packages/emo-kotlin/src/main/kotlin/ai/desertant/emo/Emo.kt
@@ -1,15 +1,11 @@
 package ai.desertant.emo
 
-import ai.desertant.DesertAntNative
-import ai.desertant.core.FfiReader
 import ai.desertant.core.FfiWriter
-
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import ai.desertant.core.LoadedModel
 
 /** The catalog id, which is how the shared native layer is asked for Emo. */
 private const val MODEL_ID = "emo"
-private val MODEL_ID_BYTES = MODEL_ID.toByteArray(Charsets.UTF_8)
+private const val MODEL_NAME = "Emo"
 
 /** A single emoji suggestion returned by [Emo.suggestions]. */
 data class EmoSuggestion(
@@ -33,53 +29,34 @@ class EmoException(message: String) : Exception(message)
  * val toned = emo.suggestions("go for a run", limit = 1, skinTone = EmojiSkinTone.MEDIUM)
  * emo.close()
  * ```
+ *
+ * Creating, downloading, running, and releasing the model are the shared
+ * `ai.desertant:core` shell ([LoadedModel]); what lives here is Emo's API and
+ * its payload schemas.
+ *
+ * @param directory the model's home. Files already there are adopted (so an app
+ *   that ships the model just points at the folder it unpacked it into),
+ *   otherwise the model is downloaded into it. Omit to use the app cache.
  */
-class Emo private constructor(private val handle: Long) : AutoCloseable {
-    // The native handle is a retained pointer: releasing it twice over-releases
-    // the model, and using it after release dereferences freed memory. Both are
-    // easy to hit with `use { }` plus a defensive close(), so guard here rather
-    // than crash the app.
-    @Volatile private var closed = false
+class Emo(
+    context: android.content.Context,
+    directory: String? = null,
+) : AutoCloseable {
+    private val model = LoadedModel(MODEL_ID, MODEL_NAME, context, directory, ::EmoException)
 
-    private fun handleOrThrow(): Long {
-        if (closed) throw EmoException("this Emo is closed")
-        return handle
-    }
-
-    /**
-     * A suggester that downloads the model into the app cache on first use and
-     * reuses it offline afterward. When [directory] is supplied, that directory
-     * is the model's home instead: files already there are adopted (so an app
-     * that ships the model just points at the folder it unpacked it into),
-     * otherwise the model is downloaded into it. Construction is cheap; the
-     * model loads on the first [suggestions] (or eagerly via [download]).
-     */
-    constructor(context: android.content.Context, directory: String? = null)
-        : this(createHandle(context.cacheDir.absolutePath, directory))
-
-    companion object {
-        private fun createHandle(cacheRoot: String, directory: String?): Long {
-            DesertAntNative.ensureLoaded()
-            val handle = DesertAntNative.create(
-                MODEL_ID_BYTES,
-                cacheRoot.toByteArray(Charsets.UTF_8),
-                directory?.toByteArray(Charsets.UTF_8))
-            if (handle == 0L) throw EmoException("failed to create Emo")
-            return handle
-        }
-    }
+    // The old handle factory lived here. Keep the marker so the generated JVM
+    // `Emo.Companion` field remains binary-compatible.
+    companion object
 
     /** Whether the model is available for this suggester with no network. */
-    fun isDownloaded(): Boolean = DesertAntNative.isDownloaded(handleOrThrow()) != 0
+    fun isDownloaded(): Boolean = model.isDownloaded()
 
     /**
      * Download the model ahead of time so the first [suggestions] is instant. A
      * no-op once available (see [isDownloaded]). Suspends on a background
      * dispatcher.
      */
-    suspend fun download(): Unit = withContext(Dispatchers.IO) {
-        if (DesertAntNative.download(handleOrThrow()) != 0) throw EmoException("model download failed")
-    }
+    suspend fun download() = model.download()
 
     /**
      * Suggest emojis for [text], most likely first. Returns up to [limit]
@@ -88,22 +65,18 @@ class Emo private constructor(private val handle: Long) : AutoCloseable {
      */
     suspend fun suggestions(
         text: String, limit: Int = 3, skinTone: EmojiSkinTone = EmojiSkinTone.DEFAULT,
-    ): List<EmoSuggestion> = withContext(Dispatchers.Default) {
-        if (text.isBlank()) return@withContext emptyList()
-        // Options payload: u32 limit, u32 skinTone. Must match the reader in
+    ): List<EmoSuggestion> {
+        if (text.isBlank()) return emptyList()
+        // Options payload: u32 limit, u32 skinTone; result payload: a count, then
+        // per suggestion an emoji string and an f64 confidence. Must match
         // Sources/ModelCatalog/Emo/Binding.swift.
         val options = FfiWriter().int(limit).int(skinTone.nativeValue).done()
-        val bytes = DesertAntNative.run(handleOrThrow(), text.toByteArray(Charsets.UTF_8), options)
-            ?: throw EmoException("suggestion failed")
-        val r = FfiReader(bytes)
-        List(r.int()) { EmoSuggestion(r.string(), r.double()) }
+        return model.run(text, options, failureMessage = "suggestion failed") { r ->
+            List(r.int()) { EmoSuggestion(r.string(), r.double()) }
+        }
     }
 
-    /** Release the native model. The suggester is unusable afterwards; calling this
-     *  again is a no-op. */
-    @Synchronized override fun close() {
-        if (closed) return
-        closed = true
-        DesertAntNative.destroy(handle)
-    }
+    /** Release the native model. The suggester is unusable afterwards; calling
+     *  this again is a no-op. */
+    @Synchronized override fun close() = model.close()
 }

--- a/packages/redact-kotlin/src/main/kotlin/ai/desertant/redact/Redact.kt
+++ b/packages/redact-kotlin/src/main/kotlin/ai/desertant/redact/Redact.kt
@@ -1,14 +1,11 @@
 package ai.desertant.redact
 
-import ai.desertant.DesertAntNative
-import ai.desertant.core.FfiReader
 import ai.desertant.core.FfiWriter
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import ai.desertant.core.LoadedModel
 
 /** The catalog id, which is how the shared native layer is asked for Redact. */
 private const val MODEL_ID = "redact"
-private val MODEL_ID_BYTES = MODEL_ID.toByteArray(Charsets.UTF_8)
+private const val MODEL_NAME = "Redact"
 
 /** A single detected entity and the placeholder that stands in for it. */
 data class RedactionItem(
@@ -67,53 +64,34 @@ class RedactException(message: String) : Exception(message)
  * r.redactedText            // "Email [GIVEN_NAME_1] at [EMAIL_1]."
  * redact.close()
  * ```
+ *
+ * Creating, downloading, running, and releasing the model are the shared
+ * `ai.desertant:core` shell ([LoadedModel]); what lives here is Redact's API and
+ * its payload schemas.
+ *
+ * @param directory the model's home. Files already there are adopted (so an app
+ *   that ships the model just points at the folder it unpacked it into),
+ *   otherwise the model is downloaded into it. Omit to use the app cache.
  */
-class Redact private constructor(private val handle: Long) : AutoCloseable {
-    // The native handle is a retained pointer: releasing it twice over-releases
-    // the model, and using it after release dereferences freed memory. Both are
-    // easy to hit with `use { }` plus a defensive close(), so guard here rather
-    // than crash the app.
-    @Volatile private var closed = false
+class Redact(
+    context: android.content.Context,
+    directory: String? = null,
+) : AutoCloseable {
+    private val model = LoadedModel(MODEL_ID, MODEL_NAME, context, directory, ::RedactException)
 
-    private fun handleOrThrow(): Long {
-        if (closed) throw RedactException("this Redact is closed")
-        return handle
-    }
-
-    /**
-     * A redactor that downloads the model into the app cache on first use and
-     * reuses it offline afterward. When [directory] is supplied, that directory
-     * is the model's home instead: files already there are adopted (so an app
-     * that ships the model just points at the folder it unpacked it into),
-     * otherwise the model is downloaded into it. Construction is cheap; the
-     * model loads on the first [redaction] (or eagerly via [download]).
-     */
-    constructor(context: android.content.Context, directory: String? = null)
-        : this(createHandle(context.cacheDir.absolutePath, directory))
-
-    companion object {
-        private fun createHandle(cacheRoot: String, directory: String?): Long {
-            DesertAntNative.ensureLoaded()
-            val handle = DesertAntNative.create(
-                MODEL_ID_BYTES,
-                cacheRoot.toByteArray(Charsets.UTF_8),
-                directory?.toByteArray(Charsets.UTF_8))
-            if (handle == 0L) throw RedactException("failed to create Redact")
-            return handle
-        }
-    }
+    // The old handle factory lived here. Keep the marker so the generated JVM
+    // `Redact.Companion` field remains binary-compatible.
+    companion object
 
     /** Whether the model is available for this redactor with no network. */
-    fun isDownloaded(): Boolean = DesertAntNative.isDownloaded(handleOrThrow()) != 0
+    fun isDownloaded(): Boolean = model.isDownloaded()
 
     /**
      * Download the model ahead of time so the first [redaction] is instant. A
      * no-op once available (see [isDownloaded]). Suspends on a background
      * dispatcher.
      */
-    suspend fun download(): Unit = withContext(Dispatchers.IO) {
-        if (DesertAntNative.download(handleOrThrow()) != 0) throw RedactException("model download failed")
-    }
+    suspend fun download() = model.download()
 
     /**
      * Detect and redact the PII in [text]. Each entity is replaced by a unique,
@@ -121,41 +99,32 @@ class Redact private constructor(private val handle: Long) : AutoCloseable {
      * an LLM and restore afterwards via [Redaction.restore]. Loads the model
      * lazily on first call.
      */
-    suspend fun redaction(text: String, options: Options = Options()): Redaction =
-        withContext(Dispatchers.Default) {
-            // Options payload: f64 minimumConfidence, then an int label count and
-            // that many names (empty means every label). Must match the reader in
-            // Sources/ModelCatalog/Redact/Binding.swift.
-            val payload = FfiWriter()
-                .double(options.minimumConfidence)
-                .strings(options.labels?.toList() ?: emptyList())
-                .done()
-            val bytes = DesertAntNative.run(handleOrThrow(), text.toByteArray(Charsets.UTF_8), payload)
-                ?: throw RedactException("redaction failed")
-            val buf = FfiReader(bytes)  // matches the native FFIWriter encoding
-            val redactedText = buf.string()
-            val n = buf.int()
-            val items = ArrayList<RedactionItem>(n)
-            repeat(n) {
-                items.add(
-                    RedactionItem(
-                        label = buf.string(),
-                        original = buf.string(),
-                        placeholder = buf.string(),
-                        confidence = buf.double(),
-                        start = buf.int(),
-                        end = buf.int(),
-                    )
+    suspend fun redaction(text: String, options: Options = Options()): Redaction {
+        // Options payload: f64 minimumConfidence, then a label count and that
+        // many names (empty means every label); result payload: the redacted
+        // text, an item count, then per item its strings, confidence, and UTF-16
+        // offsets. Must match Sources/ModelCatalog/Redact/Binding.swift.
+        val payload = FfiWriter()
+            .double(options.minimumConfidence)
+            .strings(options.labels?.toList() ?: emptyList())
+            .done()
+        return model.run(text, payload, failureMessage = "redaction failed") { r ->
+            val redactedText = r.string()
+            val items = List(r.int()) {
+                RedactionItem(
+                    label = r.string(),
+                    original = r.string(),
+                    placeholder = r.string(),
+                    confidence = r.double(),
+                    start = r.int(),
+                    end = r.int(),
                 )
             }
             Redaction(redactedText = redactedText, items = items)
         }
-
-    /** Release the native model. The redactor is unusable afterwards; calling this
-     *  again is a no-op. */
-    @Synchronized override fun close() {
-        if (closed) return
-        closed = true
-        DesertAntNative.destroy(handle)
     }
+
+    /** Release the native model. The redactor is unusable afterwards; calling
+     *  this again is a no-op. */
+    @Synchronized override fun close() = model.close()
 }


### PR DESCRIPTION
The Android counterpart to #43. Emo and Redact each repeated the same native
lifecycle: load the shared libraries, encode model id and paths, create an
opaque handle, guard closed access, query availability, dispatch downloads and
inference away from main, map native failure to the model's exception, and
destroy exactly once.

## Shared shell

`LoadedModel` now lives in `ai.desertant:core` and owns that entire lifecycle:

```kotlin
class Emo(context: Context, directory: String? = null) : AutoCloseable {
    private val model = LoadedModel("emo", "Emo", context, directory, ::EmoException)

    fun isDownloaded() = model.isDownloaded()
    suspend fun download() = model.download()

    suspend fun suggestions(...): List<EmoSuggestion> =
        model.run(text, options, failureMessage = "suggestion failed") { r ->
            List(r.int()) { EmoSuggestion(r.string(), r.double()) }
        }

    @Synchronized override fun close() = model.close()
}
```

A model SDK now keeps only:

- its model id and public name,
- its public data types and typed methods,
- the model-specific options/result payload codec,
- one `LoadedModel` field and tiny delegations.

The shell preserves each SDK's exception type and its exact existing error
messages. Download remains on `Dispatchers.IO`; inference and result decoding
remain together on `Dispatchers.Default` rather than returning binary decoding
to a possibly-main caller.

## Stronger lifecycle

The duplicated implementation checked `closed`, returned the retained pointer,
and only then called JNI. A concurrent `close()` could destroy that pointer in
between. `LoadedModel` holds the same monitor across check + native operation +
destroy, so close cannot race any use. It also retains the existing guarantees:
idempotent close, and model-specific exceptions instead of a crash after close.

## Dependencies and compatibility

- The coroutines runtime moves from every model module into core, where
  `LoadedModel` actually uses `Dispatchers`; the Gradle plugin no longer adds a
  duplicate direct dependency.
- Existing Kotlin APIs and JVM method descriptors are unchanged.
- Empty companion markers intentionally retain the generated `Emo.Companion`
  and `Redact.Companion` fields, and wrapper `close()` remains synchronized.
- A before/after `javap -public` comparison differs only in the compiler's
  synthetic accessors for the removed private `handleOrThrow` methods.

## Tests

Four host-JVM tests use an internal injectable native interface, so they test
lifecycle without loading Android native libraries:

- catalog id, cache root, and explicit directory are forwarded while
  construction performs no download or run,
- availability, download, and run all use the single created handle,
- create/download/run failures preserve exact model-specific exceptions,
- close destroys exactly once and every later operation is guarded.

Verified locally:

- `kotlin:testDebugUnitTest`: 4 tests, 0 failures
- core release AAR assembly
- Gradle plugin build and validation
- clean temporary Android library compiling the real Emo and Redact sources
  together against the core composite build

The temporary verification project was removed afterward.
