### PR TITLE
Feature/bundle clear

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,14 +11,14 @@ concurrency:
 jobs:
   test:
     name: xcodebuild test (iOS Simulator)
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 26.6
 
       - name: Set up mise
         uses: jdx/mise-action@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,14 +11,14 @@ concurrency:
 jobs:
   test:
     name: swift test (macOS)
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 26.6
 
       - name: Set up mise
         uses: jdx/mise-action@v2

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,10 @@ struct ModelPackage {
 
 let models: [ModelPackage] = [
     .init(name: "Emo"),
+    // The catalog's audio model, so the only one that pulls AudioIO/AudioDSP -
+    // both of which come with the DesertAnt umbrella, so it needs no extra
+    // dependency either.
+    .init(name: "Clear"),
     .init(
         name: "Redact",
         dependencies: [.product(name: "RealModule", package: "swift-numerics")],
@@ -134,6 +138,7 @@ let libraryTargets: [Target] = [
                 "Regex", "JSON", "TextNormalization", "Checksum",
                 "PlatformSupport", "Usage",
                 "ModelCatalog", "ModelStore", "Inference",
+                "AudioIO", "AudioDSP",
                 "FFIBuffer", "ModelBinding", "HostBridge",
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -4,10 +4,24 @@ import Foundation
 
 // Shared package for Desert Ant Labs' on-device model SDKs.
 //
-// JavaScriptKit pulls macros that conflict with Android's static-stdlib link.
-// Android builds therefore omit it; wasm-only sources are already conditional.
+// The wasm backends need JavaScriptKit, which pulls swift-syntax (macros). A
+// package dependency cannot carry a platform condition -- only the *product*
+// dependencies below can -- so declaring it unconditionally makes every consumer
+// (iOS, macOS, Linux, Android) clone JavaScriptKit + swift-syntax and build the
+// host macro plugins, for code that is entirely `#if os(WASI)`. It also breaks
+// Android's static-stdlib link, where host macros conflict with `-resource-dir`.
+//
+// So JavaScriptKit is opt-in: only a build that actually targets wasm sets
+// DAL_WASM_BUILD=1 (mise `test-wasi`, sdk-build `build-web`). Everyone else
+// resolves a graph without it. SWIFT_ANDROID_STATIC_BUILD stays honoured as a
+// hard opt-out so an Android build can never pick it up by accident.
+//
+// `Package.resolved` differs between the two modes (SwiftPM prunes unused pins),
+// which is why it stays gitignored -- switching modes just re-resolves.
 
-let noJavaScriptKit = ProcessInfo.processInfo.environment["SWIFT_ANDROID_STATIC_BUILD"] != nil
+let wasmBuild = ProcessInfo.processInfo.environment["DAL_WASM_BUILD"] != nil
+let noJavaScriptKit = !wasmBuild
+    || ProcessInfo.processInfo.environment["SWIFT_ANDROID_STATIC_BUILD"] != nil
 
 let jsDependencies: [Package.Dependency] = noJavaScriptKit ? [] : [
     .package(url: "https://github.com/swiftwasm/JavaScriptKit", from: "0.56.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,10 @@ let products: [Product] = [
         .library(name: "FFIBuffer", targets: ["FFIBuffer"]),
         .library(name: "ModelBinding", targets: ["ModelBinding"]),
         .library(name: "Checksum", targets: ["Checksum"]),
+        // Cross-platform audio: decode/encode (AudioIO) and STFT/mel/framing
+        // DSP (AudioDSP), so audio model SDKs ship no per-platform audio code.
+        .library(name: "AudioIO", targets: ["AudioIO"]),
+        .library(name: "AudioDSP", targets: ["AudioDSP"]),
         .library(name: "ModelStore", targets: ["ModelStore"]),
         .library(name: "ModelCatalog", targets: ["ModelCatalog"]),
         .library(name: "PlatformSupport", targets: ["PlatformSupport"]),
@@ -184,6 +188,19 @@ let libraryTargets: [Target] = [
             dependencies: ["ModelStore", "Usage", "PlatformSupport"],
             exclude: models.map(\.name)
         ),
+        // Pure-Swift DSP (STFT/ISTFT, windows, mel, framing, vector ops);
+        // Accelerate-backed on Apple via canImport, so no explicit dependency.
+        .target(name: "AudioDSP"),
+        // Audio decode/encode: AVFoundation on Apple, the host decoder via
+        // CHostBridge on Android, the JS host on wasm, the pure-Swift WAV
+        // codec on Linux/other. FFIBuffer's FFIReader parses the host buffer.
+        .target(
+            name: "AudioIO",
+            dependencies: [
+                .target(name: "FFIBuffer", condition: .when(platforms: [.android])),
+                .target(name: "CHostBridge", condition: .when(platforms: [.android])),
+            ] + jsWasi + jsEventLoop
+        ),
         .target(
             name: "ModelStore",
             dependencies: [
@@ -227,6 +244,9 @@ let testTargets: [Target] = [
             dependencies: ["Inference"],
             resources: [.copy("Resources/testmodel.tflite")]
         ),
+        .testTarget(name: "AudioDSPTests", dependencies: ["AudioDSP"]),
+        .testTarget(name: "AudioIOTests", dependencies: ["AudioIO"]),
+        .testTarget(name: "FFIBufferTests", dependencies: ["FFIBuffer"]),
 ]
 
 let coreTargets: [Target] = libraryTargets + testTargets + modelTargets + modelTestTargets

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,9 @@ import Foundation
 // Android's static-stdlib link, where host macros conflict with `-resource-dir`.
 //
 // So JavaScriptKit is opt-in: only a build that actually targets wasm sets
-// DAL_WASM_BUILD=1 (mise `test-wasi`, sdk-build `build-web`). Everyone else
+// DAL_WASM_BUILD=1 - mise `test-wasi` and `build-wasm-entries`, sdk-build
+// `build-web`. A wasm task that forgets it fails with "no product named
+// 'EmoWeb'", because the *Web products below are declared with it. Everyone else
 // resolves a graph without it. SWIFT_ANDROID_STATIC_BUILD stays honoured as a
 // hard opt-out so an Android build can never pick it up by accident.
 //
@@ -98,6 +100,9 @@ let modelWasmTargets: [Target] = noJavaScriptKit ? [] : models.map { model in
         dependencies: [
             .byName(name: model.name),
             .byName(name: "WasmBindings"),
+            // The model's `ModelBinding` lives in Bindings (a model module
+            // references no FFI), and the wasm ABI is driven by it.
+            .byName(name: "Bindings"),
         ] + jsWasi + jsEventLoop,
         path: "Sources/ModelCatalog/\(model.name)/Web"
     )
@@ -113,7 +118,15 @@ let modelTargets: [Target] = models.map { model in
 } + [
     .target(
         name: "Bindings",
-        dependencies: [.byName(name: "DesertAnt")] + modelDependencies
+        // FFIBuffer and ModelBinding are named explicitly even though the
+        // DesertAnt umbrella re-exports both, because this target calls their
+        // API directly: a dependency you use should be one you declare, and it
+        // keeps the graph honest for tools that read it.
+        dependencies: [
+            .byName(name: "DesertAnt"),
+            .byName(name: "FFIBuffer"),
+            .byName(name: "ModelBinding"),
+        ] + modelDependencies
     ),
 ] + modelWasmTargets
 
@@ -202,7 +215,12 @@ let libraryTargets: [Target] = [
         .target(
             name: "AudioIO",
             dependencies: [
-                .target(name: "FFIBuffer", condition: .when(platforms: [.android])),
+                // FFIBuffer is only *used* on Android (HostAudioIO parses the
+                // host's buffer), but the dependency is unconditional: Xcode
+                // drops a target from a link entirely if any edge to it is
+                // platform-conditional, which loses libFFIBuffer for every
+                // other target that needs it on iOS.
+                "FFIBuffer",
                 .target(name: "CHostBridge", condition: .when(platforms: [.android])),
             ] + jsWasi + jsEventLoop
         ),
@@ -237,6 +255,13 @@ let testTargets: [Target] = [
         .testTarget(name: "InferenceUsageTests", dependencies: ["Inference", "Usage"]),
         .testTarget(name: "PlatformSupportTests", dependencies: ["PlatformSupport"] + jsTestSupport),
         .testTarget(name: "ModelStoreTests", dependencies: ["ModelStore"]),
+        // The FFI payload schemas, which live with the conformances in Bindings
+        // rather than in the model modules (so a model links no FFI layer).
+        .testTarget(
+            name: "BindingsTests",
+            dependencies: [.byName(name: "Bindings"), .byName(name: "DesertAnt"),
+                           .byName(name: "TestSupport")] + modelDependencies
+        ),
         .testTarget(
             name: "ModelCatalogTests",
             dependencies: [.byName(name: "DesertAnt")] + modelDependencies

--- a/README.md
+++ b/README.md
@@ -6,7 +6,20 @@
 [![WASI](https://github.com/Desert-Ant-Labs/desert-ant-core/actions/workflows/wasi.yml/badge.svg)](https://github.com/Desert-Ant-Labs/desert-ant-core/actions/workflows/wasi.yml)
 
 Reusable, cross-platform Swift building blocks shared by Desert Ant Labs'
-on-device model SDKs (redact, emo, shapes, ...).
+on-device model SDKs, plus the model catalog itself.
+
+The models live in this repo under `Sources/ModelCatalog/<Model>/`, one module
+each, all on the same mechanisms (one catalog declaration, the verified model
+store, the platform inference session, one generic C ABI / JNI / wasm entry):
+
+| Model | Product | What it does |
+|---|---|---|
+| `emo` | `Emo` | multilingual emoji suggestion (text in, ranked emoji out) |
+| `redact` | `Redact` | PII detection and redaction (text in, spans out) |
+| `clear` | `Clear` | speech enhancement: denoise, dereverb, loudness-normalize (audio in, 48 kHz mono out) |
+
+Adding a model is a folder there plus one line in the bindings registry; nothing
+shared changes.
 
 A model SDK depends on the single `DesertAnt` product and writes one import:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ importable for consumers that want a narrower dependency:
 | `Regex` (type `Pattern`) | stdlib-`Regex`-shaped matching | `NSRegularExpression` | `java.util.regex` (via `CHostBridge`) | JS `RegExp` |
 | `JSON` | `Codable` decode + encode | `Foundation.JSONDecoder`/`Encoder` | host JSON parser (via `CHostBridge`) + tree encoder | JS `JSON.parse` + tree encoder |
 | `TextNormalization` | `String.nfkc` | Foundation `precomposed...` | platform ICU `unorm2` (`libicu`) | JS `String.normalize` |
+| `AudioIO` | decode to mono `Float` + WAV encode | AVFoundation (Apple) / WAV codec (Linux) | host MediaCodec (via `CHostBridge`) | JS `AudioContext.decodeAudioData` |
+| `AudioDSP` | STFT/ISTFT, mel, windows, framing | Accelerate BLAS/vDSP | pure Swift | pure Swift |
 | `FFIBuffer` | length-prefixed typed C-ABI buffer | same on every platform | | |
 | `WasmBindings` | model-agnostic wasm export surface | empty | empty | `globalThis.__DesertAntExports` |
 | `HostBridge` | Android JNI harness for model SDKs | empty | JNI marshalling + installs `CHostBridge` | empty |
@@ -180,6 +182,51 @@ The JS side resolves it with `wasmExports(modelId)` (or gets it back from
 `browserSetup`/`nodeSetup`), so a model package supplies only its payload codecs.
 `group` and `deviceId` behave exactly as on the C ABI, so usage attribution and
 call grouping work identically on every runtime.
+
+## AudioIO and AudioDSP
+
+One decode/encode API and one DSP toolbox, so an audio model SDK (clear, uhm)
+ships no per-platform audio code. `AudioIO.decode` always returns mono `Float`
+at the sample rate you ask for, resampling and mixing down for you:
+
+```swift
+import AudioIO
+
+let samples = try await AudioIO.decode(path: file, sampleRate: 16_000)  // or decode(bytes:)
+let wav = AudioIO.encodeWAV(samples, sampleRate: 16_000)                // 16-bit PCM, portable
+```
+
+`decode` is `async` (the wasm backend awaits a JS Promise; native backends
+satisfy it synchronously) and picks the backend per platform: AVFoundation on
+Apple, the pure-Swift WAV codec on Linux, the host decoder through
+`CHostBridge`'s `host_audio_decode` on Android, and
+`AudioContext.decodeAudioData` via the `__DalAudioHost` JS global on wasm.
+Encoding a 16-bit PCM WAV is pure Swift, identical everywhere.
+
+The host decoders ship in core's own runtime artifacts, so a model SDK writes no
+audio glue: `HostBridge.audioDecode` (MediaExtractor/MediaCodec) in the
+published `ai.desertant:core` Android artifact, wired by `installHostBridge`;
+and `installAudioHost()` in the `@desert-ant-labs/core` npm package (Web Audio
+in the browser, the WAV codec under Node), which sets `__DalAudioHost`.
+
+`AudioDSP` is the shared spectral/vector toolbox a speech model runs on both
+sides of inference. Pure Swift, Accelerate-backed on Apple (STFT/mel run as BLAS
+matmuls on the vector units), so every platform gets bit-compatible results:
+
+```swift
+import AudioDSP
+
+let stft = STFT(nFFT: 400, hop: 100)          // periodic Hann, center + reflect pad
+let spec = stft.forward(samples)              // magnitude()/phase() available
+let audio = stft.inverse(spec, length: samples.count)   // windowed COLA overlap-add
+
+let (norm, gain) = VectorOps.energyNormalize(samples)   // undo with scaled(_, by: 1/gain)
+let mel = MelSpectrogram(sampleRate: 16_000, nFFT: 400, hop: 160, mels: 80).logMel(samples)
+
+// Run a fixed-size model over an arbitrary-length signal and stitch outputs:
+for (start, end) in Framing.windows(count: n, window: 30 * sr, hop: 25 * sr) { /* run */ }
+var acc = OverlapAccumulator(length: totalFrames)       // average() or normalized() (COLA)
+```
 
 ## ModelStore and model resources
 
@@ -370,10 +417,14 @@ and test it locally with `mise run test-js`.
 
 ## Android wiring
 
-On Android, `Regex`/`JSON` call `host_regex_matches` / `host_json_parse` from
-`CHostBridge`; `HostBridge`'s `installHostBridge` installs the implementations
-once via `host_set_regex_matches` / `host_set_json_parse`. See
-`Sources/CHostBridge/include/CHostBridge.h` for the contract.
+On Android, `Regex`/`JSON`/`AudioIO` call `host_regex_matches` /
+`host_json_parse` / `host_audio_decode` from `CHostBridge`; `HostBridge`'s
+`installHostBridge` installs the implementations once via
+`host_set_regex_matches` / `host_set_json_parse` / `host_set_audio_decode`,
+wired to the shared `HostBridge.kt` statics (`regexMatches` / `jsonParseTree` /
+`audioDecode`) in the published `ai.desertant:core` artifact, so a model SDK
+vendors none of them. See `Sources/CHostBridge/include/CHostBridge.h` for the
+contract.
 
 ## License
 

--- a/Sources/AudioDSP/Framing.swift
+++ b/Sources/AudioDSP/Framing.swift
@@ -1,0 +1,65 @@
+// Sliding-window framing and overlap reassembly: the loop every long-audio
+// model repeats to run a fixed-size model over an arbitrary-length signal
+// (30 s windows with 5 s overlap for a detector, 100-frame chunks for an
+// enhancer) and stitch the per-window outputs back together. The model owns
+// the inference call; this owns the index math and the averaging.
+
+public enum Framing {
+    /// Half-open `[start, end)` window ranges covering `count` items with a
+    /// `window`-sized window stepped by `hop`. The final window is clamped to
+    /// `count` (so it may be shorter) and the walk stops once it reaches the
+    /// end, so there is always at least one window for a non-empty input.
+    public static func windows(count: Int, window: Int, hop: Int) -> [(start: Int, end: Int)] {
+        guard count > 0, window > 0, hop > 0 else { return [] }
+        var out: [(start: Int, end: Int)] = []
+        var start = 0
+        while start < count {
+            let end = min(count, start + window)
+            out.append((start, end))
+            if end == count { break }
+            start += hop
+        }
+        return out
+    }
+}
+
+/// Accumulates values written at overlapping offsets and reduces the overlaps.
+/// `average()` returns the mean of everything written at each index (overlapping
+/// window predictions, e.g. per-frame probabilities); `normalized(by:)` divides
+/// the running sum by a parallel weight sum (windowed COLA overlap-add). Fixed
+/// length, so out-of-range writes are ignored rather than trapping.
+public struct OverlapAccumulator {
+    private var sum: [Float]
+    private var count: [Float]
+
+    public init(length: Int) {
+        sum = [Float](repeating: 0, count: max(0, length))
+        count = [Float](repeating: 0, count: max(0, length))
+    }
+
+    /// Add `values` starting at `offset`, incrementing each touched index's
+    /// count by 1 (or by the matching `weights[i]` when given, for COLA).
+    public mutating func add(_ values: [Float], at offset: Int, weights: [Float]? = nil) {
+        for i in 0..<values.count {
+            let idx = offset + i
+            guard idx >= 0, idx < sum.count else { continue }
+            sum[idx] += values[i]
+            count[idx] += weights?[i] ?? 1
+        }
+    }
+
+    /// The per-index mean (sum / times-written); indices never written are 0.
+    public func average() -> [Float] {
+        var out = [Float](repeating: 0, count: sum.count)
+        for i in 0..<sum.count where count[i] > 0 { out[i] = sum[i] / count[i] }
+        return out
+    }
+
+    /// The per-index sum divided by the accumulated weight (COLA), with a small
+    /// floor so silent-weight indices stay 0.
+    public func normalized(floor: Float = 1e-8) -> [Float] {
+        var out = [Float](repeating: 0, count: sum.count)
+        for i in 0..<sum.count where count[i] > floor { out[i] = sum[i] / count[i] }
+        return out
+    }
+}

--- a/Sources/AudioDSP/Loudness.swift
+++ b/Sources/AudioDSP/Loudness.swift
@@ -1,0 +1,103 @@
+// Loudness measurement and normalization to a delivery target (ITU-R BS.1770-4
+// integrated LUFS: K-weighting, 400 ms blocks at 75% overlap, -70/-10 LU
+// gating), plus a gain to the target with a peak-safety cap so a master never
+// clips. The post-DSP mastering stage audio-output SDKs apply, kept out of the
+// model. Accelerate-backed (vDSP_biquad) on Apple, plain Swift elsewhere.
+
+import Foundation
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+public enum Loudness {
+    // BS.1770-4 K-weighting biquads at 48 kHz (stage 1 high shelf, stage 2 HPF).
+    private static let s1b: [Float] = [1.53512485958697, -2.69169618940638, 1.19839281085285]
+    private static let s1a: [Float] = [-1.69065929318241, 0.73248077421585]
+    private static let s2b: [Float] = [1.0, -2.0, 1.0]
+    private static let s2a: [Float] = [-1.99004745483398, 0.99007225036621]
+
+    private static func biquad(_ x: [Float], _ b: [Float], _ a: [Float]) -> [Float] {
+        var y = [Float](repeating: 0, count: x.count)
+        #if canImport(Accelerate)
+        let coeffs: [Double] = [Double(b[0]), Double(b[1]), Double(b[2]), Double(a[0]), Double(a[1])]
+        guard let setup = vDSP_biquad_CreateSetup(coeffs, 1) else { return y }
+        defer { vDSP_biquad_DestroySetup(setup) }
+        var delays = [Float](repeating: 0, count: 2 + 2)
+        x.withUnsafeBufferPointer { xp in
+            y.withUnsafeMutableBufferPointer { yp in
+                vDSP_biquad(setup, &delays, xp.baseAddress!, 1, yp.baseAddress!, 1, vDSP_Length(x.count))
+            }
+        }
+        #else
+        var x1: Float = 0, x2: Float = 0, y1: Float = 0, y2: Float = 0
+        for i in 0..<x.count {
+            let xn = x[i]
+            let yn = b[0] * xn + b[1] * x1 + b[2] * x2 - a[0] * y1 - a[1] * y2
+            x2 = x1; x1 = xn; y2 = y1; y1 = yn
+            y[i] = yn
+        }
+        #endif
+        return y
+    }
+
+    /// Integrated loudness in LUFS of mono `samples` at `sampleRate`, or nil for
+    /// silence. The K-weighting coefficients are the 48 kHz set (the common
+    /// on-device audio rate); pass 48 kHz audio.
+    public static func integratedLUFS(_ samples: [Float], sampleRate: Double) -> Double? {
+        guard sampleRate == 48_000, samples.count > 0 else { return nil }
+        let weighted = biquad(biquad(samples, s1b, s1a), s2b, s2a)
+        let block = Int(0.4 * sampleRate)      // 400 ms
+        let step = Int(0.1 * sampleRate)       // 100 ms (75% overlap)
+        guard weighted.count >= block else { return nil }
+
+        var blockLoud: [Double] = []
+        var meanSq: [Double] = []
+        var start = 0
+        while start + block <= weighted.count {
+            var ms: Double
+            #if canImport(Accelerate)
+            var msF: Float = 0
+            weighted.withUnsafeBufferPointer { vDSP_measqv($0.baseAddress! + start, 1, &msF, vDSP_Length(block)) }
+            ms = Double(msF)
+            #else
+            var sum = 0.0
+            for i in start..<(start + block) { sum += Double(weighted[i]) * Double(weighted[i]) }
+            ms = sum / Double(block)
+            #endif
+            meanSq.append(ms)
+            blockLoud.append(-0.691 + 10 * log10(ms + 1e-12))
+            start += step
+        }
+        // Absolute gate -70 LUFS, then relative gate at (gated mean - 10 LU).
+        func gatedLoudness(_ threshold: Double) -> Double? {
+            var acc = 0.0; var n = 0
+            for (i, l) in blockLoud.enumerated() where l > threshold { acc += meanSq[i]; n += 1 }
+            return n > 0 ? -0.691 + 10 * log10(acc / Double(n) + 1e-12) : nil
+        }
+        guard let firstPass = gatedLoudness(-70) else { return nil }
+        return gatedLoudness(firstPass - 10) ?? firstPass
+    }
+
+    /// Normalize `samples` to `targetLUFS`, capping the applied gain at
+    /// `maxGainDB` and never letting the peak exceed `peakCeilingDBFS`. Returns
+    /// the normalized samples and the measured input loudness (nil for silence,
+    /// left unchanged).
+    public static func normalize(_ samples: [Float], sampleRate: Double,
+                                 targetLUFS: Double, maxGainDB: Double, peakCeilingDBFS: Double)
+        -> (samples: [Float], measuredLUFS: Double?)
+    {
+        guard let lufs = integratedLUFS(samples, sampleRate: sampleRate) else { return (samples, nil) }
+        var gainDB = targetLUFS - lufs
+        if gainDB > maxGainDB { gainDB = maxGainDB }
+        var gain = Float(pow(10, gainDB / 20))
+
+        var peak: Float = 0
+        for v in samples { peak = max(peak, abs(v)) }
+        let ceiling = Float(pow(10, peakCeilingDBFS / 20))
+        if peak * gain > ceiling, peak > 0 { gain = ceiling / peak }
+
+        var out = [Float](repeating: 0, count: samples.count)
+        for i in 0..<samples.count { out[i] = max(-1, min(1, samples[i] * gain)) }
+        return (out, lufs)
+    }
+}

--- a/Sources/AudioDSP/Matmul.swift
+++ b/Sources/AudioDSP/Matmul.swift
@@ -1,0 +1,30 @@
+// Row-major single-precision GEMM behind the STFT/mel matmuls. Accelerate BLAS
+// on Apple (the whole point of doing STFT as a matmul: it runs on the vector
+// units); a plain triple loop everywhere else. Same result, so tests pass on
+// Linux and the Apple SDK build still gets BLAS.
+
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+enum Matmul {
+    /// `c[m x n] = alpha * a[m x k] @ b[k x n] + beta * c`, all row-major.
+    static func gemm(_ a: [Float], _ b: [Float], into c: inout [Float],
+                     m: Int, n: Int, k: Int, alpha: Float = 1, beta: Float = 0) {
+        #if canImport(Accelerate)
+        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                    Int32(m), Int32(n), Int32(k), alpha,
+                    a, Int32(k), b, Int32(n), beta, &c, Int32(n))
+        #else
+        for i in 0..<m {
+            for j in 0..<n {
+                var acc: Float = 0
+                let aRow = i * k
+                for p in 0..<k { acc += a[aRow + p] * b[p * n + j] }
+                let idx = i * n + j
+                c[idx] = alpha * acc + beta * c[idx]
+            }
+        }
+        #endif
+    }
+}

--- a/Sources/AudioDSP/Mel.swift
+++ b/Sources/AudioDSP/Mel.swift
@@ -1,0 +1,92 @@
+// Log-mel spectrogram front-end for audio feature models (ASR-adjacent nets,
+// keyword/filler detectors that take mel rather than raw waveform). Builds the
+// triangular mel filterbank once, applies it to STFT power, and takes the log.
+// HTK mel scale by default, matching whisper/torchaudio's common setting.
+
+import Foundation
+
+/// A triangular mel filterbank plus the STFT that feeds it. Configured once and
+/// reused: `logMel(_:)` takes a signal to a `[mels x frames]`-ordered log-mel
+/// spectrogram (frame-major internally, exposed as `frames * mels`).
+public struct MelSpectrogram: Sendable {
+    public let stft: STFT
+    public let mels: Int
+    public let sampleRate: Double
+    private let filters: [Float]   // [mels x bins]
+    private let bins: Int
+
+    /// Configure a mel front-end. `fMax` defaults to Nyquist (`sampleRate/2`).
+    public init(sampleRate: Double, nFFT: Int, hop: Int, mels: Int,
+                fMin: Double = 0, fMax: Double? = nil, htk: Bool = true,
+                window: [Float]? = nil, center: Bool = true) {
+        self.stft = STFT(nFFT: nFFT, hop: hop, window: window, center: center)
+        self.mels = mels
+        self.sampleRate = sampleRate
+        self.bins = stft.bins
+        self.filters = MelSpectrogram.filterbank(
+            sampleRate: sampleRate, nFFT: nFFT, bins: stft.bins,
+            mels: mels, fMin: fMin, fMax: fMax ?? sampleRate / 2, htk: htk)
+    }
+
+    private static func hzToMel(_ hz: Double, htk: Bool) -> Double {
+        htk ? 2595 * log10(1 + hz / 700) : hz  // HTK; linear placeholder only if !htk unused
+    }
+    private static func melToHz(_ mel: Double, htk: Bool) -> Double {
+        htk ? 700 * (pow(10, mel / 2595) - 1) : mel
+    }
+
+    private static func filterbank(sampleRate: Double, nFFT: Int, bins: Int,
+                                   mels: Int, fMin: Double, fMax: Double, htk: Bool) -> [Float] {
+        let melMin = hzToMel(fMin, htk: htk), melMax = hzToMel(fMax, htk: htk)
+        // mels + 2 band edges, evenly spaced on the mel scale.
+        var hzPoints = [Double](repeating: 0, count: mels + 2)
+        for i in 0..<(mels + 2) {
+            let mel = melMin + (melMax - melMin) * Double(i) / Double(mels + 1)
+            hzPoints[i] = melToHz(mel, htk: htk)
+        }
+        // FFT bin center frequencies.
+        var binHz = [Double](repeating: 0, count: bins)
+        for k in 0..<bins { binHz[k] = Double(k) * sampleRate / Double(nFFT) }
+
+        var fb = [Float](repeating: 0, count: mels * bins)
+        for m in 0..<mels {
+            let left = hzPoints[m], center = hzPoints[m + 1], right = hzPoints[m + 2]
+            for k in 0..<bins {
+                let hz = binHz[k]
+                var w = 0.0
+                if hz >= left, hz <= center, center > left {
+                    w = (hz - left) / (center - left)
+                } else if hz > center, hz <= right, right > center {
+                    w = (right - hz) / (right - center)
+                }
+                fb[m * bins + k] = Float(max(0, w))
+            }
+        }
+        return fb
+    }
+
+    /// Log-mel spectrogram of `signal`, frame-major `frames * mels`. `log` is
+    /// natural log of `power + eps` (set `power: false` for magnitude).
+    public func logMel(_ signal: [Float], eps: Float = 1e-10, power: Bool = true) -> (values: [Float], frames: Int, mels: Int) {
+        let spec = stft.forward(signal)
+        let frames = spec.frames
+        guard frames > 0 else { return ([], 0, mels) }
+        // Per-bin magnitude/power, frame-major [frames x bins].
+        var energy = [Float](repeating: 0, count: frames * bins)
+        for i in 0..<energy.count {
+            let mag2 = spec.re[i] * spec.re[i] + spec.im[i] * spec.im[i]
+            energy[i] = power ? mag2 : mag2.squareRoot()
+        }
+        // mel[frames x mels] = energy[frames x bins] @ filters^T[bins x mels].
+        var out = [Float](repeating: 0, count: frames * mels)
+        for fr in 0..<frames {
+            for m in 0..<mels {
+                var acc: Float = 0
+                let eRow = fr * bins, fRow = m * bins
+                for k in 0..<bins { acc += energy[eRow + k] * filters[fRow + k] }
+                out[fr * mels + m] = logf(acc + eps)
+            }
+        }
+        return (out, frames, mels)
+    }
+}

--- a/Sources/AudioDSP/STFT.swift
+++ b/Sources/AudioDSP/STFT.swift
@@ -1,0 +1,144 @@
+// STFT / ISTFT as exact real-DFT matmuls (so `nFFT` need not be a power of two)
+// with windowed COLA overlap-add reconstruction. This is the DSP a spectral
+// speech model runs on both sides of inference; one implementation, shared by
+// every SDK, matches the training-time `torch.stft`/`istft` (Hann, center,
+// reflect pad) it has to agree with bit-for-bit.
+
+import Foundation
+
+/// A dense complex spectrogram in frame-major layout: `frames` rows of `bins`
+/// (= `nFFT/2 + 1`) complex bins, real and imaginary parts split into two
+/// parallel `frames * bins` arrays (row `f`, bin `k` at index `f * bins + k`).
+public struct Spectrogram: Sendable {
+    public var re: [Float]
+    public var im: [Float]
+    public let frames: Int
+    public let bins: Int
+
+    public init(re: [Float], im: [Float], frames: Int, bins: Int) {
+        self.re = re
+        self.im = im
+        self.frames = frames
+        self.bins = bins
+    }
+
+    /// Per-bin magnitude `sqrt(re^2 + im^2)` (frame-major, `frames * bins`).
+    public func magnitude(eps: Float = 0) -> [Float] {
+        var out = [Float](repeating: 0, count: re.count)
+        for i in 0..<re.count { out[i] = (re[i] * re[i] + im[i] * im[i] + eps).squareRoot() }
+        return out
+    }
+
+    /// Per-bin phase `atan2(im, re)` (frame-major, `frames * bins`).
+    public func phase() -> [Float] {
+        var out = [Float](repeating: 0, count: re.count)
+        for i in 0..<re.count { out[i] = atan2f(im[i], re[i]) }
+        return out
+    }
+}
+
+/// A short-time Fourier transform configured once and reused. Precomputes the
+/// window and the real-DFT bases at init, so `forward`/`inverse` are just the
+/// matmuls plus overlap-add.
+public struct STFT: Sendable {
+    public let nFFT: Int
+    public let hop: Int
+    public let bins: Int
+    public let center: Bool
+    public let window: [Float]
+
+    private let fwdCos: [Float]   // [nFFT x bins]
+    private let fwdSin: [Float]   // [nFFT x bins]
+    private let invCos: [Float]   // [bins x nFFT]
+    private let invSin: [Float]   // [bins x nFFT]
+
+    /// Configure an STFT. `window` defaults to a periodic Hann of length
+    /// `nFFT`. `center` reflect-pads by `nFFT/2` so frames are centered
+    /// (`torch.stft(center=True)`), which `inverse` undoes.
+    public init(nFFT: Int, hop: Int, window: [Float]? = nil, center: Bool = true) {
+        precondition(nFFT > 0 && hop > 0, "nFFT and hop must be positive")
+        self.nFFT = nFFT
+        self.hop = hop
+        self.bins = nFFT / 2 + 1
+        self.center = center
+        let w = window ?? Window.hann(nFFT, periodic: true)
+        precondition(w.count == nFFT, "window length must equal nFFT")
+        self.window = w
+
+        let n = nFFT, f = bins
+        var fc = [Float](repeating: 0, count: n * f)
+        var fs = [Float](repeating: 0, count: n * f)
+        for t in 0..<n {
+            for k in 0..<f {
+                let a = 2 * Float.pi * Float(k) * Float(t) / Float(n)
+                fc[t * f + k] = cosf(a)
+                fs[t * f + k] = sinf(a)
+            }
+        }
+        self.fwdCos = fc
+        self.fwdSin = fs
+
+        // Real irfft basis (hermitian): x[t] = sum_k a_k/n (re cos - im sin),
+        // a_0 = a_{n/2} = 1, else 2.
+        var ic = [Float](repeating: 0, count: f * n)
+        var isn = [Float](repeating: 0, count: f * n)
+        for k in 0..<f {
+            let ak: Float = (k == 0 || k == f - 1) ? 1 : 2
+            for t in 0..<n {
+                let a = 2 * Float.pi * Float(k) * Float(t) / Float(n)
+                ic[k * n + t] = ak / Float(n) * cosf(a)
+                isn[k * n + t] = -ak / Float(n) * sinf(a)
+            }
+        }
+        self.invCos = ic
+        self.invSin = isn
+    }
+
+    /// Forward transform: windowed frames -> complex spectrogram.
+    public func forward(_ signal: [Float]) -> Spectrogram {
+        let n = nFFT, f = bins
+        let padded = center ? Padding.reflect(signal, pad: n / 2) : signal
+        guard padded.count >= n else { return Spectrogram(re: [], im: [], frames: 0, bins: f) }
+        let frames = 1 + (padded.count - n) / hop
+
+        var windowed = [Float](repeating: 0, count: frames * n)
+        for fr in 0..<frames {
+            let off = fr * hop
+            for t in 0..<n { windowed[fr * n + t] = padded[off + t] * window[t] }
+        }
+        var re = [Float](repeating: 0, count: frames * f)
+        var im = [Float](repeating: 0, count: frames * f)
+        Matmul.gemm(windowed, fwdCos, into: &re, m: frames, n: f, k: n, alpha: 1)
+        Matmul.gemm(windowed, fwdSin, into: &im, m: frames, n: f, k: n, alpha: -1)
+        return Spectrogram(re: re, im: im, frames: frames, bins: f)
+    }
+
+    /// Inverse transform: complex spectrogram -> signal, windowed COLA
+    /// overlap-add with the same window, trimming the centered padding and
+    /// clamping to `length` (pass the original sample count).
+    public func inverse(_ spec: Spectrogram, length: Int) -> [Float] {
+        let n = nFFT, f = bins, frames = spec.frames
+        guard frames > 0 else { return [] }
+        var recon = [Float](repeating: 0, count: frames * n)
+        Matmul.gemm(spec.re, invCos, into: &recon, m: frames, n: n, k: f, alpha: 1)
+        Matmul.gemm(spec.im, invSin, into: &recon, m: frames, n: n, k: f, alpha: 1, beta: 1)
+
+        let paddedLen = (frames - 1) * hop + n
+        var num = [Float](repeating: 0, count: paddedLen)
+        var den = [Float](repeating: 0, count: paddedLen)
+        for fr in 0..<frames {
+            let off = fr * hop
+            for t in 0..<n {
+                let w = window[t]
+                num[off + t] += recon[fr * n + t] * w
+                den[off + t] += w * w
+            }
+        }
+        var y = [Float](repeating: 0, count: paddedLen)
+        for i in 0..<paddedLen { y[i] = den[i] > 1e-8 ? num[i] / den[i] : 0 }
+
+        let pad = center ? n / 2 : 0
+        let count = min(length, paddedLen - 2 * pad)
+        return count > 0 ? Array(y[pad..<(pad + count)]) : []
+    }
+}

--- a/Sources/AudioDSP/VectorOps.swift
+++ b/Sources/AudioDSP/VectorOps.swift
@@ -1,0 +1,66 @@
+// Small signal-level vector helpers the audio SDKs reach for before/after
+// inference: energy normalization (speech enhancement) and per-window mean/std
+// standardization (feature models). Accelerate-backed on Apple, plain Swift
+// everywhere else, same result either way.
+
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+public enum VectorOps {
+    /// Sum of squares of `x`.
+    public static func energy(_ x: [Float]) -> Float {
+        guard !x.isEmpty else { return 0 }
+        #if canImport(Accelerate)
+        var e: Float = 0
+        vDSP_svesq(x, 1, &e, vDSP_Length(x.count))
+        return e
+        #else
+        var e: Float = 0
+        for v in x { e += v * v }
+        return e
+        #endif
+    }
+
+    /// Multiply every element by `scalar` (out-of-place).
+    public static func scaled(_ x: [Float], by scalar: Float) -> [Float] {
+        guard !x.isEmpty else { return x }
+        var out = [Float](repeating: 0, count: x.count)
+        #if canImport(Accelerate)
+        var s = scalar
+        vDSP_vsmul(x, 1, &s, &out, 1, vDSP_Length(x.count))
+        #else
+        for i in 0..<x.count { out[i] = x[i] * scalar }
+        #endif
+        return out
+    }
+
+    /// RMS-energy normalize to unit average power (`gain = sqrt(N / sum x^2)`),
+    /// the front-end MP-SENet-style enhancers apply. Returns the normalized
+    /// samples and the `gain` used, so the caller can undo it after inference
+    /// (`scaled(y, by: 1 / gain)`). A silent input is returned unchanged with
+    /// `gain == 1`.
+    public static func energyNormalize(_ x: [Float]) -> (samples: [Float], gain: Float) {
+        let e = energy(x)
+        let gain = e > 0 ? (Float(x.count) / e).squareRoot() : 1
+        return (scaled(x, by: gain), gain)
+    }
+
+    /// Standardize to zero mean and unit variance (sample std, `+ eps`), the
+    /// per-window normalization raw-waveform classifiers expect. Matches a
+    /// training-time `(x - mean) / (std + eps)` with an unbiased std.
+    public static func standardize(_ x: [Float], eps: Float = 1e-7) -> [Float] {
+        guard x.count > 1 else { return x }
+        let n = Float(x.count)
+        var mean: Float = 0
+        for v in x { mean += v }
+        mean /= n
+        var sumSq: Float = 0
+        for v in x { let d = v - mean; sumSq += d * d }
+        let std = (sumSq / (n - 1)).squareRoot() + eps
+        let inv = 1 / std
+        var out = [Float](repeating: 0, count: x.count)
+        for i in 0..<x.count { out[i] = (x[i] - mean) * inv }
+        return out
+    }
+}

--- a/Sources/AudioDSP/Windowing.swift
+++ b/Sources/AudioDSP/Windowing.swift
@@ -1,0 +1,32 @@
+// Analysis windows and the padding helpers STFT pipelines share. Pure Swift,
+// so every platform gets the same coefficients (an STFT/ISTFT pair only
+// reconstructs cleanly when both ends agree on the window to the last bit).
+
+import Foundation
+
+public enum Window {
+    /// A Hann window of `count` samples: `0.5 - 0.5 cos(2 pi k / d)` where `d`
+    /// is `count` for the periodic window (the DFT/STFT default, matching
+    /// PyTorch/librosa `periodic=True`) or `count - 1` for the symmetric one.
+    public static func hann(_ count: Int, periodic: Bool = true) -> [Float] {
+        guard count > 1 else { return [Float](repeating: 1, count: max(0, count)) }
+        let d = Float(periodic ? count : count - 1)
+        var w = [Float](repeating: 0, count: count)
+        for k in 0..<count { w[k] = 0.5 - 0.5 * cosf(2 * .pi * Float(k) / d) }
+        return w
+    }
+}
+
+public enum Padding {
+    /// Reflect-pad `x` by `pad` samples on each side (no edge-sample repeat),
+    /// matching `torch.stft(center=True)` / librosa `pad_mode="reflect"`. Used
+    /// to center STFT frames so the first/last hop are not truncated.
+    public static func reflect(_ x: [Float], pad: Int) -> [Float] {
+        guard pad > 0, !x.isEmpty else { return x }
+        var out = [Float](); out.reserveCapacity(x.count + 2 * pad)
+        for i in 0..<pad { out.append(x[min(pad - i, x.count - 1)]) }
+        out.append(contentsOf: x)
+        for i in 0..<pad { out.append(x[max(x.count - 2 - i, 0)]) }
+        return out
+    }
+}

--- a/Sources/AudioIO/AppleAudioIO.swift
+++ b/Sources/AudioIO/AppleAudioIO.swift
@@ -1,0 +1,59 @@
+#if canImport(AVFoundation)
+import AVFoundation
+import Foundation
+
+// Apple decode backend: AVFoundation reads any supported container/codec, and
+// AVAudioConverter mixes to mono and resamples to the target rate in one pass.
+// In-memory bytes are staged to a temp file because AVAudioFile reads from a URL.
+
+extension AudioIO {
+    static func appleDecode(path: String?, bytes: [UInt8]?, sampleRate: Double) throws -> [Float] {
+        let url: URL
+        var temp: URL?
+        if let path {
+            url = URL(fileURLWithPath: path)
+        } else if let bytes {
+            let t = FileManager.default.temporaryDirectory
+                .appendingPathComponent("dal-audio-\(UUID().uuidString)")
+            try Data(bytes).write(to: t)
+            url = t
+            temp = t
+        } else {
+            throw AudioIOError.decodeFailed("no path or bytes")
+        }
+        defer { if let temp { try? FileManager.default.removeItem(at: temp) } }
+
+        do {
+            let file = try AVAudioFile(forReading: url)
+            let inFormat = file.processingFormat
+            guard
+                let outFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                              sampleRate: sampleRate, channels: 1, interleaved: false),
+                let converter = AVAudioConverter(from: inFormat, to: outFormat),
+                file.length > 0,
+                let inBuffer = AVAudioPCMBuffer(pcmFormat: inFormat,
+                                                frameCapacity: AVAudioFrameCount(file.length))
+            else { throw AudioIOError.decodeFailed("cannot build converter") }
+
+            try file.read(into: inBuffer)
+            let capacity = AVAudioFrameCount(Double(inBuffer.frameLength) * (sampleRate / inFormat.sampleRate) + 4096)
+            guard let outBuffer = AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: capacity) else {
+                throw AudioIOError.decodeFailed("cannot build output buffer")
+            }
+            var fed = false
+            var error: NSError?
+            converter.convert(to: outBuffer, error: &error) { _, status in
+                if fed { status.pointee = .endOfStream; return nil }
+                fed = true; status.pointee = .haveData; return inBuffer
+            }
+            if let error { throw error }
+            guard let channel = outBuffer.floatChannelData?[0] else { return [] }
+            return Array(UnsafeBufferPointer(start: channel, count: Int(outBuffer.frameLength)))
+        } catch let e as AudioIOError {
+            throw e
+        } catch {
+            throw AudioIOError.decodeFailed("\(error)")
+        }
+    }
+}
+#endif

--- a/Sources/AudioIO/AudioIO.swift
+++ b/Sources/AudioIO/AudioIO.swift
@@ -1,0 +1,86 @@
+// One audio decode/encode API with a per-platform backend behind it, so an
+// audio model SDK never writes AVFoundation, MediaCodec, or Web Audio code:
+//
+//   Apple      AVFoundation (AVAudioFile + AVAudioConverter)
+//   Android    host MediaExtractor/MediaCodec via CHostBridge host_audio_decode
+//   WebAssembly  AudioContext.decodeAudioData via the JS host global
+//   Linux/other  the pure-Swift WAV codec + linear resample
+//
+// `decode` always returns mono `Float` at the requested sample rate, ready to
+// feed a model (or AudioDSP). It is `async` because the wasm backend awaits a
+// JS Promise; the native backends satisfy it synchronously. Encoding a 16-bit
+// PCM WAV is pure Swift, identical on every platform.
+
+public enum AudioIOError: Error, Sendable {
+    case decodeFailed(String)
+    case unsupported(String)
+}
+
+public enum AudioIO {
+    /// Decode the audio file at `path` to mono `Float` samples at
+    /// `sampleRate`, resampling and mixing to mono as needed.
+    public static func decode(path: String, sampleRate: Double) async throws -> [Float] {
+        #if canImport(AVFoundation)
+        return try appleDecode(path: path, bytes: nil, sampleRate: sampleRate)
+        #elseif os(Android)
+        return try hostDecode(path: path, bytes: nil, sampleRate: sampleRate)
+        #elseif os(WASI)
+        return try await jsDecode(path: path, bytes: nil, sampleRate: sampleRate)
+        #else
+        return try portableDecode(bytes: readFile(path), sampleRate: sampleRate)
+        #endif
+    }
+
+    /// Decode an in-memory audio file (any container the platform supports; the
+    /// portable path is WAV) to mono `Float` at `sampleRate`.
+    public static func decode(bytes: [UInt8], sampleRate: Double) async throws -> [Float] {
+        #if canImport(AVFoundation)
+        return try appleDecode(path: nil, bytes: bytes, sampleRate: sampleRate)
+        #elseif os(Android)
+        return try hostDecode(path: nil, bytes: bytes, sampleRate: sampleRate)
+        #elseif os(WASI)
+        return try await jsDecode(path: nil, bytes: bytes, sampleRate: sampleRate)
+        #else
+        return try portableDecode(bytes: bytes, sampleRate: sampleRate)
+        #endif
+    }
+
+    /// Encode mono (or interleaved) `samples` in `[-1, 1]` as a 16-bit PCM WAV
+    /// byte buffer. Portable and identical on every platform.
+    public static func encodeWAV(_ samples: [Float], sampleRate: Int, channels: Int = 1) -> [UInt8] {
+        WAV.encode(samples, sampleRate: sampleRate, channels: channels)
+    }
+
+    /// Decode WAV bytes with the pure-Swift codec, mixing to mono and
+    /// resampling to `sampleRate`. The portable-path implementation, exposed so
+    /// a caller can force the WAV codec regardless of platform.
+    static func portableDecode(bytes: [UInt8], sampleRate: Double) throws -> [Float] {
+        do {
+            let pcm = try WAV.decode(bytes)
+            return Resample.toMono(pcm, sampleRate: sampleRate)
+        } catch {
+            throw AudioIOError.decodeFailed("\(error)")
+        }
+    }
+}
+
+#if canImport(Foundation) && !os(Android) && !os(WASI)
+import Foundation
+
+public extension AudioIO {
+    /// Write mono (or interleaved) `samples` as a 16-bit PCM WAV file. Uses the
+    /// portable encoder, so the bytes match `encodeWAV`. Available where a
+    /// filesystem is (Apple/Linux); on Android/wasm write through the host.
+    static func writeWAV(_ samples: [Float], sampleRate: Int, channels: Int = 1, to path: String) throws {
+        let bytes = WAV.encode(samples, sampleRate: sampleRate, channels: channels)
+        try Data(bytes).write(to: URL(fileURLWithPath: path))
+    }
+}
+
+extension AudioIO {
+    static func readFile(_ path: String) throws -> [UInt8] {
+        do { return try [UInt8](Data(contentsOf: URL(fileURLWithPath: path))) }
+        catch { throw AudioIOError.decodeFailed("read \(path): \(error)") }
+    }
+}
+#endif

--- a/Sources/AudioIO/HostAudioIO.swift
+++ b/Sources/AudioIO/HostAudioIO.swift
@@ -1,0 +1,33 @@
+#if os(Android)
+import CHostBridge
+import FFIBuffer
+
+// Android decode backend: the host (MediaExtractor + MediaCodec, installed by
+// the runtime's JNI shim) decodes to mono `Float` at the target rate and hands
+// back a length-prefixed FFI buffer (u32 sample rate, then an f32 array). Swift
+// links no audio codec; it just reads the buffer with FFIReader.
+
+extension AudioIO {
+    static func hostDecode(path: String?, bytes: [UInt8]?, sampleRate: Double) throws -> [Float] {
+        let ptr: UnsafeMutablePointer<CChar>? = {
+            if let path {
+                return path.withCString { host_audio_decode($0, nil, 0, sampleRate) }
+            } else if let bytes {
+                return bytes.withUnsafeBufferPointer {
+                    host_audio_decode(nil, $0.baseAddress, Int64(bytes.count), sampleRate)
+                }
+            }
+            return nil
+        }()
+        guard let ptr else { throw AudioIOError.decodeFailed("host_audio_decode returned null") }
+        defer { host_free(ptr) }
+
+        let base = UnsafeRawPointer(ptr).assumingMemoryBound(to: UInt8.self)
+        let len = Int(base[0]) << 24 | Int(base[1]) << 16 | Int(base[2]) << 8 | Int(base[3])
+        let body = [UInt8](UnsafeBufferPointer(start: base + 4, count: len))
+        var reader = FFIReader(body)
+        _ = reader.u32()                 // sample rate (host already resampled)
+        return reader.f32Array()
+    }
+}
+#endif

--- a/Sources/AudioIO/JSAudioIO.swift
+++ b/Sources/AudioIO/JSAudioIO.swift
@@ -1,0 +1,36 @@
+#if os(WASI)
+import JavaScriptEventLoop
+import JavaScriptKit
+
+// WebAssembly decode backend: the JS host owns audio decoding and exposes one
+// method on the `__DalAudioHost` global, mirroring the JS inference session.
+// desert-ant-core's own npm package installs it, so a model SDK writes no JS:
+//
+//   import { installAudioHost } from "@desert-ant-labs/core";        // browser: Web Audio
+//   import { installAudioHost } from "@desert-ant-labs/core/node";   // node: WAV codec
+//   installAudioHost();   // sets globalThis.__DalAudioHost.decode(path, bytes, sampleRate)
+//
+// `path` is a string on node, null in the browser; `bytes` is the file's
+// Uint8Array in the browser, null on node. It returns mono Float32 at `rate`.
+// Bytes cross the wasm boundary raw; the host returns a Float32Array we copy in.
+
+extension AudioIO {
+    static func jsDecode(path: String?, bytes: [UInt8]?, sampleRate: Double) async throws -> [Float] {
+        guard let host = JSObject.global.__DalAudioHost.object,
+              let decode = host.decode.function else {
+            throw AudioIOError.unsupported("missing __DalAudioHost.decode")
+        }
+        let pathArg: JSValue = path.map { .string($0) } ?? .null
+        let bytesArg: JSValue = bytes.map { JSTypedArray<UInt8>($0).jsValue } ?? .null
+        let result = decode(this: host, pathArg, bytesArg, JSValue.number(sampleRate))
+        guard let promise = result.object.flatMap(JSPromise.init) else {
+            throw AudioIOError.decodeFailed("__DalAudioHost.decode did not return a promise")
+        }
+        let value = try await promise.value
+        guard let floats = JSTypedArray<Float>(from: value) else {
+            throw AudioIOError.decodeFailed("__DalAudioHost.decode returned no Float32Array")
+        }
+        return floats.withUnsafeBytes { Array($0) }
+    }
+}
+#endif

--- a/Sources/AudioIO/Resample.swift
+++ b/Sources/AudioIO/Resample.swift
@@ -1,0 +1,47 @@
+// Channel mixdown and sample-rate conversion for the portable decode path (and
+// any host decoder that returns native rate / multichannel). Linear
+// interpolation: cheap, good enough for the 16 kHz mono model front-ends these
+// SDKs feed. Apple's AVAudioConverter does its own higher-quality conversion on
+// that path; this keeps Linux/host output equivalent for model input.
+
+public enum Resample {
+    /// Mix interleaved `channels`-channel `interleaved` down to mono by
+    /// averaging channels.
+    public static func mixdownMono(_ interleaved: [Float], channels: Int) -> [Float] {
+        guard channels > 1 else { return interleaved }
+        let frames = interleaved.count / channels
+        var out = [Float](repeating: 0, count: frames)
+        let inv = 1 / Float(channels)
+        for f in 0..<frames {
+            var acc: Float = 0
+            let base = f * channels
+            for c in 0..<channels { acc += interleaved[base + c] }
+            out[f] = acc * inv
+        }
+        return out
+    }
+
+    /// Linearly resample mono `x` from `from` Hz to `to` Hz.
+    public static func linear(_ x: [Float], from: Double, to: Double) -> [Float] {
+        guard from > 0, to > 0, from != to, x.count > 1 else { return x }
+        let ratio = to / from
+        let outCount = Int((Double(x.count) * ratio).rounded())
+        guard outCount > 0 else { return [] }
+        var out = [Float](repeating: 0, count: outCount)
+        let step = from / to
+        for i in 0..<outCount {
+            let src = Double(i) * step
+            let i0 = Int(src)
+            if i0 >= x.count - 1 { out[i] = x[x.count - 1]; continue }
+            let frac = Float(src - Double(i0))
+            out[i] = x[i0] * (1 - frac) + x[i0 + 1] * frac
+        }
+        return out
+    }
+
+    /// Mix down to mono and resample to `sampleRate` in one step.
+    public static func toMono(_ pcm: PCM, sampleRate: Double) -> [Float] {
+        let mono = mixdownMono(pcm.samples, channels: pcm.channels)
+        return linear(mono, from: pcm.sampleRate, to: sampleRate)
+    }
+}

--- a/Sources/AudioIO/WAV.swift
+++ b/Sources/AudioIO/WAV.swift
@@ -1,0 +1,145 @@
+// A pure-Swift RIFF/WAVE reader and writer. It is the portable audio codec: the
+// fallback decoder on platforms with no OS decoder (Linux/server), and the one
+// encoder everywhere (16-bit PCM WAV out is the same bytes on every platform).
+// Handles PCM (8/16/24/32-bit int) and IEEE float (32/64-bit); other codecs are
+// the host decoder's job.
+
+import Foundation
+
+/// Decoded PCM: interleaved `Float` samples in `[-1, 1]`, with the file's own
+/// sample rate and channel count (mixdown/resample happen separately).
+public struct PCM: Sendable {
+    public var samples: [Float]   // interleaved
+    public var sampleRate: Double
+    public var channels: Int
+
+    public init(samples: [Float], sampleRate: Double, channels: Int) {
+        self.samples = samples
+        self.sampleRate = sampleRate
+        self.channels = channels
+    }
+}
+
+public enum WAVError: Error, Sendable {
+    case notRIFF, truncated, unsupported(String)
+}
+
+public enum WAV {
+    // MARK: Decode
+
+    /// Parse a WAV/RIFF byte buffer to interleaved float `PCM`.
+    public static func decode(_ bytes: [UInt8]) throws -> PCM {
+        guard bytes.count >= 12,
+              bytes[0] == 0x52, bytes[1] == 0x49, bytes[2] == 0x46, bytes[3] == 0x46,  // "RIFF"
+              bytes[8] == 0x57, bytes[9] == 0x41, bytes[10] == 0x56, bytes[11] == 0x45 // "WAVE"
+        else { throw WAVError.notRIFF }
+
+        func u16(_ o: Int) -> Int { Int(bytes[o]) | (Int(bytes[o + 1]) << 8) }
+        func u32(_ o: Int) -> Int { Int(bytes[o]) | (Int(bytes[o + 1]) << 8) | (Int(bytes[o + 2]) << 16) | (Int(bytes[o + 3]) << 24) }
+
+        var format = 1, channels = 1, sampleRate = 0, bitsPerSample = 16
+        var dataStart = -1, dataSize = 0
+        var pos = 12
+        while pos + 8 <= bytes.count {
+            let id = (bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3])
+            let size = u32(pos + 4)
+            let body = pos + 8
+            if id == (0x66, 0x6D, 0x74, 0x20) {          // "fmt "
+                guard body + 16 <= bytes.count else { throw WAVError.truncated }
+                format = u16(body)
+                channels = max(1, u16(body + 2))
+                sampleRate = u32(body + 4)
+                bitsPerSample = u16(body + 14)
+                if format == 0xFFFE, body + 26 <= bytes.count {  // WAVE_FORMAT_EXTENSIBLE
+                    format = u16(body + 24)                       // the real sub-format tag
+                }
+            } else if id == (0x64, 0x61, 0x74, 0x61) {   // "data"
+                dataStart = body
+                dataSize = min(size, bytes.count - body)
+            }
+            pos = body + size + (size & 1)               // chunks are word-aligned
+        }
+        guard dataStart >= 0 else { throw WAVError.truncated }
+        guard sampleRate > 0 else { throw WAVError.unsupported("sample rate 0") }
+
+        let samples = try decodeSamples(bytes, at: dataStart, size: dataSize,
+                                        format: format, bits: bitsPerSample)
+        return PCM(samples: samples, sampleRate: Double(sampleRate), channels: channels)
+    }
+
+    private static func decodeSamples(_ b: [UInt8], at start: Int, size: Int,
+                                      format: Int, bits: Int) throws -> [Float] {
+        let bytesPer = bits / 8
+        guard bytesPer > 0 else { throw WAVError.unsupported("0 bits/sample") }
+        let count = size / bytesPer
+        var out = [Float](repeating: 0, count: count)
+        if format == 3 {                                 // IEEE float
+            if bits == 32 {
+                for i in 0..<count {
+                    let o = start + i * 4
+                    let u = UInt32(b[o]) | (UInt32(b[o + 1]) << 8) | (UInt32(b[o + 2]) << 16) | (UInt32(b[o + 3]) << 24)
+                    out[i] = Float(bitPattern: u)
+                }
+            } else if bits == 64 {
+                for i in 0..<count {
+                    let o = start + i * 8
+                    var u: UInt64 = 0
+                    for j in 0..<8 { u |= UInt64(b[o + j]) << (8 * j) }
+                    out[i] = Float(Double(bitPattern: u))
+                }
+            } else { throw WAVError.unsupported("float \(bits)-bit") }
+            return out
+        }
+        guard format == 1 else { throw WAVError.unsupported("format tag \(format)") }
+        switch bits {
+        case 8:   // unsigned
+            for i in 0..<count { out[i] = (Float(b[start + i]) - 128) / 128 }
+        case 16:
+            for i in 0..<count {
+                let o = start + i * 2
+                let s = Int16(bitPattern: UInt16(b[o]) | (UInt16(b[o + 1]) << 8))
+                out[i] = Float(s) / 32768
+            }
+        case 24:
+            for i in 0..<count {
+                let o = start + i * 3
+                var v = Int(b[o]) | (Int(b[o + 1]) << 8) | (Int(b[o + 2]) << 16)
+                if v & 0x800000 != 0 { v |= ~0xFFFFFF }  // sign-extend
+                out[i] = Float(v) / 8388608
+            }
+        case 32:
+            for i in 0..<count {
+                let o = start + i * 4
+                let u = UInt32(b[o]) | (UInt32(b[o + 1]) << 8) | (UInt32(b[o + 2]) << 16) | (UInt32(b[o + 3]) << 24)
+                out[i] = Float(Int32(bitPattern: u)) / 2147483648
+            }
+        default:
+            throw WAVError.unsupported("PCM \(bits)-bit")
+        }
+        return out
+    }
+
+    // MARK: Encode
+
+    /// Encode interleaved `samples` (in `[-1, 1]`) as a 16-bit PCM WAV buffer.
+    public static func encode(_ samples: [Float], sampleRate: Int, channels: Int = 1) -> [UInt8] {
+        var out = [UInt8]()
+        out.reserveCapacity(44 + samples.count * 2)
+        func u16(_ v: Int) { out.append(UInt8(v & 0xFF)); out.append(UInt8((v >> 8) & 0xFF)) }
+        func u32(_ v: Int) { for s in 0..<4 { out.append(UInt8((v >> (8 * s)) & 0xFF)) } }
+        func tag(_ s: String) { out.append(contentsOf: s.utf8) }
+
+        let dataSize = samples.count * 2
+        let byteRate = sampleRate * channels * 2
+        tag("RIFF"); u32(36 + dataSize); tag("WAVE")
+        tag("fmt "); u32(16); u16(1); u16(channels); u32(sampleRate)
+        u32(byteRate); u16(channels * 2); u16(16)
+        tag("data"); u32(dataSize)
+        for v in samples {
+            let clamped = max(-1, min(1, v))
+            let s = Int16((clamped * 32767).rounded())
+            u16(Int(UInt16(bitPattern: s)))
+        }
+        return out
+    }
+}

--- a/Sources/Bindings/AndroidJNI.swift
+++ b/Sources/Bindings/AndroidJNI.swift
@@ -83,4 +83,29 @@ public func DesertAntNative_run(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jcl
     }
     return hostTakeBuffer(env, buf)
 }
+
+/// Run an audio model (clear) over mono samples. The audio crosses as one
+/// FFIBuffer payload - `f32Array samples`, then an `f64` sample rate - so this
+/// reuses the byte-array marshalling every other entry point uses instead of
+/// adding jfloatArray handling to the harness. Options and result are the
+/// model's own payloads, as in `run`.
+@_cdecl("Java_ai_desertant_DesertAntNative_runAudio")
+public func DesertAntNative_runAudio(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                                     _ handle: jlong, _ audio: jbyteArray?,
+                                     _ options: jbyteArray?) -> jbyteArray? {
+    installHostBridge(env, cls)
+    guard let bytes = optionalBytes(env, audio) else { return nil }
+    var reader = FFIReader(bytes)
+    let samples = reader.f32Array()
+    let sampleRate = reader.f64()
+    guard !samples.isEmpty, sampleRate > 0 else { return nil }
+    let payload = optionalBytes(env, options) ?? []
+    let buf = samples.withUnsafeBufferPointer { s in
+        payload.withUnsafeBufferPointer { p in
+            dal_run_audio(pointer(handle), s.baseAddress, Int32(s.count), sampleRate,
+                          p.baseAddress, Int32(p.count), nil, nil)
+        }
+    }
+    return hostTakeBuffer(env, buf)
+}
 #endif

--- a/Sources/Bindings/CABI.swift
+++ b/Sources/Bindings/CABI.swift
@@ -12,6 +12,8 @@ import DesertAnt
 //   dal_download(handle)                                       -> 0/-1  (blocks)
 //   dal_run(handle, textUTF8, options,len, groupId|NULL, deviceId|NULL)
 //                                                              -> buffer | NULL
+//   dal_run_audio(handle, samples,count, sampleRate, options,len,
+//                 groupId|NULL, deviceId|NULL)                 -> buffer | NULL
 //   dal_destroy(handle)
 //   dal_buffer_free(ptr)
 //
@@ -107,6 +109,35 @@ public func dal_run(
     return payload.flatMap(ffiEmit)
 }
 
+/// Run the model over mono float `samples` at `sampleRate` - the audio models'
+/// (clear) counterpart to `dal_run`, with the same options/result payload
+/// convention and the same group/device attribution. The samples are read, not
+/// retained; the host keeps owning the buffer. NULL if the run failed or the
+/// model has no audio input.
+@_cdecl("dal_run_audio")
+public func dal_run_audio(
+    _ handle: UnsafeMutableRawPointer?,
+    _ samples: UnsafePointer<Float>?, _ sampleCount: Int32,
+    _ sampleRate: Double,
+    _ options: UnsafePointer<UInt8>?, _ optionsLen: Int32,
+    _ groupId: UnsafePointer<CChar>?,
+    _ deviceId: UnsafePointer<CChar>?
+) -> UnsafeMutablePointer<CChar>? {
+    guard let model = model(handle), let samples, sampleCount > 0 else { return nil }
+    let audio = Array(UnsafeBufferPointer(start: samples, count: Int(sampleCount)))
+    let reader = FFIReader(options, optionsLen)
+    let group = string(groupId)
+    let device = string(deviceId)
+    let payload: [UInt8]? = blockingValue {
+        await InferenceContext.$deviceId.withValue(device) {
+            await InferenceContext.withCallGroup(id: group) {
+                await model.run(audio: audio, sampleRate: sampleRate, options: reader)
+            }
+        }
+    }
+    return payload.flatMap(ffiEmit)
+}
+
 /// Release a handle from `dal_create`.
 @_cdecl("dal_destroy")
 public func dal_destroy(_ handle: UnsafeMutableRawPointer?) {
@@ -114,7 +145,7 @@ public func dal_destroy(_ handle: UnsafeMutableRawPointer?) {
     Unmanaged<Handle>.fromOpaque(handle).release()
 }
 
-/// Free a buffer returned by `dal_run`.
+/// Free a buffer returned by `dal_run`/`dal_run_audio`.
 @_cdecl("dal_buffer_free")
 public func dal_buffer_free(_ pointer: UnsafeMutablePointer<CChar>?) {
     ffiFree(pointer)

--- a/Sources/Bindings/ClearBinding.swift
+++ b/Sources/Bindings/ClearBinding.swift
@@ -1,20 +1,26 @@
 // Clear's side of the cross-language binding: construction, plus the two payload
 // schemas that are genuinely model-specific (the options a run takes, and what a
-// result looks like). The exported C ABI and JNI entry points are shared by every
-// model and live in Sources/Bindings.
+// result looks like). The exported C ABI and JNI entry points beside it are
+// shared by every model.
 //
-// Clear is the catalog's first audio model, so it implements `run(audio:...)`
-// (behind `dal_run_audio`) and leaves the text run to the text models.
+// This lives in `Bindings`, not in the model's own module, so a model module
+// never references `FFIBuffer`. An app that just imports Clear links no FFI
+// layer at all - which also keeps Xcode from having to link a static library
+// whose only use is a conformance the app never calls.
 
 import DesertAnt
+@_spi(ClearBindings) import Clear
 
 extension Clear: BoundModel {
     // `isDownloaded()` and `download(progress:)` are Clear's own public API and
     // witness the protocol as they stand.
 
-    /// Options payload: `f64 strength` (0...1), `f64 targetLUFS` (NaN disables
-    /// mastering), `f64 peakCeilingDBFS`, `f64 maxGainDB`. An empty payload
-    /// means the SDK defaults.
+    /// Options payload: `f64 strength` (0...1), then the mastering chain as
+    /// `f64 integratedLUFS` (NaN bypasses mastering), `f64 truePeakDBTP`,
+    /// `f64 maxLoudnessGainDB`. An empty payload means the SDK defaults (full
+    /// strength, Apple Podcasts). A host that wants a preset sends that
+    /// preset's numbers - the presets themselves are Swift-side, so no id
+    /// crosses the boundary and adding one breaks no host.
     ///
     /// Result payload: `f32Array samples` (48 kHz mono), then `f64 sampleRate`,
     /// `f64 durationSec`, `f64 processingSec`, and `f64 measuredLUFS` (NaN when
@@ -25,9 +31,10 @@ extension Clear: BoundModel {
         if !options.isEmpty {
             opts.strength = Strength(options.f64())
             let target = options.f64()
-            opts.targetLUFS = target.isNaN ? nil : target
-            opts.peakCeilingDBFS = options.f64()
-            opts.maxGainDB = options.f64()
+            opts.mastering.enabled = !target.isNaN
+            if !target.isNaN { opts.mastering.integratedLUFS = target }
+            opts.mastering.truePeakDBTP = options.f64()
+            opts.mastering.maxLoudnessGainDB = options.f64()
         }
         guard let result = try? await enhance(samples: audio, sampleRate: sampleRate, options: opts) else {
             return nil

--- a/Sources/Bindings/EmoBinding.swift
+++ b/Sources/Bindings/EmoBinding.swift
@@ -1,9 +1,15 @@
 // Emo's side of the cross-language binding: construction, plus the two payload
 // schemas that are genuinely model-specific (the options a run takes, and what a
-// result looks like). The exported C ABI and JNI entry points are shared by every
-// model and live in Sources/Bindings.
+// result looks like). The exported C ABI and JNI entry points beside it are
+// shared by every model.
+//
+// This lives in `Bindings`, not in the model's own module, so a model module
+// never references `FFIBuffer`. An app that just imports Emo links no FFI
+// layer at all - which also keeps Xcode from having to link a static library
+// whose only use is a conformance the app never calls.
 
 import DesertAnt
+@_spi(EmoBindings) import Emo
 
 extension Emo: BoundModel {
     /// Options payload: `u32 limit`, `u32 skinTone` (0 default, 1 light,

--- a/Sources/Bindings/RedactBinding.swift
+++ b/Sources/Bindings/RedactBinding.swift
@@ -1,9 +1,15 @@
 // Redact's side of the cross-language binding: construction, plus the two payload
 // schemas that are genuinely model-specific (the options a run takes, and what a
-// result looks like). The exported C ABI and JNI entry points are shared by every
-// model and live in Sources/Bindings.
+// result looks like). The exported C ABI and JNI entry points beside it are
+// shared by every model.
+//
+// This lives in `Bindings`, not in the model's own module, so a model module
+// never references `FFIBuffer`. An app that just imports Redact links no FFI
+// layer at all - which also keeps Xcode from having to link a static library
+// whose only use is a conformance the app never calls.
 
 import DesertAnt
+@_spi(RedactBindings) import Redact
 
 extension Redact: BoundModel {
     /// Options payload: `f64 minimumConfidence`, then `u32 labelCount` and that

--- a/Sources/Bindings/Registry.swift
+++ b/Sources/Bindings/Registry.swift
@@ -10,10 +10,12 @@
 import DesertAnt
 import Emo
 import Redact
+import Clear
 
 let bindings: [String: any ModelBinding.Type] = [
     EmoBinding.id: EmoBinding.self,
     RedactBinding.id: RedactBinding.self,
+    ClearBinding.id: ClearBinding.self,
 ]
 
 /// The binding for a host-supplied model id, or nil if it is unknown.

--- a/Sources/Bindings/Registry.swift
+++ b/Sources/Bindings/Registry.swift
@@ -8,9 +8,6 @@
 // SDK, and the host picks the model at runtime.
 
 import DesertAnt
-import Emo
-import Redact
-import Clear
 
 let bindings: [String: any ModelBinding.Type] = [
     EmoBinding.id: EmoBinding.self,

--- a/Sources/CHostBridge/CHostBridge.c
+++ b/Sources/CHostBridge/CHostBridge.c
@@ -60,4 +60,12 @@ static HostAppIdFn g_app_id = 0;
 void host_set_app_id(HostAppIdFn fn) { g_app_id = fn; }
 char *host_app_id(void) { return g_app_id ? g_app_id() : 0; }
 
+static HostAudioDecodeFn g_audio_decode = 0;
+
+void host_set_audio_decode(HostAudioDecodeFn fn) { g_audio_decode = fn; }
+char *host_audio_decode(const char *path, const unsigned char *bytes,
+                        int64_t byte_count, double target_sample_rate) {
+    return g_audio_decode ? g_audio_decode(path, bytes, byte_count, target_sample_rate) : 0;
+}
+
 void host_free(char *ptr) { free(ptr); }

--- a/Sources/CHostBridge/include/CHostBridge.h
+++ b/Sources/CHostBridge/include/CHostBridge.h
@@ -85,6 +85,19 @@ typedef char *(*HostAppIdFn)(void);
 void host_set_app_id(HostAppIdFn fn);
 char *host_app_id(void);
 
+// Audio decode (Android / hosts with no in-process audio decoder): the host
+// decodes the file at `path` (or, when `path` is NULL, the `byte_count` bytes at
+// `bytes`) to mono PCM at `target_sample_rate`, mixing channels down and
+// resampling as needed. It returns a malloc'd, length-prefixed FFI buffer the
+// caller frees with host_free: a big-endian uint32 body length, then a uint32
+// sample rate, then a float32 array (uint32 count, then that many big-endian
+// floats). NULL means "not installed / decode failed".
+typedef char *(*HostAudioDecodeFn)(const char *path, const unsigned char *bytes,
+                                   int64_t byte_count, double target_sample_rate);
+void host_set_audio_decode(HostAudioDecodeFn fn);
+char *host_audio_decode(const char *path, const unsigned char *bytes,
+                        int64_t byte_count, double target_sample_rate);
+
 void host_free(char *ptr);
 
 #ifdef __cplusplus

--- a/Sources/DesertAnt/DesertAnt.swift
+++ b/Sources/DesertAnt/DesertAnt.swift
@@ -29,6 +29,11 @@
 @_exported import ModelStore
 @_exported import Inference
 
+// Audio: decode/encode (AudioIO) and the STFT/mel/framing DSP (AudioDSP) an
+// audio model SDK runs its front end on.
+@_exported import AudioIO
+@_exported import AudioDSP
+
 // Cross-language bindings: the length-prefixed FFI buffer, what a model
 // implements to be reachable from another language, and the Android JNI harness
 // (empty off the platforms that use it).

--- a/Sources/FFIBuffer/FFIBuffer.swift
+++ b/Sources/FFIBuffer/FFIBuffer.swift
@@ -48,6 +48,19 @@ public struct FFIWriter {
     /// Append a double as its big-endian IEEE-754 bit pattern.
     public mutating func f64(_ v: Double) { u64(v.bitPattern) }
 
+    /// Append a float as its big-endian IEEE-754 bit pattern. `truncatingIfNeeded`
+    /// keeps the 32 bits verbatim on wasm32, where `Int` is 32-bit and a plain
+    /// `Int(bitPattern)` traps for any pattern with the high bit set.
+    public mutating func f32(_ v: Float) { u32(Int(truncatingIfNeeded: v.bitPattern)) }
+
+    /// Append a uint32 element count, then that many big-endian floats. The
+    /// portable typed-array payload for audio buffers and feature vectors that
+    /// cross the C ABI (host reads it with the matching `FfiReader`).
+    public mutating func f32Array(_ values: [Float]) {
+        u32(values.count)
+        for v in values { f32(v) }
+    }
+
     /// Append a uint32 UTF-8 byte count, then the UTF-8 bytes.
     public mutating func string(_ s: String) {
         let utf8 = Array(s.utf8)
@@ -119,10 +132,22 @@ public struct FFIReader {
         }
     }
 
+    /// Read from a length-prefixed buffer as emitted by `ffiEmit` (a big-endian
+    /// uint32 length then the body), giving a reader over the body alone. This is
+    /// the shape a host hands back from a callback (see AudioIO's HostAudioIO).
+    public init(lengthPrefixed buffer: [UInt8]) {
+        guard buffer.count >= 4 else { self.init([]); return }
+        var length = 0
+        for i in 0..<4 { length = (length << 8) | Int(buffer[i]) }
+        self.init(Array(buffer[4..<min(buffer.count, 4 + length)]))
+    }
+
     /// Whether anything was supplied at all (an empty payload means defaults).
     public var isEmpty: Bool { bytes.isEmpty }
     /// Whether every byte has been consumed.
     public var isAtEnd: Bool { offset >= bytes.count }
+    /// Bytes not yet consumed.
+    public var remaining: Int { bytes.count - offset }
 
     private mutating func take(_ n: Int) -> ArraySlice<UInt8>? {
         guard offset + n <= bytes.count else { offset = bytes.count; return nil }
@@ -144,6 +169,18 @@ public struct FFIReader {
 
     /// Read a double from its big-endian IEEE-754 bit pattern, or 0 on underflow.
     public mutating func f64() -> Double { Double(bitPattern: u64()) }
+
+    /// Read a float from its big-endian IEEE-754 bit pattern, or 0 on underflow.
+    public mutating func f32() -> Float { Float(bitPattern: UInt32(truncatingIfNeeded: u32())) }
+
+    /// Read a `u32` count followed by that many big-endian floats (audio frames
+    /// crossing the FFI boundary). A count larger than the bytes left is a
+    /// malformed buffer and yields `[]`.
+    public mutating func f32Array() -> [Float] {
+        let count = u32()
+        guard count > 0, count <= remaining / 4 else { return [] }
+        return (0..<count).map { _ in f32() }
+    }
 
     /// Read a length-prefixed UTF-8 string, or "" on underflow.
     public mutating func string() -> String {

--- a/Sources/HostBridge/JNI.swift
+++ b/Sources/HostBridge/JNI.swift
@@ -31,6 +31,7 @@ private nonisolated(unsafe) var gHttpDownload: jmethodID?
 private nonisolated(unsafe) var gPrefsGet: jmethodID?
 private nonisolated(unsafe) var gPrefsSet: jmethodID?
 private nonisolated(unsafe) var gAppId: jmethodID?
+private nonisolated(unsafe) var gAudioDecode: jmethodID?
 
 // MARK: byte-array marshalling
 
@@ -207,6 +208,31 @@ private func hostPrefsSet(_ key: UnsafePointer<CChar>?, _ value: UnsafePointer<C
     if env.pointee!.pointee.ExceptionCheck(env) == JNI_TRUE { env.pointee!.pointee.ExceptionClear(env) }
 }
 
+// Audio decode: marshal the optional path (UTF-8 bytes) and optional file
+// bytes to jbyteArrays and the target rate to a jdouble, call the host
+// decoder, and take its length-prefixed FFI buffer (u32 rate + f32 array).
+private func hostAudioDecode(_ path: UnsafePointer<CChar>?, _ bytes: UnsafePointer<UInt8>?,
+                             _ byteCount: Int64, _ sampleRate: Double) -> UnsafeMutablePointer<CChar>? {
+    withHostEnv { env in
+        let pathArr: jbyteArray? = path.map { hostMakeBytes(env, Array(String(cString: $0).utf8)) ?? nil } ?? nil
+        let dataArr: jbyteArray?
+        if let bytes, byteCount > 0 {
+            dataArr = hostMakeBytes(env, Array(UnsafeBufferPointer(start: bytes, count: Int(byteCount))))
+        } else {
+            dataArr = nil
+        }
+        defer {
+            if let pathArr { env.pointee!.pointee.DeleteLocalRef(env, pathArr) }
+            if let dataArr { env.pointee!.pointee.DeleteLocalRef(env, dataArr) }
+        }
+        let args = [jvalue(l: pathArr), jvalue(l: dataArr), jvalue(d: sampleRate)]
+        let result = args.withUnsafeBufferPointer {
+            env.pointee!.pointee.CallStaticObjectMethodA(env, gHostClass, gAudioDecode, $0.baseAddress)
+        }
+        return resultBytes(env, result)
+    }
+}
+
 private func hostHttpTree(_ url: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>? {
     withHostEnv { env in
         guard let u = hostMakeBytes(env, Array(String(cString: url!).utf8)) else { return nil }
@@ -271,6 +297,8 @@ public func installHostBridge(_ env: HostEnv, _ cls: jclass?) {
     gPrefsSet = env.pointee!.pointee.GetStaticMethodID(env, cls, "prefsSet", "([B[B)V")
     // Optional: the app identity used as the usage turnstile key.
     gAppId = env.pointee!.pointee.GetStaticMethodID(env, cls, "appId", "()[B")
+    // Optional: audio decode (AudioIO on Android) via MediaExtractor/MediaCodec.
+    gAudioDecode = env.pointee!.pointee.GetStaticMethodID(env, cls, "audioDecode", "([B[BD)[B")
     if env.pointee!.pointee.ExceptionCheck(env) == JNI_TRUE { env.pointee!.pointee.ExceptionClear(env) }
     if gRegexMatches != nil { host_set_regex_matches(hostRegexMatches) }
     if gJSONParse != nil { host_set_json_parse(hostJSONParse) }
@@ -280,5 +308,6 @@ public func installHostBridge(_ env: HostEnv, _ cls: jclass?) {
     if gPrefsGet != nil { host_set_prefs_get(hostPrefsGet) }
     if gPrefsSet != nil { host_set_prefs_set(hostPrefsSet) }
     if gAppId != nil { host_set_app_id(hostAppId) }
+    if gAudioDecode != nil { host_set_audio_decode(hostAudioDecode) }
 }
 #endif

--- a/Sources/Inference/ComputeUnits.swift
+++ b/Sources/Inference/ComputeUnits.swift
@@ -1,0 +1,18 @@
+/// Which compute units an on-device backend may use. Maps to Core ML's
+/// `MLComputeUnits` on Apple; the ONNX/LiteRT/JS backends ignore it (they pick
+/// their own execution providers). Model SDKs pass it through the session
+/// factory so they need not import CoreML to pin, e.g., `.cpuAndNeuralEngine`.
+///
+/// Choosing: `.all` lets Core ML use CPU+GPU+ANE, but for a small-op-dense
+/// graph the GPU is often slow and, if any op forces a CPU fallback (e.g. a
+/// `while_loop`), the extra partitioning can make `.all` slower than
+/// `.cpuOnly`. ANE-friendly graphs (no dynamic control flow) are usually
+/// fastest on `.cpuAndNeuralEngine`.
+public enum ComputeUnits: Sendable {
+    /// CPU + GPU + Neural Engine; Core ML partitions across them.
+    case all
+    /// CPU + Neural Engine (skips the GPU). Often fastest on ANE-native graphs.
+    case cpuAndNeuralEngine
+    /// CPU only. Deterministic fallback / diagnostic.
+    case cpuOnly
+}

--- a/Sources/Inference/CoreMLSession.swift
+++ b/Sources/Inference/CoreMLSession.swift
@@ -1,32 +1,44 @@
 #if canImport(CoreML)
 import CoreML
+import Accelerate
 import Foundation
 import PlatformSupport
 
 /// Core ML inference backend (Apple platforms): a compiled `.mlmodelc` behind
 /// the shared ``InferenceSession`` API.
 ///
-/// Inputs must be `int32` or `float32` (Core ML has no int64 tensors; export
-/// models accordingly). `float32`/`int32` outputs are copied out directly;
-/// other output types (e.g. float16) are converted to `float32` elementwise,
-/// which is slow for large outputs, so exporters should emit `float32`.
+/// Feeds the model's native I/O precision: when an input/output is `float16`
+/// (as fp16-exported graphs declare), it converts against a `Tensor`'s
+/// `float32` bytes with vImage rather than per-element `NSNumber` subscripting,
+/// which is orders of magnitude faster on large tensors (and lets Core ML run
+/// the pure-fp16 graph instead of inserting casts). The MLMultiArrays and the
+/// feature provider are built once and reused across `run` calls of the same
+/// shape (e.g. a fixed-window model over many chunks). `int32`/`float32` I/O is
+/// copied directly; `int64` inputs are rejected (Core ML has no int64 tensors).
 final class CoreMLSession: InferenceSession, @unchecked Sendable {
     private let model: MLModel
+    private let lock = NSLock()
+    private var inArrays: [String: MLMultiArray] = [:]
+    private var provider: MLDictionaryFeatureProvider?
 
-    /// Load a compiled model. The default configuration uses every compute
-    /// unit on device (CPU-only in the simulator); pass your own to override,
-    /// e.g. `.cpuAndNeuralEngine` for large models.
-    init(modelPath: String, configuration: MLModelConfiguration = CoreMLSession.defaultConfiguration()) throws {
-        model = try MLModel(contentsOf: URL(fileURLWithPath: modelPath), configuration: configuration)
+    /// Load a compiled model. `computeUnits` is what the model SDK asks for
+    /// (Core ML's `MLComputeUnits`); the environment and the simulator can
+    /// override it - see ``configuration(for:)``.
+    init(modelPath: String, computeUnits: ComputeUnits = .all) throws {
+        model = try MLModel(contentsOf: URL(fileURLWithPath: modelPath),
+                            configuration: CoreMLSession.configuration(for: computeUnits))
     }
 
-    /// Every compute unit on device, except where that is not trustworthy or not
-    /// available: the simulator has no Neural Engine, and neither does a
-    /// virtualized macOS host (CI runners), where `.all` can silently yield
-    /// useless outputs rather than failing. `DAL_COREML_COMPUTE_UNITS` overrides
-    /// the choice - `cpu`, `cpuAndGPU`, `cpuAndNeuralEngine`, or `all` - which is
-    /// how a CI job pins itself to a configuration that is reproducible there.
-    static func defaultConfiguration() -> MLModelConfiguration {
+    /// The configuration to load with, in precedence order:
+    ///
+    /// 1. `DAL_COREML_COMPUTE_UNITS` (`cpu`, `cpuAndGPU`, `cpuAndNeuralEngine`,
+    ///    `all`) - how a CI job pins itself to a configuration that is
+    ///    reproducible there. A virtualized macOS host (CI runners) has no
+    ///    Neural Engine, and `.all` can silently yield useless outputs rather
+    ///    than failing.
+    /// 2. The simulator, which has no Neural Engine: CPU only.
+    /// 3. What the caller asked for (the SDK's own measured best choice).
+    static func configuration(for requested: ComputeUnits = .all) -> MLModelConfiguration {
         let configuration = MLModelConfiguration()
         switch environmentVariable("DAL_COREML_COMPUTE_UNITS") {
         case "cpu", "cpuOnly": configuration.computeUnits = .cpuOnly
@@ -37,60 +49,131 @@ final class CoreMLSession: InferenceSession, @unchecked Sendable {
             #if targetEnvironment(simulator)
             configuration.computeUnits = .cpuOnly
             #else
-            configuration.computeUnits = .all
+            configuration.computeUnits = requested.mlComputeUnits
             #endif
         }
         return configuration
     }
 
     func run(inputs: [String: Tensor], outputs: [String], deviceId: String?) throws -> [Tensor] {
-        var features: [String: Any] = [:]
-        for (name, tensor) in inputs { features[name] = try multiArray(tensor) }
-        let provider = try MLDictionaryFeatureProvider(dictionary: features)
-        let prediction = try model.prediction(from: provider)
+        lock.lock(); defer { lock.unlock() }
+        let desc = model.modelDescription.inputDescriptionsByName
+
+        // Build (once) and reuse the input arrays + provider; rebuild only when
+        // the set of inputs or a shape changes.
+        if provider == nil || !cacheMatches(inputs) {
+            inArrays.removeAll(keepingCapacity: true)
+            var features: [String: Any] = [:]
+            for (name, tensor) in inputs {
+                let dt = try dataType(for: tensor, declared: desc[name]?.multiArrayConstraint?.dataType)
+                let array = try MLMultiArray(shape: tensor.shape.map { NSNumber(value: $0) }, dataType: dt)
+                inArrays[name] = array
+                features[name] = array
+            }
+            provider = try MLDictionaryFeatureProvider(dictionary: features)
+        }
+        for (name, tensor) in inputs { write(tensor, into: inArrays[name]!) }
+
+        let prediction = try model.prediction(from: provider!)
         return try outputs.map { name in
             guard let array = prediction.featureValue(for: name)?.multiArrayValue else {
                 throw InferenceError.runFailed("the model returned no '\(name)'")
             }
-            return try tensor(array)
+            return readTensor(array)
         }
     }
 
-    private func multiArray(_ tensor: Tensor) throws -> MLMultiArray {
-        let dataType: MLMultiArrayDataType
+    private func cacheMatches(_ inputs: [String: Tensor]) -> Bool {
+        guard inArrays.count == inputs.count else { return false }
+        for (name, tensor) in inputs {
+            guard let a = inArrays[name], a.shape.map(\.intValue) == tensor.shape else { return false }
+        }
+        return true
+    }
+
+    private func dataType(for tensor: Tensor, declared: MLMultiArrayDataType?) throws -> MLMultiArrayDataType {
         switch tensor.element {
-        case .int32: dataType = .int32
-        case .float32: dataType = .float32
         case .int64:
             throw InferenceError.invalidTensor("Core ML takes int32, not int64; export the model accordingly")
+        case .int32:
+            return .int32
+        case .float32:
+            // Match the model's declared precision so an fp16 graph gets fp16.
+            return declared == .float16 ? .float16 : .float32
         }
-        let array = try MLMultiArray(shape: tensor.shape.map { NSNumber(value: $0) }, dataType: dataType)
-        array.withUnsafeMutableBytes { destination, _ in
-            tensor.bytes.withUnsafeBytes { destination.copyMemory(from: $0) }
-        }
-        return array
     }
 
-    private func tensor(_ array: MLMultiArray) throws -> Tensor {
+    private func write(_ tensor: Tensor, into array: MLMultiArray) {
+        let count = tensor.count
+        tensor.bytes.withUnsafeBytes { raw in
+            if array.dataType == .float16 {
+                let src = raw.bindMemory(to: Float.self)
+                var s = vImage_Buffer(data: .init(mutating: src.baseAddress!), height: 1,
+                                      width: vImagePixelCount(count), rowBytes: count * 4)
+                var d = vImage_Buffer(data: array.dataPointer, height: 1,
+                                      width: vImagePixelCount(count), rowBytes: count * 2)
+                vImageConvert_PlanarFtoPlanar16F(&s, &d, 0)
+            } else {
+                array.dataPointer.copyMemory(from: raw.baseAddress!, byteCount: count * array.dataType.byteWidth)
+            }
+        }
+    }
+
+    private func readTensor(_ array: MLMultiArray) -> Tensor {
         let shape = array.shape.map(\.intValue)
         let count = shape.reduce(1, *)
-        switch array.dataType {
-        case .float32:
-            return try Tensor(element: .float32, shape: shape, bytes: copyBytes(array, count * 4))
-        case .int32:
-            return try Tensor(element: .int32, shape: shape, bytes: copyBytes(array, count * 4))
-        default:
-            // float16/float64 outputs: convert through the typed subscript.
-            var values = [Float](repeating: 0, count: count)
-            for index in 0..<count { values[index] = array[index].floatValue }
-            return Tensor(float32: values, shape: shape)
+        let contiguous = isContiguous(array)
+        if array.dataType == .int32, contiguous {
+            let bytes = array.dataPointer.withMemoryRebound(to: UInt8.self, capacity: count * 4) {
+                Array(UnsafeBufferPointer(start: $0, count: count * 4))
+            }
+            return (try? Tensor(element: .int32, shape: shape, bytes: bytes)) ?? Tensor(float32: [], shape: shape)
         }
+        var out = [Float](repeating: 0, count: count)
+        if array.dataType == .float16, contiguous {
+            let src = array.dataPointer.assumingMemoryBound(to: UInt16.self)
+            var s = vImage_Buffer(data: .init(mutating: src), height: 1, width: vImagePixelCount(count), rowBytes: count * 2)
+            out.withUnsafeMutableBufferPointer { dp in
+                var d = vImage_Buffer(data: dp.baseAddress!, height: 1, width: vImagePixelCount(count), rowBytes: count * 4)
+                vImageConvert_Planar16FtoPlanarF(&s, &d, 0)
+            }
+        } else if array.dataType == .float32, contiguous {
+            out.withUnsafeMutableBufferPointer { $0.baseAddress!.update(from: array.dataPointer.assumingMemoryBound(to: Float.self), count: count) }
+        } else {
+            // Strided (ANE-padded inner dims) or float64: correct, slower path.
+            for i in 0..<count { out[i] = array[i].floatValue }
+        }
+        return Tensor(float32: out, shape: shape)
     }
 
-    private func copyBytes(_ array: MLMultiArray, _ byteCount: Int) -> [UInt8] {
-        array.withUnsafeBytes { source in
-            precondition(source.count >= byteCount, "MLMultiArray smaller than its shape")
-            return Array(source.prefix(byteCount))
+    private func isContiguous(_ array: MLMultiArray) -> Bool {
+        let shape = array.shape.map(\.intValue), strides = array.strides.map(\.intValue)
+        var expected = 1
+        for i in (0..<shape.count).reversed() {
+            if strides[i] != expected { return false }
+            expected *= shape[i]
+        }
+        return true
+    }
+}
+
+extension ComputeUnits {
+    var mlComputeUnits: MLComputeUnits {
+        switch self {
+        case .all: return .all
+        case .cpuAndNeuralEngine: return .cpuAndNeuralEngine
+        case .cpuOnly: return .cpuOnly
+        }
+    }
+}
+
+private extension MLMultiArrayDataType {
+    var byteWidth: Int {
+        switch self {
+        case .float16: return 2
+        case .int32, .float32: return 4
+        case .double: return 8
+        @unknown default: return 4
         }
     }
 }

--- a/Sources/Inference/SessionFactory.swift
+++ b/Sources/Inference/SessionFactory.swift
@@ -8,9 +8,13 @@ import Usage
 /// This platform's inference session for a model artifact on disk: Core ML on
 /// Apple platforms and LiteRT on Android/Linux. wasm uses the JS-hosted factory
 /// in `StoredModel.inferenceSession(model:hostGlobal:)` instead.
-public func inferenceSession(modelPath: String, sdk: SDKInfo = SDKInfo()) throws -> any InferenceSession {
+///
+/// `computeUnits` is a Core ML concern (LiteRT picks its own delegates), and the
+/// environment can still override it - see `CoreMLSession.configuration(for:)`.
+public func inferenceSession(modelPath: String, computeUnits: ComputeUnits = .all,
+                             sdk: SDKInfo = SDKInfo()) throws -> any InferenceSession {
     #if canImport(CoreML)
-    return tracked(try CoreMLSession(modelPath: modelPath), sdk: sdk)
+    return tracked(try CoreMLSession(modelPath: modelPath, computeUnits: computeUnits), sdk: sdk)
     #elseif canImport(CLiteRt)
     return tracked(try LiteRTSession(modelPath: modelPath), sdk: sdk)
     #else
@@ -48,12 +52,13 @@ public extension StoredModel {
     /// host's session is driven through the `JSInferenceSession` tensor
     /// contract. This is the one call a model SDK makes to go from resolved
     /// files to a runnable session.
-    func inferenceSession(model: String, hostGlobal: String = "__ModelHost", sdk: SDKInfo = SDKInfo()) async throws -> any InferenceSession {
+    func inferenceSession(model: String, hostGlobal: String = "__ModelHost",
+                          computeUnits: ComputeUnits = .all, sdk: SDKInfo = SDKInfo()) async throws -> any InferenceSession {
         #if os(WASI)
         try await createJavaScriptSession(modelFile: model, hostGlobal: hostGlobal)
         return tracked(try JSInferenceSession(hostGlobal: hostGlobal), sdk: sdk)
         #else
-        return try Inference.inferenceSession(modelPath: path(model), sdk: sdk)  // already tracked
+        return try Inference.inferenceSession(modelPath: path(model), computeUnits: computeUnits, sdk: sdk)  // already tracked
         #endif
     }
 }

--- a/Sources/ModelBinding/ModelBinding.swift
+++ b/Sources/ModelBinding/ModelBinding.swift
@@ -33,6 +33,21 @@ public protocol BoundModel: AnyObject {
     ///
     /// Returning `nil` reports failure to the host as a NULL buffer.
     func run(text: String, options: FFIReader) async -> [UInt8]?
+
+    /// Run the model over audio: mono `samples` at `sampleRate`, with the
+    /// model's own `options` payload, returning its own result payload (see
+    /// `run(text:options:)` for both conventions).
+    ///
+    /// A model implements the modality it has - text models (emo, redact) leave
+    /// this alone, audio models (clear) leave `run(text:options:)` alone - and
+    /// the default reports "not this model's input" to the host as a NULL
+    /// buffer, exactly like a failed run.
+    func run(audio: [Float], sampleRate: Double, options: FFIReader) async -> [UInt8]?
+}
+
+public extension BoundModel {
+    func run(text: String, options: FFIReader) async -> [UInt8]? { nil }
+    func run(audio: [Float], sampleRate: Double, options: FFIReader) async -> [UInt8]? { nil }
 }
 
 /// A model's binding: how to construct it. The instance methods live on

--- a/Sources/ModelCatalog/Clear/Binding.swift
+++ b/Sources/ModelCatalog/Clear/Binding.swift
@@ -1,0 +1,52 @@
+// Clear's side of the cross-language binding: construction, plus the two payload
+// schemas that are genuinely model-specific (the options a run takes, and what a
+// result looks like). The exported C ABI and JNI entry points are shared by every
+// model and live in Sources/Bindings.
+//
+// Clear is the catalog's first audio model, so it implements `run(audio:...)`
+// (behind `dal_run_audio`) and leaves the text run to the text models.
+
+import DesertAnt
+
+extension Clear: BoundModel {
+    // `isDownloaded()` and `download(progress:)` are Clear's own public API and
+    // witness the protocol as they stand.
+
+    /// Options payload: `f64 strength` (0...1), `f64 targetLUFS` (NaN disables
+    /// mastering), `f64 peakCeilingDBFS`, `f64 maxGainDB`. An empty payload
+    /// means the SDK defaults.
+    ///
+    /// Result payload: `f32Array samples` (48 kHz mono), then `f64 sampleRate`,
+    /// `f64 durationSec`, `f64 processingSec`, and `f64 measuredLUFS` (NaN when
+    /// mastering was disabled).
+    public func run(audio: [Float], sampleRate: Double, options: FFIReader) async -> [UInt8]? {
+        var options = options
+        var opts = Options.default
+        if !options.isEmpty {
+            opts.strength = Strength(options.f64())
+            let target = options.f64()
+            opts.targetLUFS = target.isNaN ? nil : target
+            opts.peakCeilingDBFS = options.f64()
+            opts.maxGainDB = options.f64()
+        }
+        guard let result = try? await enhance(samples: audio, sampleRate: sampleRate, options: opts) else {
+            return nil
+        }
+        var w = FFIWriter()
+        w.f32Array(result.samples)
+        w.f64(result.sampleRate)
+        w.f64(result.durationSec)
+        w.f64(result.processingSec)
+        w.f64(result.measuredLUFS ?? .nan)
+        return w.bytes
+    }
+}
+
+/// How the generic bindings construct Clear.
+public enum ClearBinding: ModelBinding {
+    public static let id = ClearModel.id
+
+    public static func make(cacheRoot: String?, directory: String?) -> any BoundModel {
+        Clear(directory: directory, cacheRoot: cacheRoot)
+    }
+}

--- a/Sources/ModelCatalog/Clear/Catalog.swift
+++ b/Sources/ModelCatalog/Clear/Catalog.swift
@@ -1,0 +1,44 @@
+// This model's catalog declaration: coordinates, file names, and which of them
+// each platform ships. The shared behaviour (distribution, resolve, availability)
+// comes from `ModelDeclaration` in the catalog's shared half.
+
+import DesertAnt
+
+/// The clear model: on-device speech enhancement (DeepFilterNet3).
+public enum ClearModel: ModelDeclaration {
+    public static let id = "clear"
+    public static let product = "Clear"
+    // The Hub repo's `v0.1.0` tag predates the LiteRT export, so pinning it
+    // would leave Android/Linux/web with no artifact. Tracks `main` until the
+    // next tag carries `clear-studio.tflite`, then becomes that `v`-tag.
+    public static let revision = "main"
+    /// No published npm/Maven package yet, so nothing cross-checks this the way
+    /// ModelCatalogTests checks emo and redact; keep it in step with
+    /// packages/clear-* when they land.
+    public static let sdkVersion = "0.1.0"
+    public static let summary = "On-device speech enhancement: denoise, dereverb, and loudness-normalize."
+
+    /// The published variant this SDK is built against. The repo also ships a
+    /// `clear-natural` export; switching variants is a file-name change here.
+    public static let variant = "clear-studio"
+    /// Core ML export (a directory on the Hub): Apple. Already ANE-friendly and
+    /// 6-bit palettized, so no per-platform export shaping is needed.
+    public static let coreML = "\(variant).mlmodelc"
+    /// LiteRT export: Android/Linux/Windows, and LiteRT.js on the web.
+    public static let tflite = "\(variant).tflite"
+
+    /// Unlike the text models, clear has no sidecars: the DSP front end
+    /// (`DSP.swift`/`Features.swift`) carries the constants that would otherwise
+    /// be a metadata file, so a platform ships exactly one artifact.
+    public static let files: [ModelPlatform: [String]] = [
+        .apple: [coreML + "/"],
+        .android: [tflite],
+        .linux: [tflite],
+        .windows: [tflite],
+        .web: [tflite],
+    ]
+
+    public static func artifact(for platform: ModelPlatform) -> String {
+        platform == .apple ? coreML : tflite
+    }
+}

--- a/Sources/ModelCatalog/Clear/Catalog.swift
+++ b/Sources/ModelCatalog/Clear/Catalog.swift
@@ -18,27 +18,24 @@ public enum ClearModel: ModelDeclaration {
     public static let sdkVersion = "0.1.0"
     public static let summary = "On-device speech enhancement: denoise, dereverb, and loudness-normalize."
 
-    /// The published variant this SDK is built against. The repo also ships a
-    /// `clear-natural` export; switching variants is a file-name change here.
-    public static let variant = "clear-studio"
+    /// The variant this declaration describes: the SDK default. The repo also
+    /// publishes `clear-natural`, which a caller selects per instance
+    /// (`Clear(variant:)`) and which downloads through ``ModelVariant`` rather
+    /// than through this manifest - the catalog entry stays one model's default
+    /// artifact, which is what tooling and the shared test fixture expect.
+    public static let variant = ModelVariant.default
     /// Core ML export (a directory on the Hub): Apple. Already ANE-friendly and
     /// 6-bit palettized, so no per-platform export shaping is needed.
-    public static let coreML = "\(variant).mlmodelc"
+    public static let coreML = variant.coreML
     /// LiteRT export: Android/Linux/Windows, and LiteRT.js on the web.
-    public static let tflite = "\(variant).tflite"
+    public static let tflite = variant.tflite
 
     /// Unlike the text models, clear has no sidecars: the DSP front end
     /// (`DSP.swift`/`Features.swift`) carries the constants that would otherwise
     /// be a metadata file, so a platform ships exactly one artifact.
-    public static let files: [ModelPlatform: [String]] = [
-        .apple: [coreML + "/"],
-        .android: [tflite],
-        .linux: [tflite],
-        .windows: [tflite],
-        .web: [tflite],
-    ]
+    public static let files: [ModelPlatform: [String]] = variant.files
 
     public static func artifact(for platform: ModelPlatform) -> String {
-        platform == .apple ? coreML : tflite
+        variant.artifact(for: platform)
     }
 }

--- a/Sources/ModelCatalog/Clear/Clear.swift
+++ b/Sources/ModelCatalog/Clear/Clear.swift
@@ -1,0 +1,214 @@
+import Foundation
+import DesertAnt
+
+/// On-device speech enhancement: denoise, dereverb, and loudness-normalize a
+/// noisy recording to a podcast-ready 48 kHz mono file. DeepFilterNet3 under the
+/// hood, running on Core ML (Apple), ONNX Runtime (Android/Linux), or the JS
+/// host (web) through desert-ant-core, with the DSP shared across all platforms.
+///
+/// ```swift
+/// let clear = try Clear(modelPath: "clear-studio.onnx")   // or download via Clear()
+/// let out = try await clear.enhance(path: "in.wav", to: "out.wav")
+/// ```
+public final class Clear: @unchecked Sendable {
+
+    /// Linear blend between the enhanced output (1.0) and the original (0.0).
+    public struct Strength: Sendable, ExpressibleByFloatLiteral {
+        public let value: Double
+        public init(_ v: Double) { self.value = v.isFinite ? min(1, max(0, v)) : 1 }
+        public init(floatLiteral v: Double) { self.init(v) }
+        public static let full: Strength = 1.0
+        public static let medium: Strength = 0.7
+        public static let subtle: Strength = 0.4
+    }
+
+    public struct Options: Sendable {
+        /// Enhancement blend. Default full.
+        public var strength: Strength
+        /// Integrated loudness target in LUFS (nil disables mastering).
+        public var targetLUFS: Double?
+        /// True-peak ceiling in dBFS for the master.
+        public var peakCeilingDBFS: Double
+        /// Cap on the upward loudness gain in dB.
+        public var maxGainDB: Double
+        public init(strength: Strength = .full, targetLUFS: Double? = -19,
+                    peakCeilingDBFS: Double = -1.0, maxGainDB: Double = 12) {
+            self.strength = strength
+            self.targetLUFS = targetLUFS
+            self.peakCeilingDBFS = peakCeilingDBFS
+            self.maxGainDB = maxGainDB
+        }
+        public static let `default` = Options()
+    }
+
+    public struct Result: Sendable {
+        public let samples: [Float]         // enhanced, 48 kHz mono
+        public let sampleRate: Double
+        public let durationSec: Double
+        public let processingSec: Double
+        public let measuredLUFS: Double?
+        public var realtimeFactor: Double { processingSec > 0 ? durationSec / processingSec : 0 }
+    }
+
+    // Resolving, downloading, single-flighting, and offline availability are
+    // `LoadedModel`; Clear adds only how a resolved directory becomes its
+    // session pool.
+    private let model: LoadedModel<ModelAssets>
+
+    /// Default model sessions to run chunks in parallel over. Native LiteRT is
+    /// single-threaded per run, so a pool uses multiple cores; Apple (fast) and
+    /// wasm (LiteRT.js is already multi-threaded) use one.
+    public static var defaultConcurrency: Int {
+        #if canImport(CoreML) || os(WASI)
+        return 1                                          // Apple: fast single session; wasm: LiteRT.js already threaded
+        #elseif os(Android)
+        return max(1, min(ProcessInfo.processInfo.activeProcessorCount, 2))   // cap memory on mobile (~2x model size)
+        #else
+        return max(1, min(ProcessInfo.processInfo.activeProcessorCount, 4))   // Linux/Windows desktop/server
+        #endif
+    }
+
+    /// `computeUnits` selects the Core ML compute units on Apple (ignored by the
+    /// LiteRT/JS backends). Default `.cpuOnly`: the palettized model benchmarks
+    /// ~2x faster on the CPU than the Neural Engine or GPU on M-series Macs.
+    /// `concurrency` is the model-session pool size (see `defaultConcurrency`).
+    ///
+    /// Nothing is bundled with this package. To ship the model with your app,
+    /// point `directory` at a folder you populated with the model files: it is
+    /// used as-is, offline, and nothing is downloaded.
+    public convenience init(directory: String? = nil, computeUnits: ComputeUnits = .cpuOnly,
+                            concurrency: Int = Clear.defaultConcurrency) {
+        self.init(directory: directory, cacheRoot: nil, computeUnits: computeUnits, concurrency: concurrency)
+    }
+
+    /// Binding entry point that also supplies the platform base cache root under
+    /// which the managed layout lives (the app cache dir on Android, node
+    /// `~/.cache` on the web). On Apple/Linux FileManager provides it, so the
+    /// public `init(directory:...)` passes `nil`.
+    @_spi(ClearBindings)
+    public init(directory: String?, cacheRoot: String?,
+                computeUnits: ComputeUnits = .cpuOnly,
+                concurrency: Int = Clear.defaultConcurrency) {
+        model = LoadedModel(ClearModel.self, directory: directory, cacheRoot: cacheRoot) { files in
+            try await .clear(files: files, computeUnits: computeUnits, concurrency: concurrency)
+        }
+    }
+
+    /// Creates an enhancer from explicitly provided assets (the Android/JNI and
+    /// custom-deployment paths).
+    @_spi(ClearBindings)
+    public init(assets: ModelAssets) {
+        model = LoadedModel { assets }
+    }
+
+    /// Load a local model file directly (a `.mlmodelc` on Apple, a `.tflite`
+    /// elsewhere), skipping the store entirely. For tests and custom
+    /// deployments; apps point `directory` at their files instead.
+    public init(modelPath: String, computeUnits: ComputeUnits = .cpuOnly,
+                concurrency: Int = Clear.defaultConcurrency) throws {
+        let sessions = try (0..<max(1, concurrency)).map { _ in
+            try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)
+        }
+        model = LoadedModel { ModelAssets(sessions: sessions) }
+    }
+
+    /// Whether the model is available for this enhancer with no network:
+    /// cached (for the managed location) or already present in `directory`.
+    public func isDownloaded() -> Bool { model.isDownloaded() }
+
+    /// Await model readiness. The bindings use this to surface load errors
+    /// eagerly; apps can just call `enhance`.
+    @_spi(ClearBindings)
+    public func waitUntilLoaded() async throws {
+        _ = try await model.value()
+    }
+
+    /// Download the model if needed, reporting progress 0...1.
+    public func download(progress: @escaping @Sendable (Double) -> Void = { _ in }) async throws {
+        try await model.download(progress: progress)
+    }
+
+    /// Enhance mono/stereo `samples` at `sampleRate`, returning 48 kHz mono.
+    public func enhance(samples: [Float], sampleRate: Double,
+                        options: Options = .default) async throws -> Result {
+        let assets = try await model.value()
+        let start = Date()
+        let input = sampleRate == ClearDSP.sampleRate
+            ? samples
+            : Resample.linear(samples, from: sampleRate, to: ClearDSP.sampleRate)
+        let enhancer = ClearEnhancer(sessions: assets.sessions)
+        var out = try await enhancer.enhance(input)
+
+        // Strength blend against the (resampled) input.
+        let s = Float(options.strength.value)
+        if s < 1 {
+            let n = min(out.count, input.count)
+            for i in 0..<n { out[i] = s * out[i] + (1 - s) * input[i] }
+        }
+
+        var measured: Double? = nil
+        if let target = options.targetLUFS {
+            let (mastered, lufs) = Loudness.normalize(
+                out, sampleRate: ClearDSP.sampleRate, targetLUFS: target,
+                maxGainDB: options.maxGainDB, peakCeilingDBFS: options.peakCeilingDBFS)
+            out = mastered
+            measured = lufs
+        }
+        return Result(samples: out, sampleRate: ClearDSP.sampleRate,
+                      durationSec: Double(out.count) / ClearDSP.sampleRate,
+                      processingSec: Date().timeIntervalSince(start), measuredLUFS: measured)
+    }
+
+    #if canImport(Foundation) && !os(Android) && !os(WASI)
+    /// Decode any audio file, enhance it, and (optionally) write a 48 kHz WAV.
+    /// Filesystem platforms (Apple/Linux); on Android/web use `enhance(bytes:)`.
+    @discardableResult
+    public func enhance(path: String, to outputPath: String? = nil,
+                        options: Options = .default) async throws -> Result {
+        let samples = try await AudioIO.decode(path: path, sampleRate: ClearDSP.sampleRate)
+        let result = try await enhance(samples: samples, sampleRate: ClearDSP.sampleRate, options: options)
+        if let outputPath {
+            try AudioIO.writeWAV(result.samples, sampleRate: Int(ClearDSP.sampleRate), to: outputPath)
+        }
+        return result
+    }
+    #endif
+
+    /// Enhance in-memory audio-file `bytes`, returning enhanced 48 kHz mono
+    /// samples and a ready-to-write WAV byte buffer.
+    public func enhance(bytes: [UInt8], options: Options = .default) async throws
+        -> (result: Result, wav: [UInt8]) {
+        let samples = try await AudioIO.decode(bytes: bytes, sampleRate: ClearDSP.sampleRate)
+        let result = try await enhance(samples: samples, sampleRate: ClearDSP.sampleRate, options: options)
+        let wav = AudioIO.encodeWAV(result.samples, sampleRate: Int(ClearDSP.sampleRate))
+        return (result, wav)
+    }
+}
+
+/// Errors thrown while loading or running the model. (`MessageError` is
+/// `LocalizedError` wherever Foundation exists, so `localizedDescription`
+/// shows `message`.)
+public enum ClearError: MessageError, Sendable {
+    /// On-device enhancement failed or returned an unexpected output.
+    case inferenceFailed(String)
+    /// A model resource could not be found.
+    case modelMissing(String)
+
+    public var message: String {
+        switch self {
+        case .inferenceFailed(let detail): "On-device speech enhancement failed: \(detail)."
+        case .modelMissing(let name): "A Clear model resource was not found: \(name)."
+        }
+    }
+}
+
+#if os(WASI)
+public extension Clear {
+    /// Build from a JS host inference session (the wasm entry point). The host
+    /// (`__ClearHost`, a LiteRT.js session) must be installed first.
+    @_spi(ClearBindings)
+    convenience init(hostGlobal: String = ClearModel.hostGlobal) throws {
+        self.init(assets: ModelAssets(session: try inferenceSession(hostGlobal: hostGlobal, sdk: ClearModel.sdkInfo)))
+    }
+}
+#endif

--- a/Sources/ModelCatalog/Clear/Clear.swift
+++ b/Sources/ModelCatalog/Clear/Clear.swift
@@ -3,11 +3,11 @@ import DesertAnt
 
 /// On-device speech enhancement: denoise, dereverb, and loudness-normalize a
 /// noisy recording to a podcast-ready 48 kHz mono file. DeepFilterNet3 under the
-/// hood, running on Core ML (Apple), ONNX Runtime (Android/Linux), or the JS
+/// hood, running on Core ML (Apple), LiteRT (Android/Linux), or the JS
 /// host (web) through desert-ant-core, with the DSP shared across all platforms.
 ///
 /// ```swift
-/// let clear = try Clear(modelPath: "clear-studio.onnx")   // or download via Clear()
+/// let clear = try Clear(modelPath: "clear-studio.tflite")  // or download via Clear()
 /// let out = try await clear.enhance(path: "in.wav", to: "out.wav")
 /// ```
 public final class Clear: @unchecked Sendable {
@@ -25,19 +25,31 @@ public final class Clear: @unchecked Sendable {
     public struct Options: Sendable {
         /// Enhancement blend. Default full.
         public var strength: Strength
-        /// Integrated loudness target in LUFS (nil disables mastering).
-        public var targetLUFS: Double?
-        /// True-peak ceiling in dBFS for the master.
-        public var peakCeilingDBFS: Double
-        /// Cap on the upward loudness gain in dB.
-        public var maxGainDB: Double
-        public init(strength: Strength = .full, targetLUFS: Double? = -19,
-                    peakCeilingDBFS: Double = -1.0, maxGainDB: Double = 12) {
+        /// Where the output should land loudness-wise. Defaults to the Apple
+        /// Podcasts spec; use a ``Clear/LoudnessPreset``, `.targetLUFS(_:)`, or
+        /// `.bypass` to leave the model's own level alone.
+        public var mastering: Mastering
+
+        public init(strength: Strength = .full, mastering: Mastering = .applePodcasts) {
             self.strength = strength
-            self.targetLUFS = targetLUFS
-            self.peakCeilingDBFS = peakCeilingDBFS
-            self.maxGainDB = maxGainDB
+            self.mastering = mastering
         }
+
+        /// Loudness targets without naming a delivery platform. `targetLUFS` is
+        /// required, so `Options()` still means "full strength, Apple Podcasts".
+        public init(strength: Strength = .full, targetLUFS: Double?,
+                    peakCeilingDBFS: Double = -1.5, maxGainDB: Double = 9) {
+            self.strength = strength
+            self.mastering = Mastering(
+                integratedLUFS: targetLUFS ?? Mastering.applePodcasts.integratedLUFS,
+                truePeakDBTP: peakCeilingDBFS,
+                enabled: targetLUFS != nil,
+                maxLoudnessGainDB: maxGainDB)
+        }
+
+        /// The integrated-LUFS target, or nil when mastering is bypassed.
+        public var targetLUFS: Double? { mastering.enabled ? mastering.integratedLUFS : nil }
+
         public static let `default` = Options()
     }
 
@@ -47,8 +59,53 @@ public final class Clear: @unchecked Sendable {
         public let durationSec: Double
         public let processingSec: Double
         public let measuredLUFS: Double?
+        /// Which published model variant produced this output, or nil when the
+        /// artifact is not a published one (a custom export, or a wasm host
+        /// that compiled the model itself).
+        public let modelVariant: ModelVariant?
         public var realtimeFactor: Double { processingSec > 0 ? durationSec / processingSec : 0 }
     }
+
+    /// Stages reported through ``ProgressHandler``. Each runs to completion
+    /// before the next starts, and `fraction` resets to 0 at every transition,
+    /// so a caller can weight them however its UI needs.
+    ///
+    /// Same cases, and the same order, as the standalone Clear SDK, so progress
+    /// code moves over unchanged. What sits behind them differs: that SDK made
+    /// two streaming passes over the file (analyze into a loudness meter, then
+    /// re-stream applying gain), while this pipeline runs the front end once,
+    /// then the model, then masters the result in memory. The split lands in
+    /// the same place - a quick analysis phase, then the long model phase.
+    public enum Phase: Sendable, Equatable {
+        /// Resolving the model: downloading or adopting the files, then
+        /// building the platform's session. On Apple the first launch also
+        /// pays the Core ML compile, which can take tens of seconds on iPhone;
+        /// it is cached afterwards. Skipped entirely once loaded.
+        case loadingModel
+        /// The DSP front end ahead of the model: resample to 48 kHz, STFT, and
+        /// the ERB/DF feature pass. Fast relative to ``enhancing``.
+        case analyzing
+        /// The model itself, chunk by chunk, plus the strength blend and the
+        /// mastering chain that follow it. The long phase: `fraction` is the
+        /// share of model chunks finished, reaching 1 once mastering is done.
+        case enhancing
+    }
+
+    /// A progress report: which ``Phase`` is running and how far into it.
+    public struct Progress: Sendable, Equatable {
+        public let phase: Phase
+        /// 0...1 within `phase`.
+        public let fraction: Double
+        public init(phase: Phase, fraction: Double) {
+            self.phase = phase
+            self.fraction = fraction
+        }
+    }
+
+    /// Called with each ``Progress`` update. Invoked from whatever context the
+    /// work is on (model chunks run across a task group), so hop to your own
+    /// actor before touching UI state.
+    public typealias ProgressHandler = @Sendable (Progress) -> Void
 
     // Resolving, downloading, single-flighting, and offline availability are
     // `LoadedModel`; Clear adds only how a resolved directory becomes its
@@ -76,9 +133,11 @@ public final class Clear: @unchecked Sendable {
     /// Nothing is bundled with this package. To ship the model with your app,
     /// point `directory` at a folder you populated with the model files: it is
     /// used as-is, offline, and nothing is downloaded.
-    public convenience init(directory: String? = nil, computeUnits: ComputeUnits = .cpuOnly,
+    public convenience init(directory: String? = nil, variant: ModelVariant = .default,
+                            computeUnits: ComputeUnits = .cpuOnly,
                             concurrency: Int = Clear.defaultConcurrency) {
-        self.init(directory: directory, cacheRoot: nil, computeUnits: computeUnits, concurrency: concurrency)
+        self.init(directory: directory, cacheRoot: nil, variant: variant,
+                  computeUnits: computeUnits, concurrency: concurrency)
     }
 
     /// Binding entry point that also supplies the platform base cache root under
@@ -87,10 +146,13 @@ public final class Clear: @unchecked Sendable {
     /// public `init(directory:...)` passes `nil`.
     @_spi(ClearBindings)
     public init(directory: String?, cacheRoot: String?,
+                variant: ModelVariant = .default,
                 computeUnits: ComputeUnits = .cpuOnly,
                 concurrency: Int = Clear.defaultConcurrency) {
-        model = LoadedModel(ClearModel.self, directory: directory, cacheRoot: cacheRoot) { files in
-            try await .clear(files: files, computeUnits: computeUnits, concurrency: concurrency)
+        // A variant is its own slice of the model repo, so the loader resolves
+        // that distribution rather than the catalog entry's default one.
+        model = LoadedModel(variant.distribution, directory: directory, cacheRoot: cacheRoot) { files in
+            try await .clear(files: files, variant: variant, computeUnits: computeUnits, concurrency: concurrency)
         }
     }
 
@@ -106,10 +168,10 @@ public final class Clear: @unchecked Sendable {
     /// deployments; apps point `directory` at their files instead.
     public init(modelPath: String, computeUnits: ComputeUnits = .cpuOnly,
                 concurrency: Int = Clear.defaultConcurrency) throws {
-        let sessions = try (0..<max(1, concurrency)).map { _ in
-            try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)
-        }
-        model = LoadedModel { ModelAssets(sessions: sessions) }
+        // Built eagerly (this initializer throws), then handed to the loader so
+        // the rest of the class has one path to its assets.
+        let assets = try ModelAssets(modelPath: modelPath, computeUnits: computeUnits, concurrency: concurrency)
+        model = LoadedModel { assets }
     }
 
     /// Whether the model is available for this enhancer with no network:
@@ -129,15 +191,37 @@ public final class Clear: @unchecked Sendable {
     }
 
     /// Enhance mono/stereo `samples` at `sampleRate`, returning 48 kHz mono.
+    ///
+    /// `progress` reports ``Phase/loadingModel`` (only when the model is not
+    /// loaded yet), then ``Phase/enhancing``, then ``Phase/mastering``.
     public func enhance(samples: [Float], sampleRate: Double,
-                        options: Options = .default) async throws -> Result {
+                        options: Options = .default,
+                        progress: ProgressHandler? = nil) async throws -> Result {
+        // Load with progress, so the first call reports the download/compile
+        // instead of appearing to hang. `download` is a no-op once loaded, and
+        // concurrent callers join the same load.
+        if let progress {
+            progress(Progress(phase: .loadingModel, fraction: 0))
+            try await model.download { progress(Progress(phase: .loadingModel, fraction: $0)) }
+        }
         let assets = try await model.value()
         let start = Date()
+        progress?(Progress(phase: .analyzing, fraction: 0))
         let input = sampleRate == ClearDSP.sampleRate
             ? samples
             : Resample.linear(samples, from: sampleRate, to: ClearDSP.sampleRate)
         let enhancer = ClearEnhancer(sessions: assets.sessions)
-        var out = try await enhancer.enhance(input)
+        // The front end (STFT + features) finishes `analyzing`; the chunk loop
+        // that follows is `enhancing`. The flip is announced when the front end
+        // reports done, so the phase change is not deferred to the first chunk
+        // (which on a long file is seconds later).
+        var out = try await enhancer.enhance(
+            input,
+            onAnalysis: { fraction in
+                progress?(Progress(phase: .analyzing, fraction: fraction))
+                if fraction >= 1 { progress?(Progress(phase: .enhancing, fraction: 0)) }
+            },
+            onChunk: { progress?(Progress(phase: .enhancing, fraction: $0)) })
 
         // Strength blend against the (resampled) input.
         let s = Float(options.strength.value)
@@ -146,17 +230,25 @@ public final class Clear: @unchecked Sendable {
             for i in 0..<n { out[i] = s * out[i] + (1 - s) * input[i] }
         }
 
+        // Mastering: integrated-LUFS normalization with the preset's gain cap
+        // and peak ceiling. `loudnessRangeLU` is not applied (no range stage
+        // yet); see `Mastering`.
         var measured: Double? = nil
-        if let target = options.targetLUFS {
+        let mastering = options.mastering
+        if mastering.enabled {
             let (mastered, lufs) = Loudness.normalize(
-                out, sampleRate: ClearDSP.sampleRate, targetLUFS: target,
-                maxGainDB: options.maxGainDB, peakCeilingDBFS: options.peakCeilingDBFS)
+                out, sampleRate: ClearDSP.sampleRate, targetLUFS: mastering.integratedLUFS,
+                maxGainDB: mastering.maxLoudnessGainDB, peakCeilingDBFS: mastering.truePeakDBTP)
             out = mastered
             measured = lufs
         }
+        // Mastering is the tail of `enhancing`, so the phase ends at 1 only
+        // once the audio is actually final.
+        progress?(Progress(phase: .enhancing, fraction: 1))
         return Result(samples: out, sampleRate: ClearDSP.sampleRate,
                       durationSec: Double(out.count) / ClearDSP.sampleRate,
-                      processingSec: Date().timeIntervalSince(start), measuredLUFS: measured)
+                      processingSec: Date().timeIntervalSince(start), measuredLUFS: measured,
+                      modelVariant: assets.variant)
     }
 
     #if canImport(Foundation) && !os(Android) && !os(WASI)
@@ -164,9 +256,11 @@ public final class Clear: @unchecked Sendable {
     /// Filesystem platforms (Apple/Linux); on Android/web use `enhance(bytes:)`.
     @discardableResult
     public func enhance(path: String, to outputPath: String? = nil,
-                        options: Options = .default) async throws -> Result {
+                        options: Options = .default,
+                        progress: ProgressHandler? = nil) async throws -> Result {
         let samples = try await AudioIO.decode(path: path, sampleRate: ClearDSP.sampleRate)
-        let result = try await enhance(samples: samples, sampleRate: ClearDSP.sampleRate, options: options)
+        let result = try await enhance(samples: samples, sampleRate: ClearDSP.sampleRate,
+                                       options: options, progress: progress)
         if let outputPath {
             try AudioIO.writeWAV(result.samples, sampleRate: Int(ClearDSP.sampleRate), to: outputPath)
         }
@@ -176,10 +270,12 @@ public final class Clear: @unchecked Sendable {
 
     /// Enhance in-memory audio-file `bytes`, returning enhanced 48 kHz mono
     /// samples and a ready-to-write WAV byte buffer.
-    public func enhance(bytes: [UInt8], options: Options = .default) async throws
+    public func enhance(bytes: [UInt8], options: Options = .default,
+                        progress: ProgressHandler? = nil) async throws
         -> (result: Result, wav: [UInt8]) {
         let samples = try await AudioIO.decode(bytes: bytes, sampleRate: ClearDSP.sampleRate)
-        let result = try await enhance(samples: samples, sampleRate: ClearDSP.sampleRate, options: options)
+        let result = try await enhance(samples: samples, sampleRate: ClearDSP.sampleRate,
+                                       options: options, progress: progress)
         let wav = AudioIO.encodeWAV(result.samples, sampleRate: Int(ClearDSP.sampleRate))
         return (result, wav)
     }

--- a/Sources/ModelCatalog/Clear/DSP.swift
+++ b/Sources/ModelCatalog/Clear/DSP.swift
@@ -1,0 +1,436 @@
+// DeepFilterNet3 DSP: STFT/ISTFT and the ERB + unit-norm feature front-end,
+// ported from the (Apple-only) clear-swift reference to portable Swift so it
+// runs identically on every platform. Accelerate-backed on Apple, plain loops
+// elsewhere; the constants and normalization state-init ramps must match the
+// training-time libDF exactly or the model gets out-of-distribution input.
+
+import Foundation
+#if canImport(Dispatch)
+import Dispatch
+#endif
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+// Carries non-Sendable state (pointers, the FFT pool) into a concurrentPerform
+// closure. Safe here: each worker touches a disjoint frame range.
+struct Unchecked<T>: @unchecked Sendable { let value: T; init(_ v: T) { value = v } }
+
+enum ClearDSP {
+    static let fftSize = 960
+    static let hopSize = 480
+    static let nFreq = 481          // fftSize/2 + 1
+    static let nErb = 32
+    static let nDf = 96
+    static let convLookahead = 2
+    static let sampleRate = 48_000.0
+    static let normAlpha: Float = 0.99   // round(exp(-hop/sr/tau), 3), tau=1s
+
+    // ERB band widths (bins per band), fixed at training time; sum == nFreq.
+    static let erbWidths: [Int] = [
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        5, 5, 7, 7, 8, 10, 12, 13, 15, 18, 20,
+        24, 28, 31, 37, 42, 50, 56, 67,
+    ]
+}
+
+// Row-major single-precision matmul: Accelerate BLAS on Apple, a plain loop
+// elsewhere. `c[m x n] = a[m x k] @ b[k x n]`.
+enum Gemm {
+    static func mul(_ a: [Float], _ b: [Float], into c: inout [Float], m: Int, n: Int, k: Int) {
+        #if canImport(Accelerate)
+        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                    Int32(m), Int32(n), Int32(k), 1, a, Int32(k), b, Int32(n), 0, &c, Int32(n))
+        #else
+        for i in 0..<m {
+            let ar = i * k, cr = i * n
+            for j in 0..<n { c[cr + j] = 0 }
+            for p in 0..<k {
+                let av = a[ar + p]
+                if av == 0 { continue }
+                let br = p * n
+                for j in 0..<n { c[cr + j] += av * b[br + j] }
+            }
+        }
+        #endif
+    }
+}
+
+#if !canImport(Accelerate)
+// Portable radix-2 complex FFT (Apple uses vDSP instead). Iterative
+// decimation-in-time with precomputed twiddles + bit-reversal.
+final class Radix2FFT {
+    let n: Int
+    private let cosT: [Float], sinT: [Float]   // size n/2
+    private let rev: [Int]
+    init(n: Int) {
+        self.n = n
+        var c = [Float](repeating: 0, count: n / 2), s = [Float](repeating: 0, count: n / 2)
+        for k in 0..<n / 2 { let a = 2 * Float.pi * Float(k) / Float(n); c[k] = cosf(a); s[k] = sinf(a) }
+        cosT = c; sinT = s
+        let bits = Int(log2(Double(n)).rounded())
+        var r = [Int](repeating: 0, count: n)
+        for i in 0..<n { var x = i, y = 0; for _ in 0..<bits { y = (y << 1) | (x & 1); x >>= 1 }; r[i] = y }
+        rev = r
+    }
+    // Pointer-based hot loop: class-member array subscripts carry ARC +
+    // exclusivity overhead that dominates otherwise.
+    func transform(_ re: UnsafeMutablePointer<Float>, _ im: UnsafeMutablePointer<Float>, inverse: Bool) {
+        let nn = n
+        rev.withUnsafeBufferPointer { rp in
+            for i in 0..<nn { let j = rp[i]; if i < j { let a = re[i]; re[i] = re[j]; re[j] = a; let b = im[i]; im[i] = im[j]; im[j] = b } }
+        }
+        cosT.withUnsafeBufferPointer { cp in sinT.withUnsafeBufferPointer { sp in
+            var len = 2
+            while len <= nn {
+                let half = len >> 1, step = nn / len
+                var i = 0
+                while i < nn {
+                    var k = 0
+                    for j in 0..<half {
+                        let c = cp[k], s = inverse ? sp[k] : -sp[k]
+                        let a = i + j, b = a + half
+                        let tr = re[b] * c - im[b] * s, ti = re[b] * s + im[b] * c
+                        re[b] = re[a] - tr; im[b] = im[a] - ti
+                        re[a] += tr;        im[a] += ti
+                        k += step
+                    }
+                    i += len
+                }
+                len <<= 1
+            }
+        } }
+        if inverse { let s = 1 / Float(nn); for i in 0..<nn { re[i] *= s; im[i] *= s } }
+    }
+}
+
+// Mixed-radix 960-point complex FFT via a six-step Cooley-Tukey split
+// N = N1*N2 = 64*15: 15 radix-2 FFTs of 64, twiddles, then 64 direct 15-point
+// DFTs. ~4x less work than Bluestein (which pads 960 -> 2048 and runs two FFTs
+// per transform), which is the portable STFT's dominant cost. Pointer-based
+// hot loop; `outR`/`outI` hold the unscaled forward DFT.
+final class MixedFFT960 {
+    private let n1 = 64, n2 = 15
+    private let fft64: Radix2FFT
+    private let w15c: [Float], w15s: [Float]   // 15x15 DFT basis (sign -)
+    private let twC: [Float], twS: [Float]     // W_960^{n2*k1} (sign -), [15*64]
+    private var ar: [Float], ai: [Float]       // input [960]
+    private var Br: [Float], Bi: [Float]       // step1+2 result [15*64]
+    private var colR: [Float], colI: [Float]   // 64-pt column scratch
+    private(set) var outR: [Float], outI: [Float]
+
+    init() {
+        fft64 = Radix2FFT(n: 64)
+        var c = [Float](repeating: 0, count: 225), s = [Float](repeating: 0, count: 225)
+        for a in 0..<15 { for b in 0..<15 { let t = -2 * Float.pi * Float(a * b) / 15; c[a * 15 + b] = cosf(t); s[a * 15 + b] = sinf(t) } }
+        w15c = c; w15s = s
+        var tc = [Float](repeating: 0, count: 960), ts = [Float](repeating: 0, count: 960)
+        for x in 0..<15 { for y in 0..<64 { let t = -2 * Float.pi * Float(x * y) / 960; tc[x * 64 + y] = cosf(t); ts[x * 64 + y] = sinf(t) } }
+        twC = tc; twS = ts
+        ar = [Float](repeating: 0, count: 960); ai = [Float](repeating: 0, count: 960)
+        Br = [Float](repeating: 0, count: 960); Bi = [Float](repeating: 0, count: 960)
+        colR = [Float](repeating: 0, count: 64); colI = [Float](repeating: 0, count: 64)
+        outR = [Float](repeating: 0, count: 960); outI = [Float](repeating: 0, count: 960)
+    }
+
+    private func run() {
+        ar.withUnsafeBufferPointer { arp in ai.withUnsafeBufferPointer { aip in
+        Br.withUnsafeMutableBufferPointer { brp in Bi.withUnsafeMutableBufferPointer { bip in
+        twC.withUnsafeBufferPointer { tcp in twS.withUnsafeBufferPointer { tsp in
+            colR.withUnsafeMutableBufferPointer { crp in colI.withUnsafeMutableBufferPointer { cip in
+                let cr = crp.baseAddress!, ci = cip.baseAddress!
+                for v in 0..<15 {                      // step 1+2, per n2 column
+                    for u in 0..<64 { cr[u] = arp[15 * u + v]; ci[u] = aip[15 * u + v] }
+                    fft64.transform(cr, ci, inverse: false)
+                    for k1 in 0..<64 {
+                        let tw = v * 64 + k1, re = cr[k1], im = ci[k1], c = tcp[tw], s = tsp[tw]
+                        brp[v * 64 + k1] = re * c - im * s
+                        bip[v * 64 + k1] = re * s + im * c
+                    }
+                }
+            } }
+            w15c.withUnsafeBufferPointer { wc in w15s.withUnsafeBufferPointer { ws in
+            outR.withUnsafeMutableBufferPointer { orp in outI.withUnsafeMutableBufferPointer { oip in
+                for k1 in 0..<64 {                      // step 3, per k1: 15-pt DFT over n2
+                    for k2 in 0..<15 {
+                        var sr: Float = 0, si: Float = 0
+                        for v in 0..<15 {
+                            let br = brp[v * 64 + k1], bi = bip[v * 64 + k1]
+                            let c = wc[v * 15 + k2], s = ws[v * 15 + k2]
+                            sr += br * c - bi * s; si += br * s + bi * c
+                        }
+                        orp[64 * k2 + k1] = sr; oip[64 * k2 + k1] = si
+                    }
+                }
+            } } } }
+        } } } } } }
+    }
+
+    func forwardReal(_ x: [Float], offset: Int, window: [Float]) {
+        ar.withUnsafeMutableBufferPointer { arp in ai.withUnsafeMutableBufferPointer { aip in
+            x.withUnsafeBufferPointer { xp in window.withUnsafeBufferPointer { wp in
+                for i in 0..<960 { arp[i] = xp[offset + i] * wp[i]; aip[i] = 0 }
+            } }
+        } }
+        run()
+    }
+    func forwardComplex(_ xr: [Float], _ xi: [Float]) {
+        ar.withUnsafeMutableBufferPointer { arp in ai.withUnsafeMutableBufferPointer { aip in
+            xr.withUnsafeBufferPointer { xrp in xi.withUnsafeBufferPointer { xip in
+                for i in 0..<960 { arp[i] = xrp[i]; aip[i] = xip[i] }
+            } }
+        } }
+        run()
+    }
+}
+
+// Bluestein's algorithm: an arbitrary-N DFT via a power-of-two FFT (kept as a
+// general fallback for non-960 sizes). `outR`/`outI` hold the unscaled DFT.
+final class BluesteinDFT {
+    let nn: Int, mm: Int
+    private let fft: Radix2FFT
+    private let wRe: [Float], wIm: [Float], fbRe: [Float], fbIm: [Float]
+    private var ar: [Float], ai: [Float]
+    private(set) var outR: [Float], outI: [Float]
+
+    init(_ N: Int) {
+        nn = N
+        var m = 1; while m < 2 * N - 1 { m <<= 1 }
+        mm = m
+        fft = Radix2FFT(n: m)
+        var wr = [Float](repeating: 0, count: N), wi = [Float](repeating: 0, count: N)
+        for k in 0..<N {
+            let ang = Float.pi * Float((k * k) % (2 * N)) / Float(N)   // exp(-i pi k^2/N)
+            wr[k] = cosf(ang); wi[k] = -sinf(ang)
+        }
+        wRe = wr; wIm = wi
+        var br = [Float](repeating: 0, count: m), bi = [Float](repeating: 0, count: m)
+        br[0] = wr[0]; bi[0] = -wi[0]                 // conj(w[0])
+        for k in 1..<N { let r = wr[k], im = -wi[k]; br[k] = r; bi[k] = im; br[m - k] = r; bi[m - k] = im }
+        fft.transform(&br, &bi, inverse: false)
+        fbRe = br; fbIm = bi
+        ar = [Float](repeating: 0, count: m); ai = [Float](repeating: 0, count: m)
+        outR = [Float](repeating: 0, count: N); outI = [Float](repeating: 0, count: N)
+    }
+
+    // Runs the convolution over already-loaded `ar`/`ai` and writes `outR`/`outI`.
+    private func run(_ arp: UnsafeMutablePointer<Float>, _ aip: UnsafeMutablePointer<Float>) {
+        fft.transform(arp, aip, inverse: false)
+        fbRe.withUnsafeBufferPointer { fr in fbIm.withUnsafeBufferPointer { fi in
+            for i in 0..<mm { let r = arp[i] * fr[i] - aip[i] * fi[i]; let m = arp[i] * fi[i] + aip[i] * fr[i]; arp[i] = r; aip[i] = m }
+        } }
+        fft.transform(arp, aip, inverse: true)
+        wRe.withUnsafeBufferPointer { wr in wIm.withUnsafeBufferPointer { wi in
+            outR.withUnsafeMutableBufferPointer { orp in outI.withUnsafeMutableBufferPointer { oip in
+                for k in 0..<nn { orp[k] = arp[k] * wr[k] - aip[k] * wi[k]; oip[k] = arp[k] * wi[k] + aip[k] * wr[k] }
+            } }
+        } }
+    }
+    /// Forward DFT of a real frame `x[offset..<offset+nn]` * `window` into `outR`/`outI`.
+    func forwardReal(_ x: [Float], offset: Int, window: [Float]) {
+        ar.withUnsafeMutableBufferPointer { arb in ai.withUnsafeMutableBufferPointer { aib in
+            let arp = arb.baseAddress!, aip = aib.baseAddress!
+            x.withUnsafeBufferPointer { xp in window.withUnsafeBufferPointer { wp in
+                wRe.withUnsafeBufferPointer { wr in wIm.withUnsafeBufferPointer { wi in
+                    for n in 0..<nn { let v = xp[offset + n] * wp[n]; arp[n] = v * wr[n]; aip[n] = v * wi[n] }
+                } }
+            } }
+            for n in nn..<mm { arp[n] = 0; aip[n] = 0 }
+            run(arp, aip)
+        } }
+    }
+    /// Forward DFT of complex input (length nn) into `outR`/`outI`.
+    func forwardComplex(_ xr: [Float], _ xi: [Float]) {
+        ar.withUnsafeMutableBufferPointer { arb in ai.withUnsafeMutableBufferPointer { aib in
+            let arp = arb.baseAddress!, aip = aib.baseAddress!
+            xr.withUnsafeBufferPointer { xrp in xi.withUnsafeBufferPointer { xip in
+                wRe.withUnsafeBufferPointer { wr in wIm.withUnsafeBufferPointer { wi in
+                    for n in 0..<nn { arp[n] = xrp[n] * wr[n] - xip[n] * wi[n]; aip[n] = xrp[n] * wi[n] + xip[n] * wr[n] }
+                } }
+            } }
+            for n in nn..<mm { arp[n] = 0; aip[n] = 0 }
+            run(arp, aip)
+        } }
+    }
+}
+#endif
+
+/// STFT/ISTFT matching DFN's reference (`libDF/src/lib.rs`): Vorbis window,
+/// n_fft 960, hop 480, forward gain `wnorm = 2*hop/n_fft^2 = 1/960`. Framing
+/// prepends `n_fft - hop = 480` zeros and drops the same from synthesis to undo
+/// the analysis-synthesis delay. Real-DFT as a matmul so it needs no power-of-two.
+final class ClearSTFT {
+    let fftSize: Int
+    let hopSize: Int
+    let nFreq: Int
+    private let window: [Float]
+    private let wnorm: Float
+    #if canImport(Accelerate)
+    private let fwd: vDSP_DFT_Setup
+    private let inv: vDSP_DFT_Setup
+    #else
+    private var pool: [MixedFFT960] = []      // one FFT per worker thread (lazy)
+    #endif
+
+    init(fftSize: Int = ClearDSP.fftSize, hopSize: Int = ClearDSP.hopSize) {
+        self.fftSize = fftSize
+        self.hopSize = hopSize
+        let f = fftSize / 2 + 1
+        self.nFreq = f
+
+        // Vorbis window: sin(pi/2 * sin^2(pi/2 * (n+0.5)/halfN)).
+        var w = [Float](repeating: 0, count: fftSize)
+        let halfN = Double(fftSize / 2)
+        for n in 0..<fftSize {
+            let s = sin(0.5 * .pi * (Double(n) + 0.5) / halfN)
+            w[n] = Float(sin(0.5 * .pi * s * s))
+        }
+        self.window = w
+        self.wnorm = Float(2 * hopSize) / Float(fftSize * fftSize)
+
+        #if canImport(Accelerate)
+        fwd = vDSP_DFT_zop_CreateSetup(nil, vDSP_Length(fftSize), .FORWARD)!
+        inv = vDSP_DFT_zop_CreateSetup(nil, vDSP_Length(fftSize), .INVERSE)!
+        #else
+        _ = f
+        precondition(fftSize == 960, "portable path is specialized for n_fft 960")
+        #endif
+    }
+
+    #if canImport(Accelerate)
+    deinit { vDSP_DFT_DestroySetup(fwd); vDSP_DFT_DestroySetup(inv) }
+    #else
+    // Cap parallel workers; wasm (single-threaded) runs concurrentPerform serially.
+    static var maxWorkers: Int { max(1, min(ProcessInfo.processInfo.activeProcessorCount, 16)) }
+    private func ensurePool(_ n: Int) { while pool.count < n { pool.append(MixedFFT960()) } }
+    /// Split `count` items across `workers` and run `body(worker, lo, hi)` in
+    /// parallel (serial when workers <= 1, e.g. on wasm).
+    static func forEachRange(count: Int, workers: Int, _ body: @Sendable (Int, Int, Int) -> Void) {
+        #if canImport(Dispatch)
+        guard workers > 1 else { if count > 0 { body(0, 0, count) }; return }
+        let per = (count + workers - 1) / workers
+        DispatchQueue.concurrentPerform(iterations: workers) { w in
+            let lo = w * per, hi = min(count, lo + per)
+            if lo < hi { body(w, lo, hi) }
+        }
+        #else
+        if count > 0 { body(0, 0, count) }   // wasm: no Dispatch, run serially
+        #endif
+    }
+    #endif
+
+    /// Windowed frames -> (real, imag) spectrogram, frame-major [nFrames x nFreq].
+    func forward(_ audio: [Float]) -> (real: [Float], imag: [Float], nFrames: Int) {
+        let prePad = fftSize - hopSize
+        var padded = [Float](repeating: 0, count: prePad + audio.count)
+        for i in 0..<audio.count { padded[prePad + i] = audio[i] }
+        guard padded.count >= fftSize else { return ([], [], 0) }
+        let nFrames = (padded.count - fftSize) / hopSize + 1
+        var re = [Float](repeating: 0, count: nFrames * nFreq)
+        var im = [Float](repeating: 0, count: nFrames * nFreq)
+
+        #if canImport(Accelerate)
+        let n = fftSize, f = nFreq
+        let iIn = [Float](repeating: 0, count: n)
+        var rIn = [Float](repeating: 0, count: n)
+        var rOut = [Float](repeating: 0, count: n), iOut = [Float](repeating: 0, count: n)
+        var scale = wnorm
+        for t in 0..<nFrames {
+            let off = t * hopSize
+            padded.withUnsafeBufferPointer { p in vDSP_vmul(p.baseAddress! + off, 1, window, 1, &rIn, 1, vDSP_Length(n)) }
+            vDSP_DFT_Execute(fwd, rIn, iIn, &rOut, &iOut)
+            re.withUnsafeMutableBufferPointer { vDSP_vsmul(rOut, 1, &scale, $0.baseAddress! + t * f, 1, vDSP_Length(f)) }
+            im.withUnsafeMutableBufferPointer { vDSP_vsmul(iOut, 1, &scale, $0.baseAddress! + t * f, 1, vDSP_Length(f)) }
+        }
+        #else
+        // Frames are independent; run the per-frame FFTs across all cores, each
+        // worker with its own FFT scratch. Disjoint writes into re/im.
+        let workers = min(nFrames, Self.maxWorkers)
+        ensurePool(workers)
+        let scale = wnorm, hop = hopSize, f2 = nFreq
+        re.withUnsafeMutableBufferPointer { rp in im.withUnsafeMutableBufferPointer { ip in
+            let box = Unchecked((rp.baseAddress!, ip.baseAddress!, self.pool, padded, window))
+            Self.forEachRange(count: nFrames, workers: workers) { w, lo, hi in
+                let (rpb, ipb, pool, padded, win) = box.value
+                let dft = pool[w]
+                for t in lo..<hi {
+                    dft.forwardReal(padded, offset: t * hop, window: win)
+                    let base = t * f2
+                    dft.outR.withUnsafeBufferPointer { orp in dft.outI.withUnsafeBufferPointer { oip in
+                        for k in 0..<f2 { rpb[base + k] = scale * orp[k]; ipb[base + k] = scale * oip[k] }
+                    } }
+                }
+            }
+        } }
+        #endif
+        return (re, im, nFrames)
+    }
+
+    /// (real, imag) spectrogram -> time signal (windowed COLA overlap-add),
+    /// dropping the analysis-synthesis prepad.
+    func inverse(real: [Float], imag: [Float], nFrames: Int) -> [Float] {
+        let prePad = fftSize - hopSize
+        guard nFrames > 0 else { return [] }
+        let rawLen = (nFrames - 1) * hopSize + fftSize
+        var out = [Float](repeating: 0, count: rawLen)
+
+        #if canImport(Accelerate)
+        let n = fftSize, f = nFreq, mirror = fftSize - nFreq
+        var rSpec = [Float](repeating: 0, count: n), iSpec = [Float](repeating: 0, count: n)
+        var rTime = [Float](repeating: 0, count: n), iTime = [Float](repeating: 0, count: n)
+        for t in 0..<nFrames {
+            let base = t * f
+            real.withUnsafeBufferPointer { memcpy(&rSpec, $0.baseAddress! + base, f * 4) }
+            imag.withUnsafeBufferPointer { memcpy(&iSpec, $0.baseAddress! + base, f * 4) }
+            if mirror > 0 {
+                real.withUnsafeBufferPointer { rp in
+                    rSpec.withUnsafeMutableBufferPointer { dp in
+                        memcpy(dp.baseAddress! + f, rp.baseAddress! + base + 1, mirror * 4)
+                        vDSP_vrvrs(dp.baseAddress! + f, 1, vDSP_Length(mirror))
+                    }
+                }
+                imag.withUnsafeBufferPointer { ip in
+                    iSpec.withUnsafeMutableBufferPointer { dp in
+                        memcpy(dp.baseAddress! + f, ip.baseAddress! + base + 1, mirror * 4)
+                        vDSP_vrvrs(dp.baseAddress! + f, 1, vDSP_Length(mirror))
+                        vDSP_vneg(dp.baseAddress! + f, 1, dp.baseAddress! + f, 1, vDSP_Length(mirror))
+                    }
+                }
+            }
+            vDSP_DFT_Execute(inv, rSpec, iSpec, &rTime, &iTime)
+            let off = t * hopSize
+            out.withUnsafeMutableBufferPointer { op in
+                vDSP_vma(rTime, 1, window, 1, op.baseAddress! + off, 1, op.baseAddress! + off, 1, vDSP_Length(n))
+            }
+        }
+        #else
+        // Per-frame windowed time (idft = conj(dft(conj(X)))) computed in
+        // parallel into a per-frame buffer; the overlap-add sum is then serial
+        // (adjacent frames overlap by fftSize-hop, so it can't parallelize).
+        let workers = min(nFrames, Self.maxWorkers)
+        ensurePool(workers)
+        let fft = fftSize, f2 = nFreq
+        var recon = [Float](repeating: 0, count: nFrames * fftSize)
+        recon.withUnsafeMutableBufferPointer { rc in
+            let box = Unchecked((rc.baseAddress!, self.pool, real, imag, window))
+            Self.forEachRange(count: nFrames, workers: workers) { w, lo, hi in
+                let (rcb, pool, real, imag, win) = box.value
+                let dft = pool[w]
+                var Xr = [Float](repeating: 0, count: fft), Xi = [Float](repeating: 0, count: fft)
+                for t in lo..<hi {
+                    let base = t * f2
+                    for k in 0..<f2 { Xr[k] = real[base + k]; Xi[k] = -imag[base + k] }
+                    for k in 1..<(f2 - 1) { Xr[fft - k] = real[base + k]; Xi[fft - k] = imag[base + k] }
+                    dft.forwardComplex(Xr, Xi)
+                    dft.outR.withUnsafeBufferPointer { orp in win.withUnsafeBufferPointer { wp in
+                        for n in 0..<fft { rcb[t * fft + n] = orp[n] * wp[n] }
+                    } }
+                }
+            }
+            let rcb = rc.baseAddress!
+            for t in 0..<nFrames { let off = t * hopSize; for n in 0..<fft { out[off + n] += rcb[t * fft + n] } }
+        }
+        #endif
+        return rawLen > prePad ? Array(out[prePad..<rawLen]) : out
+    }
+}

--- a/Sources/ModelCatalog/Clear/Enhancer.swift
+++ b/Sources/ModelCatalog/Clear/Enhancer.swift
@@ -1,0 +1,176 @@
+// Enhancement over an arbitrary-length mono signal: STFT -> DFN features ->
+// fixed-window model (via desert-ant-core's InferenceSession, so the same code
+// runs Core ML on Apple, LiteRT on Android/Linux, and the JS host on the web)
+// -> scatter enhanced spectrum -> ISTFT. Ported from clear-swift's Inference
+// chunk loop; tensors are float32 (the LiteRT/ONNX I/O type; Core ML casts fp16).
+//
+// The model is a fixed 200-frame window and each chunk is independent, so on
+// native platforms the chunk loop runs across a pool of sessions (one per
+// worker) to use multiple cores; the native LiteRT runtime is otherwise
+// single-threaded. Apple (fast, single session) and wasm (its LiteRT.js host is
+// already multi-threaded) use one session.
+
+import Foundation
+import DesertAnt
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+struct ClearEnhancer {
+    let sessions: [any InferenceSession]
+    let chunkLen: Int
+    private let stft = ClearSTFT()
+
+    init(sessions: [any InferenceSession], chunkLen: Int = 200) {
+        self.sessions = sessions.isEmpty ? [] : sessions
+        self.chunkLen = chunkLen
+    }
+
+    func enhance(_ samples: [Float]) async throws -> [Float] {
+        guard !samples.isEmpty, !sessions.isEmpty else { return samples }
+        let clean = sanitize(samples)
+        let padded = padToWindowMultiple(clean)
+        let (real, imag, nFrames) = stft.forward(padded)
+        guard nFrames > 0 else { return clean }
+
+        let (featErb, featSpecReal, featSpecImag) =
+            ClearFeatures.compute(real: real, imag: imag, nFrames: nFrames)
+
+        let count = real.count
+        let outRe = UnsafeMutablePointer<Float>.allocate(capacity: count)
+        let outIm = UnsafeMutablePointer<Float>.allocate(capacity: count)
+        outRe.initialize(repeating: 0, count: count); outIm.initialize(repeating: 0, count: count)
+        defer { outRe.deinitialize(count: count); outRe.deallocate(); outIm.deinitialize(count: count); outIm.deallocate() }
+
+        let nChunks = (nFrames + chunkLen - 1) / chunkLen
+        let workers = max(1, min(sessions.count, nChunks))
+        let chunkLen = self.chunkLen
+        // Each worker owns one session and a strided set of chunks; output
+        // ranges are disjoint per chunk, so the shared buffers need no locking.
+        let box = Unchecked((outRe, outIm, sessions, featErb, featSpecReal, featSpecImag, real, imag))
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for w in 0..<workers {
+                group.addTask {
+                    let (outRe, outIm, sessions, fe, fsr, fsi, sr, si) = box.value
+                    let session = sessions[w]
+                    var c = w
+                    while c < nChunks {
+                        let start = c * chunkLen, end = min(start + chunkLen, nFrames)
+                        try await Self.runChunk(session: session, start: start, end: end, nFrames: nFrames, chunkLen: chunkLen,
+                                                featErb: fe, featSpecReal: fsr, featSpecImag: fsi,
+                                                specReal: sr, specImag: si, outRe: outRe, outIm: outIm)
+                        c += workers
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let outReal = Array(UnsafeBufferPointer(start: outRe, count: count))
+        let outImag = Array(UnsafeBufferPointer(start: outIm, count: count))
+        let enhanced = stft.inverse(real: outReal, imag: outImag, nFrames: nFrames)
+        return Array(enhanced.prefix(samples.count))
+    }
+
+    private static func runChunk(session: any InferenceSession, start: Int, end: Int, nFrames: Int, chunkLen: Int,
+                                 featErb: [Float], featSpecReal: [Float], featSpecImag: [Float],
+                                 specReal: [Float], specImag: [Float],
+                                 outRe: UnsafeMutablePointer<Float>, outIm: UnsafeMutablePointer<Float>) async throws {
+        let T = chunkLen
+        let nFreq = ClearDSP.nFreq, nErb = ClearDSP.nErb, nDf = ClearDSP.nDf
+        let look = ClearDSP.convLookahead
+
+        var specBuf = [Float](repeating: 0, count: T * nFreq * 2)
+        var erbBuf = [Float](repeating: 0, count: T * nErb)
+        var featSpecBuf = [Float](repeating: 0, count: T * nDf * 2)
+
+        let tStart = max(0, -start - look)
+        let tEnd = min(T, nFrames - start - look)
+        let sEnd = min(T, nFrames - start)
+        #if canImport(Accelerate)
+        if tEnd > tStart {
+            let n = tEnd - tStart, src = start + tStart + look
+            featErb.withUnsafeBufferPointer { sp in erbBuf.withUnsafeMutableBufferPointer { dp in
+                memcpy(dp.baseAddress! + tStart * nErb, sp.baseAddress! + src * nErb, n * nErb * 4) } }
+            interleave(featSpecReal, featSpecImag, srcOffset: src * nDf, into: &featSpecBuf, dstOffset: tStart * nDf, count: n * nDf)
+        }
+        if sEnd > 0 {
+            interleave(specReal, specImag, srcOffset: start * nFreq, into: &specBuf, dstOffset: 0, count: sEnd * nFreq)
+        }
+        #else
+        if tEnd > tStart {
+            for t in tStart..<tEnd {
+                let src = start + t + look
+                for f in 0..<nErb { erbBuf[t * nErb + f] = featErb[src * nErb + f] }
+                for f in 0..<nDf {
+                    featSpecBuf[(t * nDf + f) * 2] = featSpecReal[src * nDf + f]
+                    featSpecBuf[(t * nDf + f) * 2 + 1] = featSpecImag[src * nDf + f]
+                }
+            }
+        }
+        for t in 0..<sEnd {
+            let src = start + t
+            for k in 0..<nFreq {
+                specBuf[(t * nFreq + k) * 2] = specReal[src * nFreq + k]
+                specBuf[(t * nFreq + k) * 2 + 1] = specImag[src * nFreq + k]
+            }
+        }
+        #endif
+
+        let outputs = try await session.run(
+            inputs: [
+                "spec": Tensor(float32: specBuf, shape: [1, 1, T, nFreq, 2]),
+                "feat_erb": Tensor(float32: erbBuf, shape: [1, 1, T, nErb]),
+                "feat_spec": Tensor(float32: featSpecBuf, shape: [1, 1, T, nDf, 2]),
+            ],
+            outputs: ["spec_enhanced"])
+        guard let enh = outputs.first?.float32Values, enh.count >= T * nFreq * 2 else {
+            throw ClearError.inferenceFailed("spec_enhanced missing or wrong size")
+        }
+
+        let validFrames = end - start
+        #if canImport(Accelerate)
+        let bins = validFrames * nFreq
+        enh.withUnsafeBufferPointer { ep in
+            var z = DSPSplitComplex(realp: outRe + start * nFreq, imagp: outIm + start * nFreq)
+            ep.baseAddress!.withMemoryRebound(to: DSPComplex.self, capacity: bins) {
+                vDSP_ctoz($0, 2, &z, 1, vDSP_Length(bins)) }
+        }
+        #else
+        for t in 0..<validFrames {
+            let dst = start + t
+            for k in 0..<nFreq {
+                outRe[dst * nFreq + k] = enh[(t * nFreq + k) * 2]
+                outIm[dst * nFreq + k] = enh[(t * nFreq + k) * 2 + 1]
+            }
+        }
+        #endif
+    }
+
+    #if canImport(Accelerate)
+    private static func interleave(_ re: [Float], _ im: [Float], srcOffset: Int, into dst: inout [Float], dstOffset: Int, count: Int) {
+        re.withUnsafeBufferPointer { rp in im.withUnsafeBufferPointer { ip in
+            var z = DSPSplitComplex(realp: .init(mutating: rp.baseAddress! + srcOffset),
+                                    imagp: .init(mutating: ip.baseAddress! + srcOffset))
+            dst.withUnsafeMutableBufferPointer { dp in
+                dp.baseAddress!.advanced(by: dstOffset * 2).withMemoryRebound(to: DSPComplex.self, capacity: count) {
+                    vDSP_ztoc(&z, 1, $0, 2, vDSP_Length(count))
+                }
+            }
+        } }
+    }
+    #endif
+
+    private func sanitize(_ samples: [Float]) -> [Float] {
+        var out = samples
+        for i in 0..<out.count where !out[i].isFinite { out[i] = 0 }
+        return out
+    }
+
+    private func padToWindowMultiple(_ samples: [Float]) -> [Float] {
+        let hop = ClearDSP.hopSize, fft = ClearDSP.fftSize
+        let needed = max(fft, ((samples.count + hop - 1) / hop) * hop + fft)
+        if samples.count >= needed { return samples }
+        return samples + [Float](repeating: 0, count: needed - samples.count)
+    }
+}

--- a/Sources/ModelCatalog/Clear/Enhancer.swift
+++ b/Sources/ModelCatalog/Clear/Enhancer.swift
@@ -2,7 +2,7 @@
 // fixed-window model (via desert-ant-core's InferenceSession, so the same code
 // runs Core ML on Apple, LiteRT on Android/Linux, and the JS host on the web)
 // -> scatter enhanced spectrum -> ISTFT. Ported from clear-swift's Inference
-// chunk loop; tensors are float32 (the LiteRT/ONNX I/O type; Core ML casts fp16).
+// chunk loop; tensors are float32 (LiteRT's I/O type; Core ML casts fp16).
 //
 // The model is a fixed 200-frame window and each chunk is independent, so on
 // native platforms the chunk loop runs across a pool of sessions (one per
@@ -16,6 +16,29 @@ import DesertAnt
 import Accelerate
 #endif
 
+/// Counts finished chunks across the worker pool and reports the fraction.
+/// A lock rather than an actor so a worker never suspends to report.
+private final class ChunkCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let total: Int
+    private let report: (@Sendable (Double) -> Void)?
+    private var done = 0
+
+    init(total: Int, report: (@Sendable (Double) -> Void)?) {
+        self.total = max(1, total)
+        self.report = report
+    }
+
+    func finishOne() {
+        guard let report else { return }
+        lock.lock()
+        done += 1
+        let fraction = min(1, Double(done) / Double(total))
+        lock.unlock()
+        report(fraction)
+    }
+}
+
 struct ClearEnhancer {
     let sessions: [any InferenceSession]
     let chunkLen: Int
@@ -26,15 +49,25 @@ struct ClearEnhancer {
         self.chunkLen = chunkLen
     }
 
-    func enhance(_ samples: [Float]) async throws -> [Float] {
+    /// - Parameters:
+    ///   - onAnalysis: the front end (STFT then the ERB/DF feature pass),
+    ///     reported as it completes each step.
+    ///   - onChunk: the fraction of model chunks completed. Chunks finish out
+    ///     of order across the session pool, so this counts completions rather
+    ///     than positions - monotonic, but not a position in the file.
+    func enhance(_ samples: [Float],
+                 onAnalysis: (@Sendable (Double) -> Void)? = nil,
+                 onChunk: (@Sendable (Double) -> Void)? = nil) async throws -> [Float] {
         guard !samples.isEmpty, !sessions.isEmpty else { return samples }
         let clean = sanitize(samples)
         let padded = padToWindowMultiple(clean)
         let (real, imag, nFrames) = stft.forward(padded)
         guard nFrames > 0 else { return clean }
+        onAnalysis?(0.5)
 
         let (featErb, featSpecReal, featSpecImag) =
             ClearFeatures.compute(real: real, imag: imag, nFrames: nFrames)
+        onAnalysis?(1)
 
         let count = real.count
         let outRe = UnsafeMutablePointer<Float>.allocate(capacity: count)
@@ -48,6 +81,7 @@ struct ClearEnhancer {
         // Each worker owns one session and a strided set of chunks; output
         // ranges are disjoint per chunk, so the shared buffers need no locking.
         let box = Unchecked((outRe, outIm, sessions, featErb, featSpecReal, featSpecImag, real, imag))
+        let completed = ChunkCounter(total: nChunks, report: onChunk)
         try await withThrowingTaskGroup(of: Void.self) { group in
             for w in 0..<workers {
                 group.addTask {
@@ -59,6 +93,7 @@ struct ClearEnhancer {
                         try await Self.runChunk(session: session, start: start, end: end, nFrames: nFrames, chunkLen: chunkLen,
                                                 featErb: fe, featSpecReal: fsr, featSpecImag: fsi,
                                                 specReal: sr, specImag: si, outRe: outRe, outIm: outIm)
+                        completed.finishOne()
                         c += workers
                     }
                 }
@@ -91,7 +126,7 @@ struct ClearEnhancer {
         if tEnd > tStart {
             let n = tEnd - tStart, src = start + tStart + look
             featErb.withUnsafeBufferPointer { sp in erbBuf.withUnsafeMutableBufferPointer { dp in
-                memcpy(dp.baseAddress! + tStart * nErb, sp.baseAddress! + src * nErb, n * nErb * 4) } }
+                _ = memcpy(dp.baseAddress! + tStart * nErb, sp.baseAddress! + src * nErb, n * nErb * 4) } }
             interleave(featSpecReal, featSpecImag, srcOffset: src * nDf, into: &featSpecBuf, dstOffset: tStart * nDf, count: n * nDf)
         }
         if sEnd > 0 {

--- a/Sources/ModelCatalog/Clear/Features.swift
+++ b/Sources/ModelCatalog/Clear/Features.swift
@@ -1,0 +1,118 @@
+// DFN3 feature front-end: ERB-band log-power with running mean normalization,
+// and unit-norm complex DF features over the first nDf bins. Ported from
+// clear-swift's Features.swift (vDSP -> plain loops). The state-init ramps
+// (erbState -60..-90 dB, unit-norm s 1e-3..1e-4) are load-bearing for model
+// parity and must NOT be zero-initialized.
+
+import Foundation
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+enum ClearFeatures {
+    /// Returns feat_erb [nFrames x nErb], and DF feat spec real/imag
+    /// [nFrames x nDf] each, from a complex spectrogram [nFrames x nFreq].
+    static func compute(real: [Float], imag: [Float], nFrames: Int)
+        -> (featErb: [Float], featSpecReal: [Float], featSpecImag: [Float])
+    {
+        let nFreq = ClearDSP.nFreq, nErb = ClearDSP.nErb, nDf = ClearDSP.nDf
+        let alpha = ClearDSP.normAlpha
+        let oneMinus = 1 - alpha
+        let widths = ClearDSP.erbWidths
+
+        // Power |z|^2 (whole spectrogram), then mean per-bin power per ERB band.
+        var erbPower = [Float](repeating: 0, count: nFrames * nErb)
+        #if canImport(Accelerate)
+        var power = [Float](repeating: 0, count: nFrames * nFreq)
+        real.withUnsafeBufferPointer { rp in imag.withUnsafeBufferPointer { ip in
+            var z = DSPSplitComplex(realp: .init(mutating: rp.baseAddress!), imagp: .init(mutating: ip.baseAddress!))
+            vDSP_zvmags(&z, 1, &power, 1, vDSP_Length(power.count))
+        } }
+        power.withUnsafeBufferPointer { p in erbPower.withUnsafeMutableBufferPointer { o in
+            for t in 0..<nFrames {
+                var off = 0
+                for band in 0..<nErb {
+                    var s: Float = 0
+                    vDSP_sve(p.baseAddress! + t * nFreq + off, 1, &s, vDSP_Length(widths[band]))
+                    o[t * nErb + band] = s / Float(widths[band])
+                    off += widths[band]
+                }
+            }
+        } }
+        #else
+        for t in 0..<nFrames {
+            let rowIn = t * nFreq, rowOut = t * nErb
+            var off = 0
+            for band in 0..<nErb {
+                let w = widths[band]
+                var sum: Float = 0
+                for k in 0..<w {
+                    let r = real[rowIn + off + k], m = imag[rowIn + off + k]
+                    sum += r * r + m * m
+                }
+                erbPower[rowOut + band] = sum / Float(w)
+                off += w
+            }
+        }
+        #endif
+
+        // ERB dB: 10*log10(power + 1e-10).
+        var erbDB = erbPower
+        #if canImport(Accelerate)
+        var eps: Float = 1e-10, ten: Float = 10; var nLog = Int32(erbDB.count)
+        vDSP_vsadd(erbDB, 1, &eps, &erbDB, 1, vDSP_Length(erbDB.count))
+        vvlog10f(&erbDB, erbDB, &nLog)
+        vDSP_vsmul(erbDB, 1, &ten, &erbDB, 1, vDSP_Length(erbDB.count))
+        #else
+        for i in 0..<erbDB.count { erbDB[i] = 10 * log10f(erbDB[i] + 1e-10) }
+        #endif
+
+        // Running-mean normalize per band; state ramps -60 -> -90 dB.
+        var featErb = [Float](repeating: 0, count: nFrames * nErb)
+        var erbState = [Float](repeating: 0, count: nErb)
+        let mnStep: Float = (-90 - -60) / Float(nErb - 1)
+        for f in 0..<nErb { erbState[f] = -60 + Float(f) * mnStep }
+        for t in 0..<nFrames {
+            let off = t * nErb
+            for f in 0..<nErb {
+                erbState[f] = erbDB[off + f] * oneMinus + erbState[f] * alpha
+                featErb[off + f] = (erbDB[off + f] - erbState[f]) / 40
+            }
+        }
+
+        // Unit-norm the first nDf complex bins; state s ramps 1e-3 -> 1e-4.
+        var featSpecReal = [Float](repeating: 0, count: nFrames * nDf)
+        var featSpecImag = [Float](repeating: 0, count: nFrames * nDf)
+        var s = [Float](repeating: 0, count: nDf)
+        let unStep: Float = (0.0001 - 0.001) / Float(nDf - 1)
+        for f in 0..<nDf { s[f] = 0.001 + Float(f) * unStep }
+        #if canImport(Accelerate)
+        var mag = [Float](repeating: 0, count: nDf), inv = [Float](repeating: 0, count: nDf)
+        var nDf32 = Int32(nDf); var om = oneMinus, al = alpha
+        for t in 0..<nFrames {
+            let inOff = t * nFreq, outOff = t * nDf
+            real.withUnsafeBufferPointer { rp in imag.withUnsafeBufferPointer { ip in
+                var z = DSPSplitComplex(realp: .init(mutating: rp.baseAddress! + inOff), imagp: .init(mutating: ip.baseAddress! + inOff))
+                vDSP_zvabs(&z, 1, &mag, 1, vDSP_Length(nDf))
+            } }
+            vDSP_vsmsma(mag, 1, &om, s, 1, &al, &s, 1, vDSP_Length(nDf))  // s = mag*(1-a) + s*a
+            vvrsqrtf(&inv, s, &nDf32)
+            real.withUnsafeBufferPointer { vDSP_vmul($0.baseAddress! + inOff, 1, inv, 1, &featSpecReal[outOff], 1, vDSP_Length(nDf)) }
+            imag.withUnsafeBufferPointer { vDSP_vmul($0.baseAddress! + inOff, 1, inv, 1, &featSpecImag[outOff], 1, vDSP_Length(nDf)) }
+        }
+        #else
+        for t in 0..<nFrames {
+            let inOff = t * nFreq, outOff = t * nDf
+            for f in 0..<nDf {
+                let r = real[inOff + f], m = imag[inOff + f]
+                let mag = (r * r + m * m).squareRoot()
+                s[f] = mag * oneMinus + s[f] * alpha
+                let inv = 1 / s[f].squareRoot()
+                featSpecReal[outOff + f] = r * inv
+                featSpecImag[outOff + f] = m * inv
+            }
+        }
+        #endif
+        return (featErb, featSpecReal, featSpecImag)
+    }
+}

--- a/Sources/ModelCatalog/Clear/Mastering.swift
+++ b/Sources/ModelCatalog/Clear/Mastering.swift
@@ -1,0 +1,137 @@
+// The post-DSP mastering chain and the delivery presets that configure it.
+//
+// Ported from the standalone Clear SDK so callers describe *where the audio is
+// going* ("Apple Podcasts") instead of hand-tuning LUFS numbers. The presets are
+// the published platform specs, so they belong to the model rather than to each
+// app that ships it.
+//
+// What the core's loudness stage implements today is integrated-LUFS
+// normalization with a gain cap and a peak ceiling (`AudioDSP.Loudness`); each
+// field below documents how it maps, including the one that does not yet.
+
+public extension Clear {
+    /// Post-DSP mastering: where the enhanced audio should land, loudness-wise.
+    ///
+    /// Build one from a ``Clear/LoudnessPreset`` (`.applePodcasts`, `.spotify`,
+    /// …), from ``targetLUFS(_:)`` for a non-standard target, or field by field.
+    struct Mastering: Sendable, Equatable {
+        /// Integrated loudness target in LUFS.
+        public var integratedLUFS: Double
+
+        /// True-peak ceiling in dBTP. -1.5 dBTP leaves headroom for lossy codecs.
+        ///
+        /// The current limiter measures *sample* peak, not true peak (no 4x
+        /// oversampling), so this is applied as a dBFS ceiling. It is therefore
+        /// slightly optimistic on inter-sample peaks - which is what the default
+        /// -1.5 dBTP of headroom absorbs.
+        public var truePeakDBTP: Double
+
+        /// Loudness range target in LU (spoken word is <= 7 LU; EBU R128
+        /// broadcast allows 10).
+        ///
+        /// Carried so a preset round-trips its full published spec, but **not
+        /// yet enforced**: the loudness stage normalizes integrated loudness and
+        /// ceils peaks, and has no range compressor. Setting it changes nothing
+        /// today; it will start being honoured when that stage lands, without a
+        /// source change here.
+        public var loudnessRangeLU: Double
+
+        /// Set false to return the unmastered model output, whose level tracks
+        /// the input. Equivalent to ``bypass``.
+        public var enabled: Bool
+
+        /// Upper bound on the loudness gain in dB.
+        ///
+        /// The chain normally lifts the output to `integratedLUFS` however quiet
+        /// the input was. For a -32 LUFS recording that is +13 dB applied to
+        /// everything, and any residual model noise comes up with it. Capping
+        /// means a very quiet input lands *under* target but stays clean:
+        /// output LUFS = `max(integratedLUFS, inputLUFS + maxLoudnessGainDB)`.
+        /// Use `.infinity` to always hit the target.
+        public var maxLoudnessGainDB: Double
+
+        public init(integratedLUFS: Double = -19.0,
+                    truePeakDBTP: Double = -1.5,
+                    loudnessRangeLU: Double = 7.0,
+                    enabled: Bool = true,
+                    maxLoudnessGainDB: Double = 9.0) {
+            self.integratedLUFS = integratedLUFS
+            self.truePeakDBTP = truePeakDBTP
+            self.loudnessRangeLU = loudnessRangeLU
+            self.enabled = enabled
+            self.maxLoudnessGainDB = maxLoudnessGainDB
+        }
+
+        /// A non-standard integrated-loudness target, with the other defaults.
+        public static func targetLUFS(_ lufs: Double) -> Mastering {
+            Mastering(integratedLUFS: lufs)
+        }
+
+        /// Apple Podcasts spec, -19 LUFS. The default.
+        public static let applePodcasts = LoudnessPreset.applePodcasts.mastering
+        /// Alias for ``applePodcasts``, for callers that think in content type.
+        public static let podcast = LoudnessPreset.applePodcasts.mastering
+        /// Spotify's normalization target, -14 LUFS.
+        public static let spotify = LoudnessPreset.spotify.mastering
+        /// YouTube's normalization target, -14 LUFS.
+        public static let youtube = LoudnessPreset.youtube.mastering
+        /// EBU R128 broadcast spec, -23 LUFS with a 10 LU range.
+        public static let broadcast = LoudnessPreset.broadcast.mastering
+        /// Skip mastering: the output level tracks the input.
+        public static let bypass = Mastering(enabled: false)
+    }
+
+    /// Standard delivery loudness targets. `CaseIterable` so a UI can render a
+    /// picker without hardcoding values, and `Identifiable`/`RawRepresentable`
+    /// so a selection persists as its `rawValue`.
+    ///
+    /// Each case yields a fully configured ``Clear/Mastering`` through
+    /// ``mastering``; for anything off-spec use ``Clear/Mastering/targetLUFS(_:)``.
+    enum LoudnessPreset: String, Sendable, CaseIterable, Identifiable {
+        case applePodcasts
+        case spotify
+        case youtube
+        case broadcast
+
+        public var id: String { rawValue }
+
+        /// The integrated-LUFS target this preset normalizes to.
+        public var integratedLUFS: Double {
+            switch self {
+            case .applePodcasts: -19.0
+            case .spotify: -14.0
+            case .youtube: -14.0
+            case .broadcast: -23.0
+            }
+        }
+
+        /// Human-readable label for a menu row.
+        public var displayName: String {
+            switch self {
+            case .applePodcasts: "Apple Podcasts"
+            case .spotify: "Spotify"
+            case .youtube: "YouTube"
+            case .broadcast: "Broadcast (EBU R128)"
+            }
+        }
+
+        /// Compact label for a segmented picker, so all four fit on an iPhone.
+        public var shortName: String {
+            switch self {
+            case .applePodcasts: "Apple"
+            case .spotify: "Spotify"
+            case .youtube: "YouTube"
+            case .broadcast: "EBU"
+            }
+        }
+
+        /// The fully configured mastering chain for this preset. Broadcast
+        /// carries R128's wider 10 LU range; the rest take the defaults.
+        public var mastering: Mastering {
+            switch self {
+            case .broadcast: Mastering(integratedLUFS: integratedLUFS, loudnessRangeLU: 10.0)
+            default: Mastering(integratedLUFS: integratedLUFS)
+            }
+        }
+    }
+}

--- a/Sources/ModelCatalog/Clear/ModelLoading.swift
+++ b/Sources/ModelCatalog/Clear/ModelLoading.swift
@@ -18,24 +18,45 @@ import DesertAnt
 @_spi(ClearBindings)
 public struct ModelAssets: Sendable {
     let sessions: [any InferenceSession]
+    /// Which published variant these sessions run, reported on `Result`. Nil
+    /// when the artifact is not a published variant (a custom export, or a
+    /// wasm host that compiled the model itself).
+    let variant: ModelVariant?
 
-    init(sessions: [any InferenceSession]) { self.sessions = sessions }
+    init(sessions: [any InferenceSession], variant: ModelVariant? = nil) {
+        self.sessions = sessions
+        self.variant = variant
+    }
 
-    /// Bindings entry point: build from already-constructed sessions (e.g. the
-    /// wasm host's `JSInferenceSession`).
+    /// Bindings entry point: build from an already-constructed session (e.g. the
+    /// wasm host's `JSInferenceSession`), whose variant only the host knows.
     @_spi(ClearBindings)
-    public init(session: any InferenceSession) { self.init(sessions: [session]) }
+    public init(session: any InferenceSession, variant: ModelVariant? = nil) {
+        self.init(sessions: [session], variant: variant)
+    }
+
+    /// Sessions over an artifact already on disk. The variant is read off the
+    /// file name, so a pre-downloaded artifact still identifies itself on
+    /// `Result`.
+    init(modelPath: String, computeUnits: ComputeUnits = .cpuOnly, concurrency: Int = 1) throws {
+        self.init(
+            sessions: try (0..<max(1, concurrency)).map { _ in
+                try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)
+            },
+            variant: ModelVariant.inferred(fromPath: modelPath))
+    }
 
     /// Build from a resolved model directory: one session per worker over this
     /// platform's artifact.
-    static func clear(files: StoredModel, computeUnits: ComputeUnits, concurrency: Int) async throws -> ModelAssets {
+    static func clear(files: StoredModel, variant: ModelVariant,
+                      computeUnits: ComputeUnits, concurrency: Int) async throws -> ModelAssets {
         var sessions: [any InferenceSession] = []
         for _ in 0..<max(1, concurrency) {
             sessions.append(try await files.inferenceSession(
-                model: ClearModel.artifact, hostGlobal: ClearModel.hostGlobal,
+                model: variant.artifact, hostGlobal: ClearModel.hostGlobal,
                 computeUnits: computeUnits, sdk: ClearModel.sdkInfo))
         }
-        return ModelAssets(sessions: sessions)
+        return ModelAssets(sessions: sessions, variant: variant)
     }
 }
 

--- a/Sources/ModelCatalog/Clear/ModelLoading.swift
+++ b/Sources/ModelCatalog/Clear/ModelLoading.swift
@@ -1,0 +1,56 @@
+// How Clear obtains and shapes its model: the download/adopt sources and the
+// `ModelAssets` the pipeline consumes. (Running the model is `Enhancer.swift`.)
+// All platform variation is data (which artifact ships where, declared in
+// `Catalog.swift`); building the platform's session is DesertAnt's
+// `inferenceSession` factory - Core ML on Apple, LiteRT on Android/Linux, the JS
+// host on the web.
+import DesertAnt
+
+// The SDK's usage identity (`ClearModel.sdkInfo`) is derived from the catalog
+// declaration's `product` + `sdkVersion`, so it cannot drift from the published
+// package version or be forgotten on a session.
+
+/// Ready inference sessions for the enhancement model. A pool (one per worker)
+/// lets the chunk loop use multiple cores on native platforms; usually one.
+///
+/// Also the entry point for the cross-language bindings and custom deployments
+/// (not part of the Swift SDK's public API, which loads the model for you).
+@_spi(ClearBindings)
+public struct ModelAssets: Sendable {
+    let sessions: [any InferenceSession]
+
+    init(sessions: [any InferenceSession]) { self.sessions = sessions }
+
+    /// Bindings entry point: build from already-constructed sessions (e.g. the
+    /// wasm host's `JSInferenceSession`).
+    @_spi(ClearBindings)
+    public init(session: any InferenceSession) { self.init(sessions: [session]) }
+
+    /// Build from a resolved model directory: one session per worker over this
+    /// platform's artifact.
+    static func clear(files: StoredModel, computeUnits: ComputeUnits, concurrency: Int) async throws -> ModelAssets {
+        var sessions: [any InferenceSession] = []
+        for _ in 0..<max(1, concurrency) {
+            sessions.append(try await files.inferenceSession(
+                model: ClearModel.artifact, hostGlobal: ClearModel.hostGlobal,
+                computeUnits: computeUnits, sdk: ClearModel.sdkInfo))
+        }
+        return ModelAssets(sessions: sessions)
+    }
+}
+
+public extension Clear {
+    /// The published model repository.
+    static var modelRepo: String { ClearModel.repo }
+    /// The model revision this SDK is built against (pinned; not configurable).
+    static var modelRevision: String { ClearModel.revision }
+}
+
+// MARK: shipping the model with your app
+
+// This package bundles no model artifact and has no resource bundle to load one
+// from. The model is downloaded on demand: to a managed cache location by
+// default, or to the `directory` you pass. Shipping the model with your app is
+// therefore just pointing `directory` at a folder that already holds this
+// platform's artifact - it is then used offline, with no download. (Android's
+// equivalent is classpath resources, and wasm always downloads.)

--- a/Sources/ModelCatalog/Clear/Variant.swift
+++ b/Sources/ModelCatalog/Clear/Variant.swift
@@ -1,0 +1,71 @@
+// Which published export of the model to run.
+//
+// The Hub repo ships two trained variants side by side, so this is a real
+// choice, not a label: it selects the files that get downloaded and loaded.
+// `Result.modelVariant` reports the one that produced a given output, which is
+// what makes a benchmark or a usage event self-identifying.
+
+import DesertAnt
+
+/// A published variant of the clear model. Its `rawValue` is the artifact stem
+/// on the Hub (`clear-studio.mlmodelc`, `clear-studio.tflite`, ...), so a
+/// persisted selection and a telemetry field are the same string.
+public enum ModelVariant: String, Sendable, Equatable, CaseIterable, Identifiable {
+    /// Studio: the more aggressive denoise/dereverb. The SDK default.
+    case clearStudio = "clear-studio"
+    /// Natural: lighter touch, keeps more of the room.
+    case clearNatural = "clear-natural"
+
+    public var id: String { rawValue }
+
+    /// The variant a `Clear` uses unless told otherwise.
+    public static let `default` = ModelVariant.clearStudio
+
+    public var displayName: String {
+        switch self {
+        case .clearStudio: "clear-studio"
+        case .clearNatural: "clear-natural"
+        }
+    }
+
+    /// Core ML export (a directory on the Hub): Apple.
+    public var coreML: String { "\(rawValue).mlmodelc" }
+    /// LiteRT export: Android/Linux/Windows, and LiteRT.js on the web.
+    public var tflite: String { "\(rawValue).tflite" }
+
+    /// The runnable artifact for `platform`.
+    public func artifact(for platform: ModelPlatform) -> String {
+        platform == .apple ? coreML : tflite
+    }
+
+    /// The artifact for the platform being built for.
+    public var artifact: String { artifact(for: .current) }
+
+    /// Repo-relative entries each platform needs for this variant. Clear has no
+    /// sidecars (the DSP front end carries what would be a metadata file), so a
+    /// platform ships exactly one artifact.
+    public var files: [ModelPlatform: [String]] {
+        [
+            .apple: [coreML + "/"],
+            .android: [tflite],
+            .linux: [tflite],
+            .windows: [tflite],
+            .web: [tflite],
+        ]
+    }
+
+    /// This variant's slice of the model repo: the same repo and pinned
+    /// revision as the catalog entry, but only this variant's files, so
+    /// choosing one variant never downloads the other.
+    public var distribution: ModelDistribution {
+        ModelDistribution(repo: ClearModel.repo, revision: ClearModel.revision, files: files)
+    }
+
+    /// The variant an artifact path belongs to, by its file name
+    /// (`.../clear-natural.mlmodelc` -> `.clearNatural`), or nil if the name is
+    /// not a published variant - a custom or renamed export.
+    public static func inferred(fromPath path: String) -> ModelVariant? {
+        let name = path.split(separator: "/").last.map(String.init) ?? path
+        return allCases.first { name.hasPrefix($0.rawValue) }
+    }
+}

--- a/Sources/ModelCatalog/Clear/Web/main.swift
+++ b/Sources/ModelCatalog/Clear/Web/main.swift
@@ -1,6 +1,7 @@
 #if os(WASI)
 import DesertAnt
 import WasmBindings
+import Bindings
 @_spi(ClearBindings) import Clear
 
 // Clear's WebAssembly entry point.

--- a/Sources/ModelCatalog/Clear/Web/main.swift
+++ b/Sources/ModelCatalog/Clear/Web/main.swift
@@ -1,0 +1,22 @@
+#if os(WASI)
+import DesertAnt
+import WasmBindings
+@_spi(ClearBindings) import Clear
+
+// Clear's WebAssembly entry point.
+//
+// The exported surface is the shared, model-agnostic ABI in `WasmBindings`
+// (`globalThis.__DesertAntExports.clear`), the wasm twin of the `dal_*` C ABI:
+// options and results cross as the FFI payloads `Clear/Binding.swift` already
+// encodes, so nothing model-specific is repeated here. The one exception is the
+// self-hosted path, where the JS host fetched the files and compiled the model
+// itself - and Clear has no sidecars, so there is nothing to read from them.
+//
+// Audio in and out crosses as the model's own payload, so the host passes
+// samples through the shared `run` entry like any other model's input.
+installWasmExports([
+    WasmModel(ClearModel.self, binding: ClearBinding.self) { _, session in
+        Clear(assets: ModelAssets(session: session))
+    },
+])
+#endif

--- a/Sources/ModelCatalog/Emo/Web/main.swift
+++ b/Sources/ModelCatalog/Emo/Web/main.swift
@@ -1,6 +1,7 @@
 #if os(WASI)
 import DesertAnt
 import WasmBindings
+import Bindings
 @_spi(EmoBindings) import Emo
 
 // Emo's WebAssembly entry point.

--- a/Sources/ModelCatalog/LoadedModel.swift
+++ b/Sources/ModelCatalog/LoadedModel.swift
@@ -52,13 +52,26 @@ public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
     ///     cache dir on Android, `~/.cache` on Node). `nil` on Apple/Linux, where
     ///     the platform provides one.
     ///   - build: turn the resolved files into the runtime.
-    public init<Declaration: ModelDeclaration>(
+    public convenience init<Declaration: ModelDeclaration>(
         _ declaration: Declaration.Type,
         directory: String? = nil,
         cacheRoot: String? = nil,
         build: @escaping @Sendable (StoredModel) async throws -> Runtime
     ) {
-        let distribution = Declaration.distribution
+        self.init(Declaration.distribution, directory: directory, cacheRoot: cacheRoot, build: build)
+    }
+
+    /// Load from an explicit distribution, for a model that publishes more than
+    /// one artifact set under the same catalog entry (clear's studio/natural
+    /// variants): the declaration names the default, and a caller selecting
+    /// another passes that variant's own slice of the repo, so choosing one
+    /// never downloads the other. Otherwise identical to the declaration form.
+    public init(
+        _ distribution: ModelDistribution,
+        directory: String? = nil,
+        cacheRoot: String? = nil,
+        build: @escaping @Sendable (StoredModel) async throws -> Runtime
+    ) {
         loader = LazyLoader { progress in
             let files = try await distribution.resolve(
                 cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction) }

--- a/Sources/ModelCatalog/Redact/Web/main.swift
+++ b/Sources/ModelCatalog/Redact/Web/main.swift
@@ -1,6 +1,7 @@
 #if os(WASI)
 import DesertAnt
 import WasmBindings
+import Bindings
 @_spi(RedactBindings) import Redact
 
 // Redact's WebAssembly entry point.

--- a/Tests/AudioDSPTests/AudioDSPTests.swift
+++ b/Tests/AudioDSPTests/AudioDSPTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+import Foundation
+@testable import AudioDSP
+
+final class AudioDSPTests: XCTestCase {
+    // Signal-to-error ratio in dB between a reference and a reconstruction.
+    private func snr(_ ref: [Float], _ rec: [Float]) -> Double {
+        let n = min(ref.count, rec.count)
+        var sig = 0.0, err = 0.0
+        for i in 0..<n {
+            sig += Double(ref[i]) * Double(ref[i])
+            let e = Double(ref[i]) - Double(rec[i])
+            err += e * e
+        }
+        return err > 0 ? 10 * log10(sig / err) : .infinity
+    }
+
+    private func tone(_ n: Int, freq: Double = 440, sr: Double = 16000) -> [Float] {
+        (0..<n).map { Float(0.5 * sin(2 * .pi * freq * Double($0) / sr)) }
+    }
+
+    func testHannPeriodic() {
+        let w = Window.hann(4, periodic: true)
+        XCTAssertEqual(w[0], 0, accuracy: 1e-6)          // periodic Hann starts at 0
+        XCTAssertEqual(w.max()!, 1, accuracy: 1e-6)      // and reaches 1
+    }
+
+    func testSTFTRoundTripReconstructsSignal() {
+        let x = tone(8000)
+        let stft = STFT(nFFT: 400, hop: 100)
+        let spec = stft.forward(x)
+        let y = stft.inverse(spec, length: x.count)
+        XCTAssertEqual(y.count, x.count)
+        // Windowed COLA + real-DFT identity should reconstruct near-perfectly.
+        XCTAssertGreaterThan(snr(x, y), 60)
+    }
+
+    func testSTFTMagnitudePhaseRebuild() {
+        let x = tone(4000, freq: 220)
+        let stft = STFT(nFFT: 256, hop: 64)
+        let spec = stft.forward(x)
+        let mag = spec.magnitude(), pha = spec.phase()
+        // Rebuild re/im from magnitude+phase and confirm the same reconstruction.
+        var rebuilt = spec
+        for i in 0..<mag.count {
+            rebuilt.re[i] = mag[i] * cos(pha[i])
+            rebuilt.im[i] = mag[i] * sin(pha[i])
+        }
+        let y = stft.inverse(rebuilt, length: x.count)
+        XCTAssertGreaterThan(snr(x, y), 60)
+    }
+
+    func testEnergyNormalizeIsInvertible() {
+        let x = tone(2000).map { $0 * 3 }
+        let (norm, gain) = VectorOps.energyNormalize(x)
+        let restored = VectorOps.scaled(norm, by: 1 / gain)
+        XCTAssertGreaterThan(snr(x, restored), 100)   // float round-trip, not bit-exact
+        // Unit average power after normalization.
+        let power = VectorOps.energy(norm) / Float(norm.count)
+        XCTAssertEqual(power, 1, accuracy: 1e-3)
+    }
+
+    func testStandardizeZeroMeanUnitStd() {
+        let x: [Float] = (0..<1000).map { Float($0) }
+        let z = VectorOps.standardize(x)
+        let mean = z.reduce(0, +) / Float(z.count)
+        XCTAssertEqual(mean, 0, accuracy: 1e-3)
+    }
+
+    func testMelSpectrogramShape() {
+        let mel = MelSpectrogram(sampleRate: 16000, nFFT: 400, hop: 160, mels: 80)
+        let (values, frames, mels) = mel.logMel(tone(16000))
+        XCTAssertEqual(mels, 80)
+        XCTAssertGreaterThan(frames, 90)              // ~1 s at hop 160
+        XCTAssertEqual(values.count, frames * mels)
+        XCTAssertTrue(values.allSatisfy { $0.isFinite })
+    }
+
+    func testFramingWindows() {
+        let w = Framing.windows(count: 250, window: 100, hop: 80)
+        XCTAssertEqual(w.first!.start, 0)
+        XCTAssertEqual(w.last!.end, 250)              // final window clamps to count
+        XCTAssertTrue(w.allSatisfy { $0.end <= 250 })
+    }
+
+    func testLoudnessNormalizeHitsTarget() {
+        // 1 kHz tone at 48 kHz, ~3 s; normalize to -19 LUFS.
+        let sr = 48_000.0
+        let x = (0..<Int(3 * sr)).map { Float(0.1 * sin(2 * .pi * 1000 * Double($0) / sr)) }
+        let before = Loudness.integratedLUFS(x, sampleRate: sr)
+        XCTAssertNotNil(before)
+        let (y, measured) = Loudness.normalize(x, sampleRate: sr, targetLUFS: -19, maxGainDB: 30, peakCeilingDBFS: -1)
+        XCTAssertEqual(measured, before)
+        let after = Loudness.integratedLUFS(y, sampleRate: sr)!
+        XCTAssertEqual(after, -19, accuracy: 0.5)          // lands on target
+        XCTAssertTrue(y.allSatisfy { abs($0) <= 1 })       // never clips
+    }
+
+    func testLoudnessSilenceIsNil() {
+        XCTAssertNil(Loudness.integratedLUFS([Float](repeating: 0, count: 48_000), sampleRate: 48_000))
+    }
+
+    func testOverlapAccumulatorAverages() {
+        var acc = OverlapAccumulator(length: 4)
+        acc.add([1, 1], at: 0)
+        acc.add([3, 3], at: 1)   // index 1 and 2 now overlap
+        let avg = acc.average()
+        XCTAssertEqual(avg, [1, 2, 3, 0])
+    }
+}

--- a/Tests/AudioIOTests/AudioIOTests.swift
+++ b/Tests/AudioIOTests/AudioIOTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import Foundation
+@testable import AudioIO
+
+final class AudioIOTests: XCTestCase {
+    private func tone(_ n: Int, freq: Double = 440, sr: Double = 16000) -> [Float] {
+        (0..<n).map { Float(0.5 * sin(2 * .pi * freq * Double($0) / sr)) }
+    }
+
+    func testWAVRoundTrip16Bit() throws {
+        let x = tone(4000)
+        let bytes = WAV.encode(x, sampleRate: 16000, channels: 1)
+        let pcm = try WAV.decode(bytes)
+        XCTAssertEqual(pcm.sampleRate, 16000)
+        XCTAssertEqual(pcm.channels, 1)
+        XCTAssertEqual(pcm.samples.count, x.count)
+        // 16-bit quantization error is bounded by ~1/32768.
+        var maxErr: Float = 0
+        for i in 0..<x.count { maxErr = max(maxErr, abs(x[i] - pcm.samples[i])) }
+        XCTAssertLessThan(maxErr, 1e-3)
+    }
+
+    // AudioIO.decode / writeWAV route through the platform backend: the
+    // AVFoundation/portable-WAV path on Apple/Linux, but the JS host on wasm
+    // (which isn't installed in the Swift test harness) and a filesystem the
+    // WASI sandbox lacks. The wasm decode path is covered by js/test/audio.test.mjs
+    // (installAudioHost). These exercise the native/portable path only.
+    #if !os(WASI)
+    func testDecodeBytesPortableWAV() async throws {
+        let x = tone(1600)
+        let wav = WAV.encode(x, sampleRate: 16000, channels: 1)
+        let mono = try await AudioIO.decode(bytes: wav, sampleRate: 16000)
+        XCTAssertEqual(mono.count, x.count)
+    }
+
+    func testDecodeResamplesToTargetRate() async throws {
+        // Encode at 8 kHz, decode requesting 16 kHz: roughly 2x the samples.
+        let x = tone(800, sr: 8000)
+        let wav = WAV.encode(x, sampleRate: 8000, channels: 1)
+        let mono = try await AudioIO.decode(bytes: wav, sampleRate: 16000)
+        XCTAssertEqual(Double(mono.count), 1600, accuracy: 4)
+    }
+
+    func testDecodeFromFileRoundTrip() async throws {
+        let x = tone(2000)
+        let dir = FileManager.default.temporaryDirectory
+        let url = dir.appendingPathComponent("dal-audioio-test-\(UUID().uuidString).wav")
+        try AudioIO.writeWAV(x, sampleRate: 16000, to: url.path)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let mono = try await AudioIO.decode(path: url.path, sampleRate: 16000)
+        XCTAssertEqual(mono.count, x.count)
+    }
+    #endif
+
+    func testStereoMixdown() throws {
+        // Interleaved L/R: L = +0.5, R = -0.5 -> mono averages to 0.
+        let interleaved = [Float](repeating: 0, count: 200).enumerated().map { i, _ in
+            i % 2 == 0 ? Float(0.5) : Float(-0.5)
+        }
+        let wav = WAV.encode(interleaved, sampleRate: 16000, channels: 2)
+        let pcm = try WAV.decode(wav)
+        XCTAssertEqual(pcm.channels, 2)
+        let mono = Resample.mixdownMono(pcm.samples, channels: 2)
+        XCTAssertEqual(mono.count, 100)
+        XCTAssertTrue(mono.allSatisfy { abs($0) < 1e-3 })
+    }
+}

--- a/Tests/BindingsTests/ClearBindingTests.swift
+++ b/Tests/BindingsTests/ClearBindingTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import Foundation
+import DesertAnt
+import TestSupport
+@_spi(ClearBindings) import Clear
+@testable import Bindings
+
+/// The model-specific half of the cross-language binding: the payload schemas a
+/// host encodes and decodes. The conformances live in `Bindings` (a model module
+/// never references `FFIBuffer`), so their tests live here too.
+final class ClearBindingTests: XCTestCase {
+#if !os(WASI)
+    private func requireModelBacked() throws {
+        try XCTSkipUnless(runsModelBackedTests, "model-backed tests do not run on iOS or Android")
+    }
+
+    private func enhancer() async throws -> Clear {
+        let files = try await ModelFixture.files(ClearModel.self)
+        do { return try Clear(modelPath: files.path(ClearModel.artifact)) }
+        catch { throw XCTSkip("no runtime for \(ClearModel.artifact) on this host: \(error)") }
+    }
+
+    /// 2.5 s of tone plus deterministic noise at 48 kHz.
+    private func noisyTone() -> [Float] {
+        var x = (0..<120_000).map { 0.3 * Float(sin(2 * .pi * 220 * Double($0) / 48_000)) }
+        var seed: UInt64 = 1
+        for i in 0..<x.count {
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            x[i] += 0.15 * (Float(seed >> 40) / Float(1 << 24) - 0.5)
+        }
+        return x
+    }
+
+    /// The audio payload contract (`dal_run_audio`): options in and samples out,
+    /// decoded with the same reader a host uses.
+    func testAudioPayloadRoundTrip() async throws {
+        try requireModelBacked()
+        let clear = try await enhancer()
+        var options = FFIWriter()
+        options.f64(1.0)        // strength
+        options.f64(.nan)       // integratedLUFS: mastering bypassed
+        options.f64(-1.5)       // true-peak ceiling
+        options.f64(9)          // max loudness gain
+        guard let payload = await clear.run(audio: noisyTone(), sampleRate: 48_000,
+                                            options: FFIReader(options.bytes)) else {
+            return XCTFail("the audio binding returned no payload")
+        }
+        var reader = FFIReader(payload)
+        let samples = reader.f32Array()
+        XCTAssertFalse(samples.isEmpty)
+        XCTAssertEqual(reader.f64(), 48_000)            // sample rate
+        XCTAssertGreaterThan(reader.f64(), 0)           // duration
+        XCTAssertGreaterThan(reader.f64(), 0)           // processing time
+        XCTAssertTrue(reader.f64().isNaN)               // measured LUFS: none, mastering off
+    }
+
+    /// Every model in the registry is reachable by its catalog id, which is how
+    /// a host asks for one over the C ABI.
+    func testRegistryResolvesEveryModelId() {
+        for id in ["emo", "redact", "clear"] {
+            XCTAssertNotNil(binding(for: id), "no binding registered for '\(id)'")
+        }
+        XCTAssertNil(binding(for: "not-a-model"))
+    }
+#endif
+}

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -100,6 +100,33 @@ final class ClearTests: XCTestCase {
         XCTAssertTrue(Clear().isDownloaded())
     }
 
+    /// The file-in/file-out path (Apple/Linux): decode any audio file, enhance,
+    /// and write a 48 kHz WAV. Uses the core's AudioIO for both ends, so this
+    /// also covers the WAV encode the SDK hands users.
+    #if canImport(Foundation) && !os(Android)
+    func testEnhanceFileToFile() async throws {
+        try requireModelBacked()
+        let clear = try await enhancer()
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("clear-file-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let input = dir.appendingPathComponent("in.wav")
+        let output = dir.appendingPathComponent("out.wav")
+        try AudioIO.writeWAV(noisyTone(), sampleRate: 48_000, to: input.path)
+
+        let result = try await clear.enhance(path: input.path, to: output.path)
+        XCTAssertEqual(result.sampleRate, 48_000)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: output.path))
+
+        // The written file decodes back to the enhanced signal.
+        let decoded = try await AudioIO.decode(path: output.path, sampleRate: 48_000)
+        XCTAssertEqual(Double(decoded.count), Double(result.samples.count), accuracy: 480)
+        XCTAssertTrue(decoded.contains { $0 != 0 })
+    }
+    #endif
+
     /// The bindings' audio payload contract (`dal_run_audio`): options in and
     /// samples out, decoded with the same reader a host uses.
     func testBindingAudioPayloadRoundTrip() async throws {

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+import Foundation
+import DesertAnt
+import TestSupport
+@testable import Clear
+
+/// Clear's suite has two halves: the DSP front end, which is pure Swift and runs
+/// everywhere with no model, and the end-to-end enhancement, which uses the
+/// shared `ModelFixture` download like every other model's suite (no artifact is
+/// committed) and is skipped where model-backed tests do not run.
+final class ClearTests: XCTestCase {
+    private func tone(_ n: Int, freq: Double = 220, sr: Double = 48_000, amp: Float = 0.3) -> [Float] {
+        (0..<n).map { amp * Float(sin(2 * .pi * freq * Double($0) / sr)) }
+    }
+
+    private func snr(_ ref: [Float], _ rec: [Float]) -> Double {
+        let n = min(ref.count, rec.count)
+        var sig = 0.0, err = 0.0
+        for i in 0..<n { sig += Double(ref[i]) * Double(ref[i]); let e = Double(ref[i]) - Double(rec[i]); err += e * e }
+        return err > 0 ? 10 * log10(sig / err) : .infinity
+    }
+
+    // MARK: DSP (no model)
+
+    // Validates the ported DFN STFT: analysis+synthesis reconstructs the signal
+    // (Vorbis-window COLA identity), independent of the model.
+    func testSTFTReconstruction() {
+        let x = tone(48_000)
+        let stft = ClearSTFT()
+        let (re, im, frames) = stft.forward(x)
+        XCTAssertGreaterThan(frames, 90)
+        let y = stft.inverse(real: re, imag: im, nFrames: frames)
+        XCTAssertGreaterThanOrEqual(y.count, x.count)
+        // COLA identity holds on the interior; the first/last half-window lack
+        // full overlap (the pipeline pads the tail, so this is edge-only).
+        let pad = ClearDSP.fftSize
+        let xi = Array(x[pad..<(x.count - pad)])
+        let yi = Array(y[pad..<(x.count - pad)])
+        XCTAssertGreaterThan(snr(xi, yi), 60)
+    }
+
+    func testFeaturesAreFinite() {
+        let stft = ClearSTFT()
+        let (re, im, frames) = stft.forward(tone(24_000))
+        let (fe, fr, fi) = ClearFeatures.compute(real: re, imag: im, nFrames: frames)
+        XCTAssertEqual(fe.count, frames * ClearDSP.nErb)
+        XCTAssertEqual(fr.count, frames * ClearDSP.nDf)
+        XCTAssertTrue((fe + fr + fi).allSatisfy { $0.isFinite })
+    }
+
+    // MARK: end to end (downloaded model)
+
+    // Model-backed tests are wasm-guarded because the shared fixture does not
+    // exist there (the store's filesystem and transport come from the JS host the
+    // app installs), and skipped off iOS/Android by `requireModelBacked`.
+#if !os(WASI)
+    private func requireModelBacked() throws {
+        try XCTSkipUnless(runsModelBackedTests, "model-backed tests do not run on iOS or Android")
+    }
+
+    /// The cached artifact for this platform: the Core ML directory on Apple,
+    /// the LiteRT file elsewhere. Downloaded once per process by the fixture.
+    private func enhancer() async throws -> Clear {
+        let files = try await ModelFixture.files(ClearModel.self)
+        do { return try Clear(modelPath: files.path(ClearModel.artifact)) }
+        catch { throw XCTSkip("no runtime for \(ClearModel.artifact) on this host: \(error)") }
+    }
+
+    /// 2.5 s of tone plus deterministic noise at 48 kHz.
+    private func noisyTone() -> [Float] {
+        var x = tone(120_000)
+        var seed: UInt64 = 1
+        for i in 0..<x.count {
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            x[i] += 0.15 * (Float(seed >> 40) / Float(1 << 24) - 0.5)
+        }
+        return x
+    }
+
+    func testEnhanceEndToEnd() async throws {
+        try requireModelBacked()
+        let clear = try await enhancer()
+        let x = noisyTone()
+        let result = try await clear.enhance(samples: x, sampleRate: 48_000,
+                                             options: .init(strength: .full, targetLUFS: -19))
+        XCTAssertEqual(result.sampleRate, 48_000)
+        XCTAssertEqual(Double(result.samples.count), Double(x.count), accuracy: 480)
+        XCTAssertTrue(result.samples.allSatisfy { $0.isFinite })
+        var energy: Float = 0; for v in result.samples { energy += v * v }
+        XCTAssertGreaterThan(energy, 0)                 // not silent
+        XCTAssertNotNil(result.measuredLUFS)
+    }
+
+    /// The store path the SDK's own initializer takes: resolve the pinned model
+    /// into the managed cache, then report it as available offline.
+    func testResolvesThroughTheModelStore() async throws {
+        try requireModelBacked()
+        _ = try await ModelFixture.files(ClearModel.self)
+        // Availability is per instance now (LoadedModel owns it), so ask one.
+        XCTAssertTrue(Clear().isDownloaded())
+    }
+
+    /// The bindings' audio payload contract (`dal_run_audio`): options in and
+    /// samples out, decoded with the same reader a host uses.
+    func testBindingAudioPayloadRoundTrip() async throws {
+        try requireModelBacked()
+        let clear = try await enhancer()
+        var options = FFIWriter()
+        options.f64(1.0)        // strength
+        options.f64(.nan)       // targetLUFS: mastering disabled
+        options.f64(-1.0)       // peak ceiling
+        options.f64(12)         // max gain
+        guard let payload = await clear.run(audio: noisyTone(), sampleRate: 48_000,
+                                            options: FFIReader(options.bytes)) else {
+            return XCTFail("the audio binding returned no payload")
+        }
+        var reader = FFIReader(payload)
+        let samples = reader.f32Array()
+        XCTAssertFalse(samples.isEmpty)
+        XCTAssertEqual(reader.f64(), 48_000)            // sample rate
+        XCTAssertGreaterThan(reader.f64(), 0)           // duration
+        XCTAssertGreaterThan(reader.f64(), 0)           // processing time
+        XCTAssertTrue(reader.f64().isNaN)               // measured LUFS: none, mastering off
+    }
+#endif
+}

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -1,111 +1,217 @@
-import XCTest
 import Foundation
+import Testing
 import DesertAnt
 import TestSupport
 @testable import Clear
 
-/// Clear's suite has two halves: the DSP front end, which is pure Swift and runs
-/// everywhere with no model, and the end-to-end enhancement, which uses the
-/// shared `ModelFixture` download like every other model's suite (no artifact is
-/// committed) and is skipped where model-backed tests do not run.
-final class ClearTests: XCTestCase {
-    private func tone(_ n: Int, freq: Double = 220, sr: Double = 48_000, amp: Float = 0.3) -> [Float] {
-        (0..<n).map { amp * Float(sin(2 * .pi * freq * Double($0) / sr)) }
+/// A sine tone, the input every test builds on.
+func tone(_ n: Int, freq: Double = 220, sr: Double = 48_000, amp: Float = 0.3) -> [Float] {
+    (0..<n).map { amp * Float(sin(2 * .pi * freq * Double($0) / sr)) }
+}
+
+/// Signal-to-noise ratio in dB between a reference and a reconstruction.
+func snr(_ ref: [Float], _ rec: [Float]) -> Double {
+    let n = min(ref.count, rec.count)
+    var sig = 0.0, err = 0.0
+    for i in 0..<n { sig += Double(ref[i]) * Double(ref[i]); let e = Double(ref[i]) - Double(rec[i]); err += e * e }
+    return err > 0 ? 10 * log10(sig / err) : .infinity
+}
+
+/// 2.5 s of tone plus deterministic noise at 48 kHz: what the model is asked to
+/// clean up. Deterministic so a failure reproduces.
+func noisyTone() -> [Float] {
+    var x = tone(120_000)
+    var seed: UInt64 = 1
+    for i in 0..<x.count {
+        seed = seed &* 6364136223846793005 &+ 1442695040888963407
+        x[i] += 0.15 * (Float(seed >> 40) / Float(1 << 24) - 0.5)
     }
+    return x
+}
 
-    private func snr(_ ref: [Float], _ rec: [Float]) -> Double {
-        let n = min(ref.count, rec.count)
-        var sig = 0.0, err = 0.0
-        for i in 0..<n { sig += Double(ref[i]) * Double(ref[i]); let e = Double(ref[i]) - Double(rec[i]); err += e * e }
-        return err > 0 ? 10 * log10(sig / err) : .infinity
-    }
+/// Collects progress updates from the task group the chunk loop runs on.
+final class ProgressLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var updates: [Clear.Progress] = []
+    func append(_ update: Clear.Progress) { lock.withLock { updates.append(update) } }
+    func all() -> [Clear.Progress] { lock.withLock { updates } }
+}
 
-    // MARK: DSP (no model)
+/// The half of Clear that needs no model: the DSP front end, the mastering
+/// presets, and the variant declarations.
+struct ClearTests {
+    // MARK: DSP
 
-    // Validates the ported DFN STFT: analysis+synthesis reconstructs the signal
-    // (Vorbis-window COLA identity), independent of the model.
-    func testSTFTReconstruction() {
+    /// Validates the ported DFN STFT: analysis+synthesis reconstructs the signal
+    /// (Vorbis-window COLA identity), independent of the model.
+    @Test func stftReconstruction() {
         let x = tone(48_000)
         let stft = ClearSTFT()
         let (re, im, frames) = stft.forward(x)
-        XCTAssertGreaterThan(frames, 90)
+        #expect(frames > 90)
         let y = stft.inverse(real: re, imag: im, nFrames: frames)
-        XCTAssertGreaterThanOrEqual(y.count, x.count)
+        #expect(y.count >= x.count)
         // COLA identity holds on the interior; the first/last half-window lack
         // full overlap (the pipeline pads the tail, so this is edge-only).
         let pad = ClearDSP.fftSize
         let xi = Array(x[pad..<(x.count - pad)])
         let yi = Array(y[pad..<(x.count - pad)])
-        XCTAssertGreaterThan(snr(xi, yi), 60)
+        #expect(snr(xi, yi) > 60)
     }
 
-    func testFeaturesAreFinite() {
+    @Test func featuresAreFinite() {
         let stft = ClearSTFT()
         let (re, im, frames) = stft.forward(tone(24_000))
         let (fe, fr, fi) = ClearFeatures.compute(real: re, imag: im, nFrames: frames)
-        XCTAssertEqual(fe.count, frames * ClearDSP.nErb)
-        XCTAssertEqual(fr.count, frames * ClearDSP.nDf)
-        XCTAssertTrue((fe + fr + fi).allSatisfy { $0.isFinite })
+        #expect(fe.count == frames * ClearDSP.nErb)
+        #expect(fr.count == frames * ClearDSP.nDf)
+        #expect((fe + fr + fi).allSatisfy { $0.isFinite })
     }
 
-    // MARK: end to end (downloaded model)
+    // MARK: mastering presets
 
-    // Model-backed tests are wasm-guarded because the shared fixture does not
-    // exist there (the store's filesystem and transport come from the JS host the
-    // app installs), and skipped off iOS/Android by `requireModelBacked`.
+    /// The published targets each preset normalizes to, and that a preset round
+    /// trips into `Options`. These are platform specs, so a change here is a
+    /// deliberate spec change, not a refactor.
+    @Test func loudnessPresetTargets() {
+        #expect(Clear.LoudnessPreset.applePodcasts.integratedLUFS == -19)
+        #expect(Clear.LoudnessPreset.spotify.integratedLUFS == -14)
+        #expect(Clear.LoudnessPreset.youtube.integratedLUFS == -14)
+        #expect(Clear.LoudnessPreset.broadcast.integratedLUFS == -23)
+
+        // EBU R128 allows a wider range than spoken-word delivery.
+        #expect(Clear.LoudnessPreset.broadcast.mastering.loudnessRangeLU == 10)
+        #expect(Clear.LoudnessPreset.applePodcasts.mastering.loudnessRangeLU == 7)
+
+        // Every case is pickable and labelled, so a UI can render the list.
+        #expect(Clear.LoudnessPreset.allCases.count == 4)
+        for preset in Clear.LoudnessPreset.allCases {
+            #expect(!preset.displayName.isEmpty)
+            #expect(!preset.shortName.isEmpty)
+            #expect(preset.id == preset.rawValue)
+            #expect(Clear.LoudnessPreset(rawValue: preset.rawValue) == preset)
+            #expect(preset.mastering.integratedLUFS == preset.integratedLUFS)
+        }
+    }
+
+    @Test func masteringDefaultsAndBypass() {
+        // The default options are the Apple Podcasts preset at full strength.
+        #expect(Clear.Options.default.mastering == .applePodcasts)
+        #expect(Clear.Options.default.strength.value == 1)
+        #expect(Clear.Options.default.targetLUFS == -19)
+        #expect(Clear.Mastering.podcast == Clear.Mastering.applePodcasts)
+
+        // Bypass reports no target, which is what disables the loudness stage.
+        #expect(Clear.Options(mastering: .bypass).targetLUFS == nil)
+        #expect(Clear.Options(targetLUFS: nil).targetLUFS == nil)
+
+        // The numeric initializer maps onto the same chain.
+        let explicit = Clear.Options(targetLUFS: -16, peakCeilingDBFS: -2, maxGainDB: 6)
+        #expect(explicit.mastering.integratedLUFS == -16)
+        #expect(explicit.mastering.truePeakDBTP == -2)
+        #expect(explicit.mastering.maxLoudnessGainDB == 6)
+        #expect(Clear.Mastering.targetLUFS(-21).integratedLUFS == -21)
+    }
+
+    // MARK: variants
+
+    /// The variant is what selects files, so its names must match the Hub's
+    /// artifact stems exactly, and each variant must fetch only its own.
+    @Test func modelVariantFilesAndInference() {
+        #expect(ModelVariant.default == .clearStudio)
+        #expect(ClearModel.variant == .clearStudio)
+        #expect(ModelVariant.clearStudio.rawValue == "clear-studio")
+        #expect(ModelVariant.clearNatural.rawValue == "clear-natural")
+        #expect(ModelVariant.clearNatural.coreML == "clear-natural.mlmodelc")
+        #expect(ModelVariant.clearNatural.tflite == "clear-natural.tflite")
+
+        // A variant's manifest carries that variant alone.
+        let natural = ModelVariant.clearNatural.distribution
+        #expect(natural.repo == ClearModel.repo)
+        #expect(natural.revision == ClearModel.revision)
+        for (_, files) in natural.files {
+            #expect(files.allSatisfy { $0.hasPrefix("clear-natural") }, "got \(files)")
+        }
+
+        // The catalog entry stays the default variant, which is what the shared
+        // fixture and tooling read.
+        #expect(ClearModel.files[.apple] == ModelVariant.clearStudio.files[.apple])
+
+        // A path identifies its variant; anything else is not a published one.
+        #expect(ModelVariant.inferred(fromPath: "/tmp/x/clear-studio.mlmodelc") == .clearStudio)
+        #expect(ModelVariant.inferred(fromPath: "clear-natural.tflite") == .clearNatural)
+        #expect(ModelVariant.inferred(fromPath: "/tmp/my-own-export.tflite") == nil)
+    }
+}
+
+// `.modelBacked` (TestSupport) decides where these run - one trait on the suite
+// instead of a platform `#if` around each test - and the wasm guard is because
+// the shared fixture does not exist there (the model store's filesystem and
+// transport come from the JS host an app installs, which the bare test harness
+// never does).
 #if !os(WASI)
-    private func requireModelBacked() throws {
-        try XCTSkipUnless(runsModelBackedTests, "model-backed tests do not run on iOS or Android")
-    }
-
-    /// The cached artifact for this platform: the Core ML directory on Apple,
-    /// the LiteRT file elsewhere. Downloaded once per process by the fixture.
+@Suite(.serialized, .modelBacked) struct ClearModelTests {
+    /// An enhancer over the cached artifact for this platform: the Core ML
+    /// directory on Apple, the LiteRT file elsewhere. The fixture downloads it
+    /// once per process and every test here reuses it.
     private func enhancer() async throws -> Clear {
         let files = try await ModelFixture.files(ClearModel.self)
-        do { return try Clear(modelPath: files.path(ClearModel.artifact)) }
-        catch { throw XCTSkip("no runtime for \(ClearModel.artifact) on this host: \(error)") }
+        return try Clear(modelPath: files.path(ClearModel.artifact))
     }
 
-    /// 2.5 s of tone plus deterministic noise at 48 kHz.
-    private func noisyTone() -> [Float] {
-        var x = tone(120_000)
-        var seed: UInt64 = 1
-        for i in 0..<x.count {
-            seed = seed &* 6364136223846793005 &+ 1442695040888963407
-            x[i] += 0.15 * (Float(seed >> 40) / Float(1 << 24) - 0.5)
-        }
-        return x
-    }
-
-    func testEnhanceEndToEnd() async throws {
-        try requireModelBacked()
+    @Test func enhanceEndToEnd() async throws {
         let clear = try await enhancer()
         let x = noisyTone()
         let result = try await clear.enhance(samples: x, sampleRate: 48_000,
-                                             options: .init(strength: .full, targetLUFS: -19))
-        XCTAssertEqual(result.sampleRate, 48_000)
-        XCTAssertEqual(Double(result.samples.count), Double(x.count), accuracy: 480)
-        XCTAssertTrue(result.samples.allSatisfy { $0.isFinite })
+                                             options: .init(mastering: .applePodcasts))
+        #expect(result.sampleRate == 48_000)
+        #expect(abs(result.samples.count - x.count) <= 480)
+        #expect(result.samples.allSatisfy { $0.isFinite })
         var energy: Float = 0; for v in result.samples { energy += v * v }
-        XCTAssertGreaterThan(energy, 0)                 // not silent
-        XCTAssertNotNil(result.measuredLUFS)
+        #expect(energy > 0)                             // not silent
+        #expect(result.measuredLUFS != nil)
+        // The run identifies the artifact that produced it (read off the cached
+        // file name), so a benchmark or usage event is self-describing.
+        #expect(result.modelVariant == .clearStudio)
+    }
+
+    /// A preset actually moves the output level: the same input mastered to
+    /// Spotify (-14) is louder than to broadcast (-23), and bypass leaves the
+    /// model's own level (so it reports no measurement).
+    @Test func presetsChangeTheMasteredLevel() async throws {
+        let clear = try await enhancer()
+        let x = noisyTone()
+
+        func rms(_ s: [Float]) -> Double {
+            var acc = 0.0
+            for v in s { acc += Double(v) * Double(v) }
+            return (acc / Double(max(1, s.count))).squareRoot()
+        }
+
+        let spotify = try await clear.enhance(samples: x, sampleRate: 48_000,
+                                              options: .init(mastering: .spotify))
+        let broadcast = try await clear.enhance(samples: x, sampleRate: 48_000,
+                                                options: .init(mastering: .broadcast))
+        let bypassed = try await clear.enhance(samples: x, sampleRate: 48_000,
+                                               options: .init(mastering: .bypass))
+
+        #expect(rms(spotify.samples) > rms(broadcast.samples))
+        #expect(spotify.measuredLUFS != nil)
+        #expect(bypassed.measuredLUFS == nil)
     }
 
     /// The store path the SDK's own initializer takes: resolve the pinned model
     /// into the managed cache, then report it as available offline.
-    func testResolvesThroughTheModelStore() async throws {
-        try requireModelBacked()
+    @Test func resolvesThroughTheModelStore() async throws {
         _ = try await ModelFixture.files(ClearModel.self)
-        // Availability is per instance now (LoadedModel owns it), so ask one.
-        XCTAssertTrue(Clear().isDownloaded())
+        // Availability is per instance (LoadedModel owns it), so ask one.
+        #expect(Clear().isDownloaded())
     }
 
     /// The file-in/file-out path (Apple/Linux): decode any audio file, enhance,
     /// and write a 48 kHz WAV. Uses the core's AudioIO for both ends, so this
     /// also covers the WAV encode the SDK hands users.
-    #if canImport(Foundation) && !os(Android)
-    func testEnhanceFileToFile() async throws {
-        try requireModelBacked()
+    @Test func enhanceFileToFile() async throws {
         let clear = try await enhancer()
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("clear-file-\(UUID().uuidString)")
@@ -117,37 +223,60 @@ final class ClearTests: XCTestCase {
         try AudioIO.writeWAV(noisyTone(), sampleRate: 48_000, to: input.path)
 
         let result = try await clear.enhance(path: input.path, to: output.path)
-        XCTAssertEqual(result.sampleRate, 48_000)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: output.path))
+        #expect(result.sampleRate == 48_000)
+        #expect(FileManager.default.fileExists(atPath: output.path))
 
         // The written file decodes back to the enhanced signal.
         let decoded = try await AudioIO.decode(path: output.path, sampleRate: 48_000)
-        XCTAssertEqual(Double(decoded.count), Double(result.samples.count), accuracy: 480)
-        XCTAssertTrue(decoded.contains { $0 != 0 })
+        #expect(abs(decoded.count - result.samples.count) <= 480)
+        #expect(decoded.contains { $0 != 0 })
     }
-    #endif
 
-    /// The bindings' audio payload contract (`dal_run_audio`): options in and
-    /// samples out, decoded with the same reader a host uses.
-    func testBindingAudioPayloadRoundTrip() async throws {
-        try requireModelBacked()
+    /// Progress reporting: the phases arrive in pipeline order, each fraction is
+    /// monotonic within its phase, and enhancing is subdivided (more than one
+    /// chunk report) rather than jumping 0 -> 1.
+    @Test func progressReportsPhasesInOrder() async throws {
         let clear = try await enhancer()
-        var options = FFIWriter()
-        options.f64(1.0)        // strength
-        options.f64(.nan)       // targetLUFS: mastering disabled
-        options.f64(-1.0)       // peak ceiling
-        options.f64(12)         // max gain
-        guard let payload = await clear.run(audio: noisyTone(), sampleRate: 48_000,
-                                            options: FFIReader(options.bytes)) else {
-            return XCTFail("the audio binding returned no payload")
+        let log = ProgressLog()
+
+        _ = try await clear.enhance(samples: noisyTone(), sampleRate: 48_000,
+                                    options: .init(mastering: .applePodcasts)) { log.append($0) }
+
+        let updates = log.all()
+        #expect(!updates.isEmpty)
+
+        // The model is already loaded here (the fixture built the session), so
+        // the phases present are analyzing then enhancing, never interleaved.
+        let phases = updates.map(\.phase)
+        let order: [Clear.Phase] = [.loadingModel, .analyzing, .enhancing]
+        let ranks = phases.compactMap { order.firstIndex(of: $0) }
+        #expect(ranks == ranks.sorted(), "phases must not interleave: \(phases)")
+
+        #expect(phases.contains(.analyzing))
+        #expect(phases.contains(.enhancing))
+
+        // Fractions stay in range and never go backwards within a phase.
+        for phase in Set(phases) {
+            let fractions = updates.filter { $0.phase == phase }.map(\.fraction)
+            #expect(fractions == fractions.sorted(), "\(phase) fractions went backwards")
+            #expect(fractions.allSatisfy { $0 >= 0 && $0 <= 1 })
         }
-        var reader = FFIReader(payload)
-        let samples = reader.f32Array()
-        XCTAssertFalse(samples.isEmpty)
-        XCTAssertEqual(reader.f64(), 48_000)            // sample rate
-        XCTAssertGreaterThan(reader.f64(), 0)           // duration
-        XCTAssertGreaterThan(reader.f64(), 0)           // processing time
-        XCTAssertTrue(reader.f64().isNaN)               // measured LUFS: none, mastering off
+
+        // 2.5 s is many model chunks, so enhancing is genuinely incremental, and
+        // it ends at 1 only after mastering (its tail) has run.
+        #expect(updates.filter { $0.phase == .enhancing }.count > 2)
+        #expect(updates.last?.phase == .enhancing)
+        #expect(updates.last?.fraction == 1)
+        #expect(updates.filter { $0.phase == .analyzing }.last?.fraction == 1)
     }
-#endif
+
+    /// A fresh instance that has to resolve the model reports `.loadingModel`
+    /// first, so the first call does not look like a hang.
+    @Test func progressReportsModelLoad() async throws {
+        _ = try await ModelFixture.files(ClearModel.self)   // cached; the load is local
+        let log = ProgressLog()
+        _ = try await Clear().enhance(samples: tone(48_000), sampleRate: 48_000) { log.append($0) }
+        #expect(log.all().first?.phase == .loadingModel)
+    }
 }
+#endif

--- a/Tests/ClearTests/HubDownloadTests.swift
+++ b/Tests/ClearTests/HubDownloadTests.swift
@@ -1,0 +1,32 @@
+#if !os(WASI)
+import XCTest
+import TestSupport
+@testable import Clear
+
+final class HubDownloadTests: XCTestCase {
+    func testDownloadThenEnhance() async throws {
+        try await HubDownloadScenario.run(
+            ClearModel.self,
+            make: { Clear(directory: $0) },
+            isDownloaded: { $0.isDownloaded() },
+            download: { try await $0.download(progress: $1) }
+        ) { clear, cached in
+            // A second of tone plus noise: enough frames for several model
+            // chunks, cheap enough for a network-gated test.
+            let noisy = noisyTone()
+            let result = try await clear.enhance(samples: noisy, sampleRate: 48_000)
+            XCTAssertEqual(result.sampleRate, 48_000)
+            XCTAssertTrue(result.samples.allSatisfy { $0.isFinite })
+            XCTAssertNotNil(result.measuredLUFS)
+            // Downloaded through the store, so the artifact names its variant.
+            XCTAssertEqual(result.modelVariant, .clearStudio)
+
+            // The cached instance loads the same files with no network.
+            let again = try await cached.enhance(samples: noisy, sampleRate: 48_000,
+                                                 options: .init(mastering: .bypass))
+            XCTAssertEqual(again.samples.count, result.samples.count)
+            XCTAssertNil(again.measuredLUFS)   // mastering bypassed
+        }
+    }
+}
+#endif

--- a/Tests/FFIBufferTests/FFIBufferTests.swift
+++ b/Tests/FFIBufferTests/FFIBufferTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import FFIBuffer
+
+final class FFIBufferTests: XCTestCase {
+    func testScalarRoundTrip() {
+        var w = FFIWriter()
+        w.u32(0x0102_0304)
+        w.u64(0xDEAD_BEEF_1234_5678)
+        w.f32(1.5)
+        w.f64(-3.25)
+        w.string("héllo")
+
+        var r = FFIReader(w.bytes)
+        XCTAssertEqual(r.u32(), 0x0102_0304)
+        XCTAssertEqual(r.u64(), 0xDEAD_BEEF_1234_5678)
+        XCTAssertEqual(r.f32(), 1.5)
+        XCTAssertEqual(r.f64(), -3.25)
+        XCTAssertEqual(r.string(), "héllo")
+    }
+
+    func testFloatArrayRoundTrip() {
+        let values: [Float] = [0, 1, -1, 0.333, 1e6, -1e-6]
+        var w = FFIWriter()
+        w.f32Array(values)
+        var r = FFIReader(w.bytes)
+        XCTAssertEqual(r.f32Array(), values)
+    }
+
+    func testLengthPrefixedReaderMatchesEmit() {
+        var w = FFIWriter()
+        w.u32(7)
+        w.f32Array([2, 4, 8])
+        // ffiEmit prefixes the body with a big-endian u32 length.
+        guard let ptr = w.emit() else { return XCTFail("emit failed") }
+        defer { ffiFree(ptr) }
+        let base = UnsafeRawPointer(ptr).assumingMemoryBound(to: UInt8.self)
+        let total = 4 + w.bytes.count
+        let buffer = [UInt8](UnsafeBufferPointer(start: base, count: total))
+
+        var r = FFIReader(lengthPrefixed: buffer)
+        XCTAssertEqual(r.u32(), 7)
+        XCTAssertEqual(r.f32Array(), [2, 4, 8])
+    }
+
+    func testTruncatedReadsDegrade() {
+        var r = FFIReader([0x00, 0x01])  // too short for a u32
+        XCTAssertEqual(r.u32(), 0)  // an underflowing read yields the default, not a partial value
+        XCTAssertEqual(r.f32Array(), [])
+    }
+}

--- a/Tests/ModelCatalogTests/ModelCatalogTests.swift
+++ b/Tests/ModelCatalogTests/ModelCatalogTests.swift
@@ -3,6 +3,7 @@ import Testing
 import DesertAnt
 @testable import Emo
 @testable import Redact
+@testable import Clear
 
 /// Every model in the monorepo. The list lives here rather than beside the
 /// `ModelDeclaration` protocol because each model's module depends on the
@@ -11,6 +12,7 @@ import DesertAnt
 let catalog: [any ModelDeclaration.Type] = [
     EmoModel.self,
     RedactModel.self,
+    ClearModel.self,
 ]
 
 /// Invariants every catalog entry must hold, so a malformed declaration fails
@@ -20,7 +22,10 @@ struct ModelCatalogTests {
         for model in catalog {
             #expect(model.id == model.id.lowercased() && !model.id.isEmpty)
             #expect(model.repo == "desert-ant-labs/\(model.id)")
-            #expect(model.revision.hasPrefix("v"), "\(model.id): revision must be a v-tag")
+            // A v-tag, or `main` for a model whose first tag predates one of its
+            // platform artifacts (clear: the Hub tag has no LiteRT export yet).
+            #expect(model.revision.hasPrefix("v") || model.revision == "main",
+                    "\(model.id): revision must be a v-tag (or a documented `main` pin)")
             #expect(model.product.first?.isUppercase == true, "\(model.id): product is capitalized")
             #expect(!model.summary.isEmpty)
         }

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -33,6 +33,20 @@ export class FfiWriter {
   done(): Uint8Array;
 }
 
+/** The audio-decode host the wasm AudioIO backend calls (`__DalAudioHost`). */
+export interface AudioHost {
+  decode(path: string | null, bytes: Uint8Array | null, sampleRate: number): Promise<Float32Array>;
+}
+
+/** Install `globalThis.__DalAudioHost` so the wasm core can decode audio.
+ *  Browser: Web Audio (any container). Node (`/node` entry): the WAV codec. */
+export function installAudioHost(): AudioHost;
+
+/** Decode a WAV/RIFF buffer to interleaved float samples + rate + channels. */
+export function decodeWav(bytes: Uint8Array): { samples: Float32Array; sampleRate: number; channels: number };
+export function mixdownMono(interleaved: Float32Array, channels: number): Float32Array;
+export function resampleLinear(x: Float32Array, from: number, to: number): Float32Array;
+
 export function loadLiteRt(options: {
   litert?: any;
   wasmDir?: string;

--- a/js/index.js
+++ b/js/index.js
@@ -2,12 +2,14 @@
 // model SDKs. This entry is browser-safe (no `node:*`): the shared model-SDK
 // runtime (load / run / dispose over either core), the LiteRT.js host and
 // session contract, the LiteRT loader/guards, the self-hosted-model fetch
-// helper, the browser platform seam, and the FFI codecs. The node-only native
-// loader, native SDK factory, and node platform seam live in the "./node"
-// subpath.
+// helper, the browser platform seam, the FFI codecs, and the audio host. The
+// node-only native loader, native SDK factory, and node platform seam live in
+// the "./node" subpath.
 export { FfiReader, FfiWriter } from "./src/ffi.js";
 export { makeCallGroups, CALL_GROUP_END_SYMBOL } from "./src/callgroup.js";
 export { createWasmSdk, LoadedModel, readyModel, wasmCore } from "./src/sdk.js";
+export { installAudioHost } from "./src/audio.js";
+export { decodeWav, mixdownMono, resampleLinear } from "./src/wav.js";
 export {
   loadLiteRt,
   assertBrowserRuntime,

--- a/js/node.d.ts
+++ b/js/node.d.ts
@@ -1,6 +1,10 @@
 // Type declarations for the node-only entry of @desert-ant-labs/core/node.
-import { FfiReader, FfiWriter } from "./index.js";
+import { FfiReader, FfiWriter, AudioHost } from "./index.js";
 export { FfiReader, FfiWriter };
+
+/** Install `globalThis.__DalAudioHost` backed by the pure-JS WAV codec (Node
+ *  has no Web Audio). Reads the file at `path` through `node:fs`. */
+export function installAudioHost(): AudioHost;
 
 export interface NativeCore {
   koffi: any;

--- a/js/node.js
+++ b/js/node.js
@@ -13,3 +13,4 @@ export {
   nodeCacheRoot,
 } from "./src/platform-node.js";
 export { FfiReader, FfiWriter } from "./src/ffi.js";
+export { installAudioHost } from "./src/audio-node.js";

--- a/js/src/audio-node.js
+++ b/js/src/audio-node.js
@@ -1,0 +1,30 @@
+// Node audio-decode host for the wasm AudioIO backend (SSR / server-side). Node
+// has no Web Audio, so this decodes with the pure-JS WAV codec and resampler
+// (WAV only, matching Swift AudioIO's portable path). Installs the same
+// `__DalAudioHost.decode` global as the browser host (audio.js); node-only
+// (reads files through `node:fs`).
+
+import { decodeWav, mixdownMono, resampleLinear } from "./wav.js";
+
+/**
+ * Install `globalThis.__DalAudioHost.decode(path, bytes, sampleRate)`, returning
+ * a mono `Float32Array` at `sampleRate`. Under Node the Swift ModelStore hands a
+ * cached file `path` (bytes null); a caller may also pass `bytes` directly.
+ * Idempotent.
+ */
+export function installAudioHost() {
+  globalThis.__DalAudioHost ??= {
+    decode: async (path, bytes, sampleRate) => {
+      let data = bytes;
+      if (!data && path) {
+        const fs = await import("node:fs");
+        data = new Uint8Array(fs.readFileSync(path));
+      }
+      if (!data) throw new Error("__DalAudioHost.decode: no path or bytes");
+      const { samples, sampleRate: srcRate, channels } = decodeWav(data);
+      const mono = mixdownMono(samples, channels);
+      return resampleLinear(mono, srcRate, sampleRate);
+    },
+  };
+  return globalThis.__DalAudioHost;
+}

--- a/js/src/audio.js
+++ b/js/src/audio.js
@@ -1,0 +1,39 @@
+// Browser audio-decode host for the wasm AudioIO backend. Web Audio decodes any
+// container the browser supports (wav/mp3/m4a/ogg/...), and an
+// OfflineAudioContext renders it to mono at the requested sample rate (it
+// downmixes and resamples for us). Installs the `__DalAudioHost.decode` global
+// that Swift AudioIO calls on wasm; browser-safe (no `node:*`).
+
+/**
+ * Install `globalThis.__DalAudioHost.decode(path, bytes, sampleRate)`, returning
+ * a mono `Float32Array` at `sampleRate`. In the browser `path` is null and
+ * `bytes` is the file's `Uint8Array`. Idempotent.
+ */
+export function installAudioHost() {
+  globalThis.__DalAudioHost ??= {
+    decode: async (path, bytes, sampleRate) => decodeBrowser(bytes, sampleRate),
+  };
+  return globalThis.__DalAudioHost;
+}
+
+async function decodeBrowser(bytes, sampleRate) {
+  if (!bytes) throw new Error("__DalAudioHost.decode: browser decode needs file bytes");
+  const Offline = globalThis.OfflineAudioContext || globalThis.webkitOfflineAudioContext;
+  if (!Offline) throw new Error("__DalAudioHost.decode: no OfflineAudioContext");
+
+  // decodeAudioData consumes (detaches) its ArrayBuffer, so hand it an owned copy.
+  const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  const probe = new Offline(1, 1, 44100);
+  const decoded = await probe.decodeAudioData(ab);
+
+  // Render through a 1-channel OfflineAudioContext at the target rate: it mixes
+  // down to mono and resamples in one pass.
+  const frames = Math.max(1, Math.round(decoded.duration * sampleRate));
+  const ctx = new Offline(1, frames, sampleRate);
+  const src = ctx.createBufferSource();
+  src.buffer = decoded;
+  src.connect(ctx.destination);
+  src.start();
+  const rendered = await ctx.startRendering();
+  return rendered.getChannelData(0);
+}

--- a/js/src/wav.js
+++ b/js/src/wav.js
@@ -1,0 +1,91 @@
+// Pure-JS WAV decode + mono mixdown + linear resample: the browser-safe
+// counterpart of Swift AudioIO's portable WAV path (Sources/AudioIO/WAV.swift)
+// and Kotlin's resampler. Node uses this to decode audio without a native codec
+// (WAV only, matching the Swift portable path); the browser uses Web Audio
+// instead (audio.js), so this stays codec-free and dependency-free.
+
+/** Decode a WAV/RIFF Uint8Array to { samples: Float32Array (interleaved),
+ *  sampleRate, channels }. Supports PCM 8/16/24/32-bit and IEEE float 32/64. */
+export function decodeWav(bytes) {
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const tag = (o) => String.fromCharCode(bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]);
+  if (bytes.length < 12 || tag(0) !== "RIFF" || tag(8) !== "WAVE") {
+    throw new Error("not a RIFF/WAVE file");
+  }
+  let format = 1, channels = 1, sampleRate = 0, bits = 16;
+  let dataStart = -1, dataSize = 0;
+  let pos = 12;
+  while (pos + 8 <= bytes.length) {
+    const id = tag(pos);
+    const size = dv.getUint32(pos + 4, true);
+    const body = pos + 8;
+    if (id === "fmt ") {
+      format = dv.getUint16(body, true);
+      channels = Math.max(1, dv.getUint16(body + 2, true));
+      sampleRate = dv.getUint32(body + 4, true);
+      bits = dv.getUint16(body + 14, true);
+      if (format === 0xfffe && body + 26 <= bytes.length) format = dv.getUint16(body + 24, true);
+    } else if (id === "data") {
+      dataStart = body;
+      dataSize = Math.min(size, bytes.length - body);
+    }
+    pos = body + size + (size & 1);
+  }
+  if (dataStart < 0 || sampleRate <= 0) throw new Error("no data/fmt chunk");
+
+  const bytesPer = bits / 8;
+  const count = Math.floor(dataSize / bytesPer);
+  const out = new Float32Array(count);
+  if (format === 3) {
+    if (bits === 32) for (let i = 0; i < count; i++) out[i] = dv.getFloat32(dataStart + i * 4, true);
+    else if (bits === 64) for (let i = 0; i < count; i++) out[i] = dv.getFloat64(dataStart + i * 8, true);
+    else throw new Error(`float ${bits}-bit unsupported`);
+  } else if (format === 1) {
+    if (bits === 8) for (let i = 0; i < count; i++) out[i] = (bytes[dataStart + i] - 128) / 128;
+    else if (bits === 16) for (let i = 0; i < count; i++) out[i] = dv.getInt16(dataStart + i * 2, true) / 32768;
+    else if (bits === 24)
+      for (let i = 0; i < count; i++) {
+        const o = dataStart + i * 3;
+        let v = bytes[o] | (bytes[o + 1] << 8) | (bytes[o + 2] << 16);
+        if (v & 0x800000) v |= ~0xffffff;
+        out[i] = v / 8388608;
+      }
+    else if (bits === 32) for (let i = 0; i < count; i++) out[i] = dv.getInt32(dataStart + i * 4, true) / 2147483648;
+    else throw new Error(`PCM ${bits}-bit unsupported`);
+  } else {
+    throw new Error(`format tag ${format} unsupported`);
+  }
+  return { samples: out, sampleRate, channels };
+}
+
+/** Average interleaved channels down to a mono Float32Array. */
+export function mixdownMono(interleaved, channels) {
+  if (channels <= 1) return interleaved;
+  const frames = Math.floor(interleaved.length / channels);
+  const out = new Float32Array(frames);
+  const inv = 1 / channels;
+  for (let f = 0; f < frames; f++) {
+    let acc = 0;
+    const base = f * channels;
+    for (let c = 0; c < channels; c++) acc += interleaved[base + c];
+    out[f] = acc * inv;
+  }
+  return out;
+}
+
+/** Linearly resample mono `x` from `from` Hz to `to` Hz. */
+export function resampleLinear(x, from, to) {
+  if (from <= 0 || to <= 0 || from === to || x.length < 2) return x;
+  const outCount = Math.round(x.length * (to / from));
+  if (outCount <= 0) return new Float32Array(0);
+  const out = new Float32Array(outCount);
+  const step = from / to;
+  for (let i = 0; i < outCount; i++) {
+    const src = i * step;
+    const i0 = Math.floor(src);
+    if (i0 >= x.length - 1) { out[i] = x[x.length - 1]; continue; }
+    const frac = src - i0;
+    out[i] = x[i0] * (1 - frac) + x[i0 + 1] * frac;
+  }
+  return out;
+}

--- a/js/test/audio.test.mjs
+++ b/js/test/audio.test.mjs
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { decodeWav, mixdownMono, resampleLinear } from "../index.js";
+import { installAudioHost } from "../node.js";
+
+// Build a minimal 16-bit PCM WAV in JS (mirror of Swift WAV.encode) so the test
+// needs no fixture file.
+function encodeWav(samples, sampleRate, channels = 1) {
+  const dataSize = samples.length * 2;
+  const buf = new ArrayBuffer(44 + dataSize);
+  const dv = new DataView(buf);
+  const tag = (o, s) => { for (let i = 0; i < s.length; i++) dv.setUint8(o + i, s.charCodeAt(i)); };
+  tag(0, "RIFF"); dv.setUint32(4, 36 + dataSize, true); tag(8, "WAVE");
+  tag(12, "fmt "); dv.setUint32(16, 16, true); dv.setUint16(20, 1, true);
+  dv.setUint16(22, channels, true); dv.setUint32(24, sampleRate, true);
+  dv.setUint32(28, sampleRate * channels * 2, true); dv.setUint16(32, channels * 2, true);
+  dv.setUint16(34, 16, true); tag(36, "data"); dv.setUint32(40, dataSize, true);
+  for (let i = 0; i < samples.length; i++) {
+    const v = Math.max(-1, Math.min(1, samples[i]));
+    dv.setInt16(44 + i * 2, Math.round(v * 32767), true);
+  }
+  return new Uint8Array(buf);
+}
+
+const tone = (n, freq = 440, sr = 16000) =>
+  Float32Array.from({ length: n }, (_, i) => 0.5 * Math.sin((2 * Math.PI * freq * i) / sr));
+
+test("decodeWav round-trips 16-bit PCM within quantization error", () => {
+  const x = tone(2000);
+  const { samples, sampleRate, channels } = decodeWav(encodeWav(x, 16000, 1));
+  assert.equal(sampleRate, 16000);
+  assert.equal(channels, 1);
+  assert.equal(samples.length, x.length);
+  let maxErr = 0;
+  for (let i = 0; i < x.length; i++) maxErr = Math.max(maxErr, Math.abs(x[i] - samples[i]));
+  assert.ok(maxErr < 1e-3, `maxErr ${maxErr}`);
+});
+
+test("stereo mixdown averages channels", () => {
+  const interleaved = Float32Array.from({ length: 200 }, (_, i) => (i % 2 === 0 ? 0.5 : -0.5));
+  const mono = mixdownMono(interleaved, 2);
+  assert.equal(mono.length, 100);
+  assert.ok(mono.every((v) => Math.abs(v) < 1e-6));
+});
+
+test("resampleLinear roughly doubles length from 8k to 16k", () => {
+  const y = resampleLinear(tone(800, 440, 8000), 8000, 16000);
+  assert.ok(Math.abs(y.length - 1600) <= 4, `len ${y.length}`);
+});
+
+test("installAudioHost decodes bytes to mono at the target rate (node)", async () => {
+  const host = installAudioHost();
+  const wav = encodeWav(tone(1600, 440, 8000), 8000, 1);
+  const mono = await host.decode(null, wav, 16000);
+  assert.ok(mono instanceof Float32Array);
+  assert.ok(Math.abs(mono.length - 3200) <= 8, `len ${mono.length}`); // 1600 @ 8k -> ~3200 @ 16k
+});

--- a/js/test/entries.test.mjs
+++ b/js/test/entries.test.mjs
@@ -18,6 +18,10 @@ test("browser-safe entry exports the expected surface", async () => {
     "browserWasmDir",
     "browserReadModelSource",
     "browserCacheRoot",
+    "installAudioHost",
+    "decodeWav",
+    "mixdownMono",
+    "resampleLinear",
   ]) {
     assert.equal(typeof core[name], "function", `exports ${name}`);
   }
@@ -34,6 +38,7 @@ test("node entry exports the native loader + node seam", async () => {
     "nodeCacheRoot",
     "FfiReader",
     "FfiWriter",
+    "installAudioHost",
   ]) {
     assert.equal(typeof node[name], "function", `exports ${name}`);
   }

--- a/kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt
+++ b/kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt
@@ -1,9 +1,13 @@
 package ai.desertant.core
 
 import android.content.SharedPreferences
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
 import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
 import java.io.File
+import java.nio.ByteOrder
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.ByteBuffer
@@ -165,6 +169,143 @@ object HostBridge {
      * Implemented natively (desert-ant-core Inference); requires the SDK's .so loaded.
      */
     @JvmStatic external fun flushUsage()
+
+    /**
+     * Decode an audio file (any container/codec MediaCodec supports) to mono
+     * `Float` PCM at [sampleRate], the counterpart of Swift AudioIO's decode on
+     * Android. Pass the file path as [pathUtf8], or the file bytes as [data]
+     * (staged to a temp file, since MediaExtractor reads a path/fd). Returns the
+     * length-prefixed FFI buffer AudioIO expects: big-endian u32 body length,
+     * then u32 sample rate, then a float32 array (u32 count, then big-endian
+     * floats). Empty result on failure ("leave it to the caller").
+     */
+    @JvmStatic
+    fun audioDecode(pathUtf8: ByteArray?, data: ByteArray?, sampleRate: Double): ByteArray {
+        var temp: File? = null
+        return try {
+            val path = when {
+                pathUtf8 != null -> pathUtf8.toString(Charsets.UTF_8)
+                data != null -> {
+                    val f = File.createTempFile("dal-audio", ".bin")
+                    f.writeBytes(data)
+                    temp = f
+                    f.absolutePath
+                }
+                else -> return ByteArray(0)
+            }
+            val (pcm, srcRate, channels) = decodePcmMono16(path)
+            val mono = if (channels > 1) mixdownMono(pcm, channels) else pcm
+            val resampled = resampleLinear(mono, srcRate.toDouble(), sampleRate)
+            encodeAudioBuffer(sampleRate.toInt(), resampled)
+        } catch (e: Exception) {
+            ByteArray(0)
+        } finally {
+            temp?.delete()
+        }
+    }
+
+    // Decode via MediaExtractor + MediaCodec to interleaved 16-bit PCM ->
+    // Float in [-1, 1]. Synchronous (dequeue) loop; the model SDKs decode whole
+    // files, not streams.
+    private fun decodePcmMono16(path: String): Triple<FloatArray, Int, Int> {
+        val extractor = MediaExtractor()
+        extractor.setDataSource(path)
+        var track = -1
+        var format: MediaFormat? = null
+        for (i in 0 until extractor.trackCount) {
+            val f = extractor.getTrackFormat(i)
+            if (f.getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true) {
+                track = i; format = f; break
+            }
+        }
+        if (track < 0 || format == null) { extractor.release(); throw IllegalStateException("no audio track") }
+        extractor.selectTrack(track)
+        val srcRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        val channels = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+        val mime = format.getString(MediaFormat.KEY_MIME)!!
+
+        val codec = MediaCodec.createDecoderByType(mime)
+        codec.configure(format, null, null, 0)
+        codec.start()
+        val info = MediaCodec.BufferInfo()
+        val out = ArrayList<Float>()
+        var sawInputEnd = false
+        var sawOutputEnd = false
+        while (!sawOutputEnd) {
+            if (!sawInputEnd) {
+                val inIndex = codec.dequeueInputBuffer(10_000)
+                if (inIndex >= 0) {
+                    val buf = codec.getInputBuffer(inIndex)!!
+                    val size = extractor.readSampleData(buf, 0)
+                    if (size < 0) {
+                        codec.queueInputBuffer(inIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                        sawInputEnd = true
+                    } else {
+                        codec.queueInputBuffer(inIndex, 0, size, extractor.sampleTime, 0)
+                        extractor.advance()
+                    }
+                }
+            }
+            val outIndex = codec.dequeueOutputBuffer(info, 10_000)
+            if (outIndex >= 0) {
+                if (info.size > 0) {
+                    val buf = codec.getOutputBuffer(outIndex)!!
+                    buf.position(info.offset)
+                    buf.limit(info.offset + info.size)
+                    val shorts = buf.order(ByteOrder.LITTLE_ENDIAN).asShortBuffer()
+                    while (shorts.hasRemaining()) out.add(shorts.get() / 32768f)
+                }
+                codec.releaseOutputBuffer(outIndex, false)
+                if (info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) sawOutputEnd = true
+            }
+        }
+        codec.stop(); codec.release(); extractor.release()
+        return Triple(out.toFloatArray(), srcRate, channels)
+    }
+
+    private fun mixdownMono(interleaved: FloatArray, channels: Int): FloatArray {
+        val frames = interleaved.size / channels
+        val out = FloatArray(frames)
+        val inv = 1f / channels
+        for (f in 0 until frames) {
+            var acc = 0f
+            val base = f * channels
+            for (c in 0 until channels) acc += interleaved[base + c]
+            out[f] = acc * inv
+        }
+        return out
+    }
+
+    private fun resampleLinear(x: FloatArray, from: Double, to: Double): FloatArray {
+        if (from <= 0 || to <= 0 || from == to || x.size < 2) return x
+        val outCount = Math.round(x.size * (to / from)).toInt()
+        if (outCount <= 0) return FloatArray(0)
+        val out = FloatArray(outCount)
+        val step = from / to
+        for (i in 0 until outCount) {
+            val src = i * step
+            val i0 = src.toInt()
+            if (i0 >= x.size - 1) { out[i] = x[x.size - 1]; continue }
+            val frac = (src - i0).toFloat()
+            out[i] = x[i0] * (1 - frac) + x[i0 + 1] * frac
+        }
+        return out
+    }
+
+    // FFI buffer: big-endian u32 body length, then u32 sample rate, then an
+    // f32 array (u32 count + big-endian floats), matching Swift's FFIReader.
+    private fun encodeAudioBuffer(sampleRate: Int, samples: FloatArray): ByteArray {
+        val body = ByteArrayOutputStream()
+        DataOutputStream(body).use { d ->
+            d.writeInt(sampleRate)
+            d.writeInt(samples.size)
+            for (v in samples) d.writeFloat(v)
+        }
+        val tree = body.toByteArray()
+        val out = ByteArrayOutputStream()
+        DataOutputStream(out).use { it.writeInt(tree.size); it.write(tree) }
+        return out.toByteArray()
+    }
 
     @JvmStatic
     fun jsonParseTree(jsonUtf8: ByteArray): ByteArray {

--- a/mise.toml
+++ b/mise.toml
@@ -193,6 +193,10 @@ SWIFT_VER=$(swift --version 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-
 [ -n "$SWIFT_VER" ] || { echo "error: could not determine the Swift version" >&2; exit 1; }
 SDK=${WASM_SDK:-swift-$SWIFT_VER-RELEASE_wasm}
 
+# Adds JavaScriptKit to the manifest (see Package.swift): it is opt-in so that
+# non-wasm consumers do not resolve it and build its swift-syntax macros.
+export DAL_WASM_BUILD=1
+
 # SwiftPM's SDK dir varies by host: ~/.swiftpm (macOS), ~/.config/swiftpm (Linux).
 have_bundle() { for d in "$HOME/.swiftpm/swift-sdks" "$HOME/.config/swiftpm/swift-sdks" "$HOME/Library/org.swift.swiftpm/swift-sdks"; do [ -d "$d/$1" ] && return 0; done; return 1; }
 if ! have_bundle "$SDK.artifactbundle"; then

--- a/mise.toml
+++ b/mise.toml
@@ -161,6 +161,11 @@ tools = { swift = "6.3.3" }
 run = """
 set -euo pipefail
 
+# Adds JavaScriptKit to the manifest, which is what declares the *Web products
+# (see Package.swift). Without it they do not exist and this fails with
+# "no product named 'EmoWeb'"; every wasm-building task must export it.
+export DAL_WASM_BUILD=1
+
 SWIFT_VER=$(swift --version 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]/){print $i; exit}}')
 [ -n "$SWIFT_VER" ] || { echo "error: could not determine the Swift version" >&2; exit 1; }
 SDK=${WASM_SDK:-swift-$SWIFT_VER-RELEASE_wasm}
@@ -174,7 +179,8 @@ if ! have_bundle "$SDK.artifactbundle"; then
     rm -rf "$tmp"
 fi
 
-swift build --swift-sdk "$SDK" --product EmoWeb --product RedactWeb
+# One --product per model in Package.swift's `models` list.
+swift build --swift-sdk "$SDK" --product EmoWeb --product RedactWeb --product ClearWeb
 """
 
 [tasks.test-wasi]

--- a/sdk-build/model-sdk.toml
+++ b/sdk-build/model-sdk.toml
@@ -116,6 +116,10 @@ SWIFT_VER=$(swift --version 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-
 [ -n "$SWIFT_VER" ] || { echo "error: could not determine the Swift version" >&2; exit 1; }
 SDK=${WASM_SDK:-swift-$SWIFT_VER-RELEASE_wasm}
 
+# Adds JavaScriptKit to the desert-ant-core manifest (SwiftPM re-evaluates it in
+# this process env). It is opt-in so non-wasm consumers never resolve it.
+export DAL_WASM_BUILD=1
+
 have_bundle() { for d in "$HOME/.swiftpm/swift-sdks" "$HOME/.config/swiftpm/swift-sdks" "$HOME/Library/org.swift.swiftpm/swift-sdks"; do [ -d "$d/$1" ] && return 0; done; return 1; }
 if ! have_bundle "$SDK.artifactbundle"; then
     echo "Installing the Swift WebAssembly SDK $SWIFT_VER (one-time)..."


### PR DESCRIPTION
Brings the standalone Clear speech-enhancement SDK into this repo as an in-repo model module, on the same mechanisms every other model uses. Also merges audio-primitives (which Clear needs) and makes JavaScriptKit opt-in.

 ### What's in it

 JavaScriptKit is now opt-in (077a511). A package dependency can't carry a platform condition, so every consumer — iOS, macOS, Android — cloned
 JavaScriptKit and built its swift-syntax macro plugins for code that is entirely #if os(WASI). Only builds that set DAL_WASM_BUILD=1 (mise
 test-wasi, build-web) resolve it now.

 AudioIO / AudioDSP merged from audio-primitives (f3ad9c1), and added to the DesertAnt umbrella. Two conflicts resolved deliberately: the
 bounds-checked FFIReader kept (gaining the branch's lengthPrefixed init, f32, f32Array), and DAL_COREML_COMPUTE_UNITS now takes precedence over
 a caller's requested ComputeUnits.

 Clear as a catalog model (28e42cc, bb83fbb) — Sources/ModelCatalog/Clear/:
 - ClearModel: ModelDeclaration, so it downloads/adopts/verifies through the shared model store
 - usage-tracked sessions via the session factory; opt-in app bundling; ClearWeb wasm entry point with the same load/loadBundled/flushTelemetry
   surface as the other models
 - Clear.Mastering + LoudnessPreset (Apple Podcasts / Spotify / YouTube / EBU R128), same case names and raw values as the standalone SDK
 - ProgressHandler with the same Phase cases and order, so consumer switches stay exhaustive
 - ModelVariant (clear-studio / clear-natural) that actually selects files, reported on Result.modelVariant

 FFI layer moved out of the model modules. Each model's BoundModel conformance now lives in Bindings beside the C ABI and JNI entry points.
 Previously a Swift-only app compiled and linked the cross-language layer for a conformance it never calls — and Xcode built FFIBuffer.o but
 omitted it from every link list, so an app extension linking Clear failed with undefined FFIBuffer symbols. Emo and Redact had the same latent
 bug and moved too.

 Clear is the first audio model, so BoundModel gained run(audio:sampleRate:options:) behind a new dal_run_audio symbol and its JNI entry — still
 one native library, no per-model symbols.

 ### Deliberately not done
 - forceMono / stereo dropped — the pipeline is mono end to end; a forceMono: false that silently downmixes would be a lie.
 - loudnessRangeLU carried but not enforced — no range compressor in the loudness stage; documented inline so .broadcast still round-trips its published spec.