### PR TITLE
Run every model through one Hub download scenario

### DIFF
--- a/Tests/EmoTests/HubDownloadTests.swift
+++ b/Tests/EmoTests/HubDownloadTests.swift
@@ -1,32 +1,24 @@
 #if !os(WASI)
-import Foundation
 import XCTest
+import TestSupport
 @testable import Emo
 
-/// End-to-end: download the model from the Hub (no bundled resources), then run
-/// a real suggestion. Network + the real model, so opt-in via HF_INTEGRATION=1.
-/// The non-Apple path needs `emo.tflite` published on the model repo at the
-/// pinned revision (Apple uses `emo.mlmodelc`).
 final class HubDownloadTests: XCTestCase {
     func testDownloadThenSuggest() async throws {
-        try XCTSkipUnless(ProcessInfo.processInfo.environment["HF_INTEGRATION"] == "1",
-                          "set HF_INTEGRATION=1 to run the network test")
-        let tmp = NSTemporaryDirectory() + "emo-hub-\(UUID().uuidString)"
-        defer { try? FileManager.default.removeItem(atPath: tmp) }
+        try await HubDownloadScenario.run(
+            EmoModel.self,
+            make: { Emo(directory: $0) },
+            isDownloaded: { $0.isDownloaded() },
+            download: { try await $0.download(progress: $1) }
+        ) { emo, cached in
+            let suggestions = try await emo.suggestions(for: "Pay my bills", limit: 3)
+            XCTAssertEqual(suggestions.count, 3)
 
-        let emo = Emo(directory: tmp)
-        XCTAssertFalse(emo.isDownloaded())
-        try await emo.download { print("download \(Int($0 * 100))%") }
-        XCTAssertTrue(emo.isDownloaded())
-
-        let suggestions = try await emo.suggestions(for: "Pay my bills", limit: 3)
-        XCTAssertEqual(suggestions.count, 3)
-
-        // A second suggester loads from the cache with no network.
-        let cached = Emo(directory: tmp)
-        XCTAssertTrue(cached.isDownloaded())
-        let flight = try await cached.suggestions(for: "book a flight to Tokyo", limit: 5).map(\.emoji)
-        XCTAssertTrue(flight.contains("✈️"), "got \(flight)")
+            let flight = try await cached
+                .suggestions(for: "book a flight to Tokyo", limit: 5)
+                .map(\.emoji)
+            XCTAssertTrue(flight.contains("✈️"), "got \(flight)")
+        }
     }
 }
 #endif

--- a/Tests/RedactTests/HubDownloadTests.swift
+++ b/Tests/RedactTests/HubDownloadTests.swift
@@ -1,30 +1,32 @@
 #if !os(WASI)
 import XCTest
-import Foundation
+import TestSupport
 @testable import Redact
 
-/// End-to-end: download the model from the Hub (no bundled resources), then run
-/// a real redaction. Network + the real model, so opt-in via HF_INTEGRATION=1.
 final class HubDownloadTests: XCTestCase {
     func testDownloadThenRedact() async throws {
-        try XCTSkipUnless(ProcessInfo.processInfo.environment["HF_INTEGRATION"] == "1",
-                          "set HF_INTEGRATION=1 to run the network test")
-        let tmp = NSTemporaryDirectory() + "redact-hub-\(UUID().uuidString)"
-        defer { try? FileManager.default.removeItem(atPath: tmp) }
+        try await HubDownloadScenario.run(
+            RedactModel.self,
+            make: { Redact(directory: $0) },
+            isDownloaded: { $0.isDownloaded() },
+            download: { try await $0.download(progress: $1) }
+        ) { redact, cached in
+            let result = try await redact.redaction(
+                of: "Email Anna Kovács at anna@example.com about the invoice."
+            )
+            XCTAssertTrue(result.redactedText.contains("[EMAIL_1]"), result.redactedText)
+            XCTAssertTrue(result.redactedText.contains("[GIVEN_NAME_1]"), result.redactedText)
+            XCTAssertEqual(
+                result.items.first { $0.label.rawValue == "EMAIL" }?.original,
+                "anna@example.com"
+            )
 
-        let redact = Redact(directory: tmp)
-        XCTAssertFalse(redact.isDownloaded())
-        try await redact.download { print("download \(Int($0 * 100))%") }
-        XCTAssertTrue(redact.isDownloaded())  // offline check, verified
-        let r = try await redact.redaction(of: "Email Anna Kovács at anna@example.com about the invoice.")
-        XCTAssertTrue(r.redactedText.contains("[EMAIL_1]"), r.redactedText)
-        XCTAssertTrue(r.redactedText.contains("[GIVEN_NAME_1]"), r.redactedText)
-        XCTAssertEqual(r.items.first { $0.label.rawValue == "EMAIL" }?.original, "anna@example.com")
-
-        // A second redactor loads from the cache with no network.
-        let cached = Redact(directory: tmp)
-        let r2 = try await cached.redaction(of: "Card 4111111111111111.")
-        XCTAssertTrue(r2.redactedText.contains("[CREDIT_CARD_1]"), r2.redactedText)
+            let cachedResult = try await cached.redaction(of: "Card 4111111111111111.")
+            XCTAssertTrue(
+                cachedResult.redactedText.contains("[CREDIT_CARD_1]"),
+                cachedResult.redactedText
+            )
+        }
     }
 }
 #endif

