### PR TITLE
Keep the README accurate as models are added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Desert Ant Core
 
-On-device AI SDKs for Swift, Kotlin, and JavaScript. Suggest emoji, redact
-personal data, and clean up noisy speech directly on the user's phone, Mac, or
-browser tab. Every model runs locally through Core ML on Apple, LiteRT (formerly
-TensorFlow Lite) on Android, and WebAssembly with LiteRT.js on the web, so text
-and audio never leave the device.
+On-device AI SDKs for Swift, Kotlin, and JavaScript. Small, focused models that
+run directly on the user's phone, Mac, or browser tab, through Core ML on Apple,
+LiteRT (formerly TensorFlow Lite) on Android, and WebAssembly with LiteRT.js on
+the web, so text, audio, and images never leave the device.
 
 ```swift
 import Emo
@@ -38,7 +37,9 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 | **Clear** | Speech enhancement: denoise, dereverb, podcast-ready 48 kHz | `Clear` | soon | soon | [Hugging Face](https://huggingface.co/desert-ant-labs/clear) |
 
 Each model behaves the same on every platform, so you can build a feature once
-and ship it everywhere.
+and ship it everywhere. New models are added regularly; the current set is always
+this table, and the weights live on [Hugging
+Face](https://huggingface.co/desert-ant-labs).
 
 ## Swift
 
@@ -52,8 +53,8 @@ Add the package with Swift Package Manager:
 .package(url: "https://github.com/Desert-Ant-Labs/desert-ant-core.git", from: "0.5.5")
 ```
 
-Then add the products you want to your app target: `Emo`, `Redact`, `Clear`. You
-only pay for what you add, so an Emo-only app carries nothing from the others.
+Then add a product per model you want, named as in the table above. You only pay
+for what you add, so an Emo-only app carries nothing from the other models.
 
 ### Usage
 
@@ -163,6 +164,8 @@ dependencies {
 }
 ```
 
+One dependency per model, using the coordinates from the table above.
+
 ### Usage
 
 `suggestions`, `redaction`, and `download` are suspending functions. A model owns
@@ -200,6 +203,8 @@ val offline = Emo(context, directory = myModelDir)   // adopted as-is, nothing d
 ## JavaScript and TypeScript
 
 ### Install
+
+Each model is its own package, so install the ones you use:
 
 ```bash
 # Browser (WebAssembly + LiteRT.js):


### PR DESCRIPTION
Adding a model should not mean editing the first paragraph of the README. It did: the opening sentence named emoji suggestion, PII redaction, and speech enhancement, and both install sections listed the products and coordinates by name.

## README

| Was | Now |
|---|---|
| "Suggest emoji, redact personal data, and clean up noisy speech..." | "Small, focused models that run directly on the user's phone, Mac, or browser tab..." |
| "add the products you want: `Emo`, `Redact`, `Clear`" | "add a product per model you want, named as in the table above" |
| Gradle block with no context | plus "One dependency per model, using the coordinates from the table above." |
| npm block with no context | plus "Each model is its own package, so install the ones you use" |

The model table is now the single place the current set lives, with a line noting that new models are added regularly and linking to the weights on Hugging Face. The existing snippets stay as examples, since a reader still wants to see a real coordinate.

## Repository metadata

Description, which previously named the three capabilities:

> On-device AI SDKs for iOS, macOS, Android, and the web. Small, focused models that run fully offline in Swift, Kotlin, and JavaScript with Core ML, LiteRT, and WebAssembly.

Topics keep the platform and runtime terms and swap the three model-specific ones for `edge-ai`, `inference`, and `sdk`, which stay accurate as the catalog grows. Ten of the twenty still match `emo`, `redact`, and `shapes`, so the repos keep clustering on the same topic pages.

Both are already applied, since they are repository settings rather than files in this diff.
