### PR TITLE
Stop the Android harness compiling every core Kotlin file

### DIFF
--- a/androidtest/build.gradle.kts
+++ b/androidtest/build.gradle.kts
@@ -32,10 +32,15 @@ android {
         jvmTarget = "17"
     }
 
-    // Reuse the shared host bridge (regexMatches / jsonParseTree) verbatim.
-    sourceSets["main"].java.srcDir("../kotlin/src/main/kotlin")
     // libCoreAndroidTests.so + libc++_shared.so are staged here by the mise task.
     sourceSets["main"].jniLibs.srcDir("src/main/jniLibs")
+}
+
+// Reuse HostBridge without compiling unrelated core Kotlin sources.
+kotlin.sourceSets.named("main") {
+    kotlin.srcDir("../kotlin/src/main/kotlin")
+    kotlin.include("ai/desertant/core/HostBridge.kt")
+    kotlin.include("ai/desertant/core/androidtest/**")
 }
 
 dependencies {


### PR DESCRIPTION
## Root cause

The Android instrumentation harness says it reuses `HostBridge.kt`, but its
source set actually included the entire `kotlin/src/main/kotlin` tree:

```kotlin
sourceSets["main"].java.srcDir("../kotlin/src/main/kotlin")
```

That happened to work until 67278898 added `LoadedModel.kt`. The harness then
compiled `LoadedModel` too, despite never using it, and failed because
`androidtest` correctly has no coroutines dependency:

```
LoadedModel.kt:5:16 Unresolved reference: coroutines
LoadedModel.kt:98:48 Unresolved reference: Dispatchers
LoadedModel.kt:112:17 Unresolved reference: withContext
```

It was also compiling `DesertAntNative.kt`, another class outside this harness's
scope.

## Fix

Configure the Kotlin source set directly, adding the shared source root but
including only `ai/desertant/core/HostBridge.kt` and the harness's own package.
This restores the intended dependency boundary instead of adding coroutines for
code the test never exercises. Future unrelated files added to the core Kotlin
artifact can no longer break this harness.

## Verification

With Android SDK 35, both now pass cleanly:

- `compileDebugKotlin`
- `compileDebugAndroidTestKotlin`

The resulting main classes are exactly:

- `HostBridge`
- `FfiReader`
- `FfiWriter`
- the harness's `CoreBridge`

`LoadedModel` and `DesertAntNative` are absent.