--- a/Tests/TestSupport/HubDownloadScenario.swift
+++ b/Tests/TestSupport/HubDownloadScenario.swift
@@ -1,0 +1,57 @@
+#if !os(WASI)
+import Foundation
+import XCTest
+import DesertAnt
+
+/// The Hub integration scenario shared by every model SDK.
+public enum HubDownloadScenario {
+    /// Download through the public SDK, verify its offline checks, construct a
+    /// second SDK over the same directory, then run model-specific assertions.
+    public static func run<Declaration: ModelDeclaration, SDK>(
+        _ declaration: Declaration.Type,
+        make: (String) -> SDK,
+        isDownloaded: (SDK) -> Bool,
+        download: (SDK, @escaping @Sendable (Double) -> Void) async throws -> Void,
+        verify: (SDK, SDK) async throws -> Void
+    ) async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["HF_INTEGRATION"] == "1",
+            "set HF_INTEGRATION=1 to run the network test"
+        )
+
+        let directory = NSTemporaryDirectory() + "\(declaration.id)-hub-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        let first = make(directory)
+        XCTAssertFalse(isDownloaded(first))
+        XCTAssertFalse(declaration.isAvailable(directory: directory))
+
+        let progress = ProgressValues()
+        try await download(first) { progress.append($0) }
+
+        let values = progress.snapshot
+        XCTAssertEqual(values.last, 1)
+        XCTAssertTrue(values.allSatisfy { (0...1).contains($0) })
+        XCTAssertEqual(values, values.sorted(), "download progress must be monotonic")
+        XCTAssertTrue(isDownloaded(first))
+        XCTAssertTrue(declaration.isAvailable(directory: directory))
+
+        let cached = make(directory)
+        XCTAssertTrue(isDownloaded(cached))
+        try await verify(first, cached)
+    }
+}
+
+private final class ProgressValues: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Double] = []
+
+    func append(_ value: Double) {
+        lock.withLock { values.append(value) }
+    }
+
+    var snapshot: [Double] {
+        lock.withLock { values }
+    }
+}
+#endif


### PR DESCRIPTION
Emo and Redact each implemented the same Hub integration lifecycle:

1. require `HF_INTEGRATION=1`
2. create and later remove a model-named temporary directory
3. construct the public SDK over that directory and assert unavailable
4. download through the public SDK
5. assert available offline
6. construct a second SDK over the same directory
7. run real inference through both instances

Only step 7's typed assertions differed.

## Shared scenario

`TestSupport.HubDownloadScenario.run` is generic over the model's
`ModelDeclaration` and SDK type. Each suite supplies its constructor plus tiny
`isDownloaded` and `download` adapters, then receives the first and cached SDKs
for model-specific inference assertions:

```swift
try await HubDownloadScenario.run(
    EmoModel.self,
    make: { Emo(directory: $0) },
    isDownloaded: { $0.isDownloaded() },
    download: { try await $0.download(progress: $1) }
) { emo, cached in
    // Emo-specific inference assertions only
}
```

A future model gets the complete download/cache integration scenario without
copying its environment gate, filesystem lifecycle, or generic assertions.

## Stronger shared invariants

In addition to preserving the old checks, every model now verifies that:

- `ModelDeclaration.isAvailable` agrees with the SDK's public
  `isDownloaded()` before and after download
- a newly constructed SDK reports the downloaded directory available before
  loading it
- every progress fraction is in `0...1`
- progress is monotonic and ends at exactly `1`

Progress collection is lock-protected because the callback is `@Sendable`.

## Verification

On pv-studio:

- `HF_INTEGRATION=1 swift test --filter HubDownloadTests`: both tests passed
  against fresh explicit directories, including real Redact and Emo inference
  from the second cached SDK, 25.8 seconds total
- regular opt-out run: both tests reported skipped, 0 failures
- wasm suite: 66 tests in 14 suites passed
- full host suite: 87 tests; only the 2 pre-existing HTTPClientTests failures
  that require the echo server started by `mise run test-macos`

Remote scratch directory cleaned afterward.
