### PR TITLE
Release model SDKs from this monorepo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build
 
-# Verify desert-ant-core's three published artifacts actually build. The Swift
-# package is covered per-platform by macos/ios/wasi/android.yml; these are the
-# non-Swift artifacts, which previously only ever built during a publish - so a
-# break in them stayed invisible until release time.
+# Verify desert-ant-core's three published artifacts actually build, and that
+# every artifact in the repo still carries one version. The Swift package is
+# covered per-platform by macos/ios/wasi/android.yml; these are the non-Swift
+# artifacts, which previously only ever built during a publish - so a break in
+# them stayed invisible until release time. Version drift had the same problem.
 
 on:
   push:
@@ -19,6 +20,17 @@ permissions:
   contents: read
 
 jobs:
+  versions:
+    name: one version everywhere
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          install: false
+      # Drift is only a release-time problem if nothing checks it before then.
+      - run: mise run check-version
+
   kotlin:
     name: ai.desertant:core (Android AAR)
     runs-on: ubuntu-latest

--- a/.github/workflows/model-sdk-release.yml
+++ b/.github/workflows/model-sdk-release.yml
@@ -102,9 +102,9 @@ jobs:
             exit 0
           fi
 
-          # Every artifact ships at every release: the model packages pin core
-          # exactly, so a skipped version would leave a package pinning a core
-          # that was never published.
+          # Every artifact ships at every release: the model packages depend on
+          # core at this version, so a skipped one would leave a package
+          # resolving against a core that was never published.
           { echo "android=true"; echo "npm=true"; } >> "$GITHUB_OUTPUT"
 
   # ------------------------------------------------------------------ Android

--- a/.github/workflows/model-sdk-release.yml
+++ b/.github/workflows/model-sdk-release.yml
@@ -57,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       model: ${{ steps.g.outputs.model }}
+      product: ${{ steps.g.outputs.product }}
+      mise_env: ${{ steps.g.outputs.mise_env }}
       version: ${{ steps.g.outputs.version }}
       android: ${{ steps.g.outputs.android }}
       npm: ${{ steps.g.outputs.npm }}
@@ -70,9 +72,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
           MODEL="${{ inputs.model }}"
           [ -n "$MODEL" ] || MODEL="${GITHUB_REPOSITORY##*/}"
           echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+          echo "product=$(printf '%s' "$MODEL" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')" >> "$GITHUB_OUTPUT"
+          # The monorepo keeps model tasks behind MISE_ENV=model.
+          if [ -f mise.model.toml ]; then echo "mise_env=model" >> "$GITHUB_OUTPUT"
+          else echo "mise_env=" >> "$GITHUB_OUTPUT"; fi
 
           # The release version is single-sourced from the npm package; the two
           # Gradle modules must match it (the mise check-version task verifies).
@@ -89,41 +96,16 @@ jobs:
           fi
           echo "dry=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
 
-          TAG="${GITHUB_REF_NAME}"
           if [ "${TAG#v}" != "$VERSION" ]; then
             echo "tag ${TAG} != $MODEL ${VERSION}; publishing nothing." >&2
             { echo "android=false"; echo "npm=false"; } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
-          if [ -z "$PREV" ]; then
-            echo "no previous tag; publishing everything."
-            { echo "android=true"; echo "npm=true"; } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # A path counts as changed if any file under it changed, ignoring
-          # version-only edits to the manifests `mise run set-version` rewrites.
-          changed() { # $@ = paths
-            local files
-            files=$(git diff --name-only "$PREV" "$TAG" -- "$@")
-            [ -n "$files" ] || { echo no; return; }
-            local body
-            body=$(git diff "$PREV" "$TAG" -- "$@" \
-              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
-              | grep -vE '^[+-]version = "' \
-              | grep -vE '^[+-]  "version": "' || true)
-            [ -n "$body" ] && echo yes || echo no
-          }
-          # Sources/ and the manifest are shared by both artifacts (the manifest
-          # pins desert-ant-core, whose code is compiled into both the AAR and the
-          # Node native), so a change to either ships both.
-          AND=$(changed "Sources/" "Package.swift" "Package.resolved" "packages/$MODEL-kotlin/")
-          NPM=$(changed "Sources/" "Package.swift" "Package.resolved" "packages/$MODEL-node/")
-          echo "since ${PREV}: android=$AND npm=$NPM"
-          { echo "android=$([ "$AND" = yes ] && echo true || echo false)"
-            echo "npm=$([ "$NPM" = yes ] && echo true || echo false)"; } >> "$GITHUB_OUTPUT"
+          # Every artifact ships at every release: the model packages pin core
+          # exactly, so a skipped version would leave a package pinning a core
+          # that was never published.
+          { echo "android=true"; echo "npm=true"; } >> "$GITHUB_OUTPUT"
 
   # ------------------------------------------------------------------ Android
 
@@ -132,6 +114,11 @@ jobs:
     needs: gate
     if: needs.gate.outputs.android == 'true'
     runs-on: ubuntu-latest
+    env:
+      # Empty in a model repo, where `[vars]` names the model.
+      MISE_ENV: ${{ needs.gate.outputs.mise_env }}
+      DAL_MODEL: ${{ needs.gate.outputs.model }}
+      DAL_PRODUCT: ${{ needs.gate.outputs.product }}
     environment: maven-central
     steps:
       - uses: actions/checkout@v4
@@ -208,6 +195,11 @@ jobs:
           - target: darwin-arm64
             runner: macos-14
     runs-on: ${{ matrix.runner }}
+    env:
+      # Empty in a model repo, where `[vars]` names the model.
+      MISE_ENV: ${{ needs.gate.outputs.mise_env }}
+      DAL_MODEL: ${{ needs.gate.outputs.model }}
+      DAL_PRODUCT: ${{ needs.gate.outputs.product }}
     steps:
       - uses: actions/checkout@v4
 
@@ -245,6 +237,11 @@ jobs:
     needs: [gate, node-natives]
     if: needs.gate.outputs.npm == 'true'
     runs-on: ubuntu-latest
+    env:
+      # Empty in a model repo, where `[vars]` names the model.
+      MISE_ENV: ${{ needs.gate.outputs.mise_env }}
+      DAL_MODEL: ${{ needs.gate.outputs.model }}
+      DAL_PRODUCT: ${{ needs.gate.outputs.product }}
     environment: npm
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -64,32 +64,8 @@ jobs:
             echo "publish=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
-          if [ -z "$PREV" ]; then
-            echo "no previous tag; publishing ${VERSION}."
-            echo "publish=true" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-
-          # Publish only if kotlin/ actually changed since the previous tag,
-          # counting a pure version bump in build.gradle.kts as no change (so a
-          # blanket set-version that only touches version lines republishes
-          # nothing). Any other changed file - including binaries - counts.
-          files=$(git diff --name-only "$PREV" "$TAG" -- kotlin/)
-          if [ -z "$files" ]; then
-            publish=false
-          elif [ "$files" = "kotlin/build.gradle.kts" ]; then
-            body=$(git diff "$PREV" "$TAG" -- kotlin/build.gradle.kts \
-              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]version = "' || true)
-            [ -n "$body" ] && publish=true || publish=false
-          else
-            publish=true
-          fi
-
-          if [ "$publish" = true ]; then
-            echo "kotlin/ changed since ${PREV}; publishing ${VERSION}."
-          else
-            echo "kotlin/ unchanged since ${PREV} (only the version bump, if any); skipping."
-          fi
+          # One version across the repo: every artifact publishes at every tag.
+          publish=true
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/publish-gradle-plugin.yml
+++ b/.github/workflows/publish-gradle-plugin.yml
@@ -49,30 +49,8 @@ jobs:
             echo "publish=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
-          if [ -z "$PREV" ]; then
-            echo "no previous tag; publishing ${VERSION}."
-            echo "publish=true" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-
-          # Publish only if gradle-plugin/ changed since the previous tag,
-          # counting a pure version bump in build.gradle.kts as no change.
-          files=$(git diff --name-only "$PREV" "$TAG" -- gradle-plugin/)
-          if [ -z "$files" ]; then
-            publish=false
-          elif [ "$files" = "gradle-plugin/build.gradle.kts" ]; then
-            body=$(git diff "$PREV" "$TAG" -- gradle-plugin/build.gradle.kts \
-              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]version = "' || true)
-            [ -n "$body" ] && publish=true || publish=false
-          else
-            publish=true
-          fi
-
-          if [ "$publish" = true ]; then
-            echo "gradle-plugin/ changed since ${PREV}; publishing ${VERSION}."
-          else
-            echo "gradle-plugin/ unchanged since ${PREV} (only the version bump, if any); skipping."
-          fi
+          # One version across the repo: every artifact publishes at every tag.
+          publish=true
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,7 +6,8 @@ name: Publish npm
 #
 # Release model: `mise run set-version X.Y.Z` sets ONE version across every
 # artifact in the repo, you commit and push `vX.Y.Z`, and everything publishes at
-# it. The model packages pin core exactly, so a mismatched pair cannot exist.
+# it. The model packages track core with a caret on that version, so two of
+# them from different releases still resolve to a single copy of core.
 #
 # Organization secret, visibility `all` (set once for the whole org with
 # `gh secret set NPM_TOKEN --org Desert-Ant-Labs --visibility all`), so every SDK
@@ -56,7 +57,7 @@ jobs:
           fi
 
           # Every artifact in the repo ships one version, and the model packages
-          # pin core exactly, so core has to exist at every released version.
+          # depend on core at it, so core has to exist at every released version.
           publish=true
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,16 +1,12 @@
 name: Publish npm
 
-# Publish the @desert-ant-labs/core npm package when a release tag (vX.Y.Z) is
-# pushed, but only if the package actually changed. Pure JS, no build step, so it
-# just runs `mise run publish-npm`. The token comes from the Desert-Ant-Labs
-# organization secrets.
+# Publish the @desert-ant-labs/core npm package on a release tag (vX.Y.Z). Pure
+# JS, no build step, so it just runs `mise run publish-npm`. The token comes from
+# the Desert-Ant-Labs organization secrets.
 #
-# Release model: `mise run set-version X.Y.Z` bumps every artifact's version (so
-# they stay current), you commit and push `vX.Y.Z`, and each publish workflow
-# ships only the artifact whose content changed since the previous tag. A pure
-# version bump does not count as a change, so a blanket set-version that touches
-# nothing but version lines republishes nothing. Published versions may skip
-# (an unchanged artifact keeps its last published version until it next changes).
+# Release model: `mise run set-version X.Y.Z` sets ONE version across every
+# artifact in the repo, you commit and push `vX.Y.Z`, and everything publishes at
+# it. The model packages pin core exactly, so a mismatched pair cannot exist.
 #
 # Organization secret, visibility `all` (set once for the whole org with
 # `gh secret set NPM_TOKEN --org Desert-Ant-Labs --visibility all`), so every SDK
@@ -59,32 +55,9 @@ jobs:
             echo "publish=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
-          if [ -z "$PREV" ]; then
-            echo "no previous tag; publishing ${VERSION}."
-            echo "publish=true" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-
-          # Publish only if js/ actually changed since the previous tag, counting
-          # a pure version bump in package.json as no change (so a blanket
-          # set-version that only touches version lines republishes nothing). Any
-          # other changed file - including binaries - counts.
-          files=$(git diff --name-only "$PREV" "$TAG" -- js/)
-          if [ -z "$files" ]; then
-            publish=false
-          elif [ "$files" = "js/package.json" ]; then
-            body=$(git diff "$PREV" "$TAG" -- js/package.json \
-              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]  "version": "' || true)
-            [ -n "$body" ] && publish=true || publish=false
-          else
-            publish=true
-          fi
-
-          if [ "$publish" = true ]; then
-            echo "js/ changed since ${PREV}; publishing ${VERSION}."
-          else
-            echo "js/ unchanged since ${PREV} (only the version bump, if any); skipping."
-          fi
+          # Every artifact in the repo ships one version, and the model packages
+          # pin core exactly, so core has to exist at every released version.
+          publish=true
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -1,0 +1,66 @@
+name: Publish model SDKs
+
+# Publishes every model SDK on a release tag (vX.Y.Z), alongside core's own
+# artifacts. One version covers the whole repo, so one tag releases all of it.
+#
+# Core goes first, and not just for tidiness: a model's Android build resolves
+# the `ai.desertant.model-sdk` convention plugin and `ai.desertant:core` from
+# Maven Central at the version being released, so it cannot even build until
+# core's publish workflows have landed. The tag starts those in parallel with
+# this one, so wait for them here.
+#
+# Add a model to the matrix when it gains npm/Maven packages.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  core-published:
+    name: wait for core
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - id: v
+        shell: bash
+        run: |
+          set -euo pipefail
+          V="${GITHUB_REF_NAME#v}"
+          echo "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "not a release tag: ${GITHUB_REF_NAME}"; exit 1; }
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for core ${{ steps.v.outputs.version }} on Maven Central and npm
+        shell: bash
+        env:
+          V: ${{ steps.v.outputs.version }}
+        run: |
+          set -uo pipefail
+          M=https://repo1.maven.org/maven2/ai/desertant
+          urls=(
+            "$M/core/$V/core-$V.pom"
+            "$M/model-sdk-gradle-plugin/$V/model-sdk-gradle-plugin-$V.pom"
+            "https://registry.npmjs.org/@desert-ant-labs/core/$V"
+          )
+          for url in "${urls[@]}"; do
+            echo "waiting for $url"
+            for _ in $(seq 1 80); do   # ~40 min at 30s
+              code=$(curl -sS -o /dev/null -w '%{http_code}' -L "$url" || echo 000)
+              [ "$code" = 200 ] && { echo "  ok"; break; }
+              sleep 30
+            done
+            [ "${code:-000}" = 200 ] || { echo "::error::core $V never appeared at $url"; exit 1; }
+          done
+
+  models:
+    needs: core-published
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [redact, emo]
+    uses: ./.github/workflows/model-sdk-release.yml
+    with:
+      model: ${{ matrix.model }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Requirements: iOS 16+, macOS 13+, tvOS 16+, visionOS 1+, and Swift 5.9+.
 Add the package with Swift Package Manager:
 
 ```swift
-.package(url: "https://github.com/Desert-Ant-Labs/desert-ant-core.git", from: "0.5.5")
+.package(url: "https://github.com/Desert-Ant-Labs/desert-ant-core.git", from: "1.0.0")
 ```
 
 Then add a product per model you want, named as in the table above. You only pay

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ dependencyResolutionManagement {
 
 // build.gradle.kts
 dependencies {
-    implementation("ai.desertant:emo:0.10.2")
-    implementation("ai.desertant:redact:0.7.2")
+    implementation("ai.desertant:emo:1.0.0")
+    implementation("ai.desertant:redact:1.0.0")
 }
 ```
 

--- a/Sources/Clear/Catalog.swift
+++ b/Sources/Clear/Catalog.swift
@@ -15,7 +15,7 @@ public enum ClearModel: ModelDeclaration {
     /// No published npm/Maven package yet, so nothing cross-checks this the way
     /// ModelCatalogTests checks emo and redact; keep it in step with
     /// packages/clear-* when they land.
-    public static let sdkVersion = "0.1.0"
+    public static let sdkVersion = "1.0.0"
     public static let summary = "On-device speech enhancement: denoise, dereverb, and loudness-normalize."
 
     /// The variant this declaration describes: the SDK default. The repo also

--- a/Sources/Emo/Catalog.swift
+++ b/Sources/Emo/Catalog.swift
@@ -11,7 +11,7 @@ public enum EmoModel: ModelDeclaration {
     public static let revision = "v0.7.0"
     /// Matches packages/emo-node/package.json and packages/emo-kotlin/build.gradle.kts
     /// (ModelCatalogTests enforces it).
-    public static let sdkVersion = "0.10.2"
+    public static let sdkVersion = "1.0.0"
     public static let summary = "Multilingual on-device emoji suggestion."
 
     /// Labels plus the featurizer/tokenizer constants.

--- a/Sources/Redact/Catalog.swift
+++ b/Sources/Redact/Catalog.swift
@@ -11,7 +11,7 @@ public enum RedactModel: ModelDeclaration {
     public static let revision = "v0.4.0"
     /// Matches packages/redact-node/package.json and
     /// packages/redact-kotlin/build.gradle.kts (ModelCatalogTests enforces it).
-    public static let sdkVersion = "0.8.0"
+    public static let sdkVersion = "1.0.0"
     public static let summary = "Multilingual on-device PII detection and redaction."
 
     /// Compact SentencePiece vocab.

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.6.0"
+version = "1.0.0"
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.7.3")

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/core",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Shared JavaScript runtime for Desert Ant Labs on-device model SDKs: the LiteRT.js host session, the koffi native loader, and the FFI buffer reader that the per-model node packages build on.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 group = "ai.desertant"
-version = "0.5.5"
+version = "1.0.0"
 
 android {
     namespace = "ai.desertant.core"

--- a/mise.model.toml
+++ b/mise.model.toml
@@ -1,0 +1,13 @@
+# Model-SDK tasks for this monorepo, behind `MISE_ENV=model` so they do not
+# shadow core's own publish/version tasks. Which model is a runtime choice:
+#
+#   MISE_ENV=model DAL_MODEL=redact DAL_PRODUCT=Redact mise run publish-web
+
+[tools]
+swift = "6.3.3"
+
+[env]
+DAL_GPU = "" # non-empty ships the LiteRT GPU accelerator siblings
+
+[task_config]
+includes = ["sdk-build/model-sdk.toml"]

--- a/mise.toml
+++ b/mise.toml
@@ -356,6 +356,13 @@ set -euo pipefail
 #   ORG_GRADLE_PROJECT_signingInMemoryKey / ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
 : "${ORG_GRADLE_PROJECT_mavenCentralUsername:?set the Central portal token in mise.local.toml}"
 : "${ORG_GRADLE_PROJECT_signingInMemoryKey:?set the in-memory GPG signing key in mise.local.toml}"
+V=$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' kotlin/build.gradle.kts)
+# Re-runnable: Central rejects a duplicate version, which on a re-run of a
+# partly-failed tag would hide the job that actually failed.
+if curl -sfIL "https://repo1.maven.org/maven2/ai/desertant/core/$V/core-$V.pom" >/dev/null 2>&1; then
+    echo "ai.desertant:core:$V is already published; nothing to do"
+    exit 0
+fi
 ./gradlew -p kotlin publishAndReleaseToMavenCentral --no-configuration-cache
 echo "published: ai.desertant:core:$(mise run check-version)"
 """
@@ -390,9 +397,9 @@ for cat in Sources/*/Catalog.swift; do
     dir="packages/$model-node"
     [ -d "$dir" ] || continue
     check "$(node -p "require('./$dir/package.json').version")" "$dir/package.json"
-    # The model packages pin core exactly, so a published pair can never mismatch.
+    # Caret on this release's core: same train, and npm can dedupe two models.
     pin=$(node -p "require('./$dir/package.json').dependencies?.['@desert-ant-labs/core'] ?? ''")
-    [ -z "$pin" ] || check "$pin" "$dir core dependency"
+    [ -z "$pin" ] || check "${pin#^}" "$dir core dependency"
     kts="packages/$model-kotlin/build.gradle.kts"
     [ ! -f "$kts" ] || {
         check "$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' "$kts")" "$kts"
@@ -425,12 +432,13 @@ echo "$VERSION" | grep -Eq '^[0-9]+\\.[0-9]+\\.[0-9]+$' || { echo "error: versio
 sed -i.bak 's/^version = ".*"$/version = "'"$VERSION"'"/' kotlin/build.gradle.kts && rm -f kotlin/build.gradle.kts.bak
 sed -i.bak 's/^version = ".*"$/version = "'"$VERSION"'"/' gradle-plugin/build.gradle.kts && rm -f gradle-plugin/build.gradle.kts.bak
 ( cd js && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null )
-sed -i.bak -E 's|(ai\\.desertant:core:)[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|g' README.md && rm -f README.md.bak
+# Every ai.desertant coordinate, not just core: the README installs models too.
+sed -i.bak -E 's|(ai\\.desertant:[a-z0-9-]+:)[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|g' README.md && rm -f README.md.bak
 sed -i.bak -E 's|(desert-ant-core\\.git", from: ")[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|' README.md && rm -f README.md.bak
 
 # ---- every model SDK --------------------------------------------------------
-# One version for the whole repo, and the model packages pin core exactly, so a
-# model can never resolve against a core it was not built against.
+# One version for the whole repo. The model packages track core with a caret, so
+# two models from different releases still resolve to a single copy of it.
 for cat in Sources/*/Catalog.swift; do
     [ -f "$cat" ] || continue
     product="$(basename "$(dirname "$cat")")"
@@ -442,7 +450,7 @@ for cat in Sources/*/Catalog.swift; do
       const fs = require("fs"), f = process.argv[1] + "/package.json";
       const p = JSON.parse(fs.readFileSync(f, "utf8"));
       for (const field of ["dependencies", "peerDependencies", "devDependencies"]) {
-        if (p[field] && p[field]["@desert-ant-labs/core"]) p[field]["@desert-ant-labs/core"] = process.argv[2];
+        if (p[field] && p[field]["@desert-ant-labs/core"]) p[field]["@desert-ant-labs/core"] = "^" + process.argv[2];
       }
       fs.writeFileSync(f, JSON.stringify(p, null, 2) + "\\n");
     ' "$dir" "$VERSION"
@@ -492,6 +500,13 @@ tools = { node = "22" }
 shell = "bash -c"
 run = """
 set -euo pipefail
+# Re-runnable: a tag that failed halfway re-runs every publish job, and npm
+# rejects a duplicate version, which would hide the job that actually failed.
+V=$(node -p 'require("./package.json").version')
+if npm view "@desert-ant-labs/core@$V" version >/dev/null 2>&1; then
+    echo "@desert-ant-labs/core@$V is already published; nothing to do"
+    exit 0
+fi
 # The npm tarball must carry the license (package.json: SEE LICENSE IN LICENSE.md).
 cp ../LICENSE.md LICENSE.md
 # Auth: NPM_TOKEN from mise.local.toml (or a CI env), else an interactive
@@ -553,6 +568,13 @@ set -euo pipefail
 #   ORG_GRADLE_PROJECT_signingInMemoryKey / ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
 : "${ORG_GRADLE_PROJECT_mavenCentralUsername:?set the Central portal token in mise.local.toml}"
 : "${ORG_GRADLE_PROJECT_signingInMemoryKey:?set the in-memory GPG signing key in mise.local.toml}"
+V=$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' gradle-plugin/build.gradle.kts)
+# Re-runnable: Central rejects a duplicate version, which on a re-run of a
+# partly-failed tag would hide the job that actually failed.
+if curl -sfIL "https://repo1.maven.org/maven2/ai/desertant/model-sdk-gradle-plugin/$V/model-sdk-gradle-plugin-$V.pom" >/dev/null 2>&1; then
+    echo "ai.desertant:model-sdk-gradle-plugin:$V is already published; nothing to do"
+    exit 0
+fi
 ./gradlew -p gradle-plugin publishAndReleaseToMavenCentral --no-configuration-cache
 echo "published: ai.desertant model-sdk Gradle plugin $(mise run check-version-plugin)"
 """

--- a/mise.toml
+++ b/mise.toml
@@ -369,18 +369,47 @@ run = "./gradlew -p kotlin publishToMavenLocal"
 
 # Print the single-sourced artifact version (from kotlin/build.gradle.kts).
 [tasks.check-version]
-hide = true
+description = "Verify every artifact in the repo carries the same version"
 dir = "{{ config_root }}"
 shell = "bash -c"
 run = """
 set -euo pipefail
-v=$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' kotlin/build.gradle.kts)
-[ -n "$v" ] || { echo "error: no version in kotlin/build.gradle.kts" >&2; exit 1; }
-echo "$v"
+V=$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' kotlin/build.gradle.kts)
+[ -n "$V" ] || { echo "error: no version in kotlin/build.gradle.kts" >&2; exit 1; }
+bad=0
+check() { # <found> <where>
+    [ "$1" = "$V" ] || { echo "  $2: $1 (expected $V)" >&2; bad=1; }
+}
+check "$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' gradle-plugin/build.gradle.kts)" "gradle-plugin/build.gradle.kts"
+check "$(node -p 'require("./js/package.json").version')" "js/package.json"
+for cat in Sources/*/Catalog.swift; do
+    [ -f "$cat" ] || continue
+    product="$(basename "$(dirname "$cat")")"
+    model="$(printf '%s' "$product" | tr '[:upper:]' '[:lower:]')"
+    check "$(sed -n -E 's|.*sdkVersion = "([^"]*)".*|\\1|p' "$cat")" "$cat"
+    dir="packages/$model-node"
+    [ -d "$dir" ] || continue
+    check "$(node -p "require('./$dir/package.json').version")" "$dir/package.json"
+    # The model packages pin core exactly, so a published pair can never mismatch.
+    pin=$(node -p "require('./$dir/package.json').dependencies?.['@desert-ant-labs/core'] ?? ''")
+    [ -z "$pin" ] || check "$pin" "$dir core dependency"
+    kts="packages/$model-kotlin/build.gradle.kts"
+    [ ! -f "$kts" ] || {
+        check "$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' "$kts")" "$kts"
+        check "$(sed -n -E 's|.*id\\("ai\\.desertant\\.model-sdk"\\) version "([^"]*)".*|\\1|p' "$kts")" "$kts plugin pin"
+        # The AAR declares ai.desertant:core at this version. Unset means the
+        # convention plugin's stale default ships instead.
+        core=$(sed -n -E 's|.*coreVersion = "([^"]*)".*|\\1|p' "$kts")
+        [ -n "$core" ] || { echo "  $kts: coreVersion not set" >&2; bad=1; }
+        [ -z "$core" ] || check "$core" "$kts coreVersion"
+    }
+done
+[ "$bad" = 0 ] || { echo "error: versions disagree" >&2; exit 1; }
+echo "$V"
 """
 
 [tasks.set-version]
-description = "Set the desert-ant-core artifact versions (ai.desertant:core + @desert-ant-labs/core + README)"
+description = "Set THE version: every artifact in this repo ships one number"
 dir = "{{ config_root }}"
 tools = { node = "22" }
 shell = "bash -c"
@@ -391,16 +420,43 @@ run = """
 set -euo pipefail
 VERSION="${usage_version:?version arg required}"
 echo "$VERSION" | grep -Eq '^[0-9]+\\.[0-9]+\\.[0-9]+$' || { echo "error: version must be X.Y.Z, got '$VERSION'" >&2; exit 1; }
-# Android artifact version (single-sourced in the Gradle build).
+
+# ---- core -------------------------------------------------------------------
 sed -i.bak 's/^version = ".*"$/version = "'"$VERSION"'"/' kotlin/build.gradle.kts && rm -f kotlin/build.gradle.kts.bak
-# Gradle plugin version (published as ai.desertant:model-sdk-gradle-plugin).
 sed -i.bak 's/^version = ".*"$/version = "'"$VERSION"'"/' gradle-plugin/build.gradle.kts && rm -f gradle-plugin/build.gradle.kts.bak
-# npm package version (npm keeps package.json + any lockfile in sync).
 ( cd js && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null )
-# The Maven coordinate and the SwiftPM install snippet in the README.
 sed -i.bak -E 's|(ai\\.desertant:core:)[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|g' README.md && rm -f README.md.bak
 sed -i.bak -E 's|(desert-ant-core\\.git", from: ")[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|' README.md && rm -f README.md.bak
-echo "version set to $VERSION (kotlin/build.gradle.kts, gradle-plugin/build.gradle.kts, js/package.json, README)"
+
+# ---- every model SDK --------------------------------------------------------
+# One version for the whole repo, and the model packages pin core exactly, so a
+# model can never resolve against a core it was not built against.
+for cat in Sources/*/Catalog.swift; do
+    [ -f "$cat" ] || continue
+    product="$(basename "$(dirname "$cat")")"
+    model="$(printf '%s' "$product" | tr '[:upper:]' '[:lower:]')"
+    sed -i.bak -E 's|(sdkVersion = ")[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|' "$cat" && rm -f "$cat.bak"
+    dir="packages/$model-node"
+    [ -d "$dir" ] && ( cd "$dir" && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null )
+    [ -d "$dir" ] && node -e '
+      const fs = require("fs"), f = process.argv[1] + "/package.json";
+      const p = JSON.parse(fs.readFileSync(f, "utf8"));
+      for (const field of ["dependencies", "peerDependencies", "devDependencies"]) {
+        if (p[field] && p[field]["@desert-ant-labs/core"]) p[field]["@desert-ant-labs/core"] = process.argv[2];
+      }
+      fs.writeFileSync(f, JSON.stringify(p, null, 2) + "\\n");
+    ' "$dir" "$VERSION"
+    kts="packages/$model-kotlin/build.gradle.kts"
+    if [ -f "$kts" ]; then
+        sed -i.bak 's/^version = ".*"$/version = "'"$VERSION"'"/' "$kts"
+        sed -i.bak -E 's|(id\\("ai\\.desertant\\.model-sdk"\\) version ")[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|' "$kts"
+        sed -i.bak -E 's|(coreVersion = ")[0-9]+\\.[0-9]+\\.[0-9]+|\\1'"$VERSION"'|' "$kts"
+        rm -f "$kts.bak"
+    fi
+done
+
+mise run check-version >/dev/null
+echo "everything set to $VERSION"
 """
 
 # ---------------------------------------------------------------- npm artifact

--- a/packages/emo-kotlin/build.gradle.kts
+++ b/packages/emo-kotlin/build.gradle.kts
@@ -3,9 +3,11 @@
 // (published from desert-ant-core); this file supplies only Emo's version and
 // description. `mise run build-android` -> `mise run android-natives` builds the
 // prebuilt Swift JNI into src/main/jniLibs before packaging.
-plugins { id("ai.desertant.model-sdk") version "0.6.0" }
-version = "0.10.2"
+plugins { id("ai.desertant.model-sdk") version "1.0.0" }
+version = "1.0.0"
 desertAntSdk {
+    // Pinned exactly, like the npm package: one version across the repo.
+    coreVersion = "1.0.0"
     description = "On-device multilingual emoji suggestion for Android: turns a short task, calendar " +
         "entry, or message into ranked emoji, fully on device."
 }

--- a/packages/emo-node/package-lock.json
+++ b/packages/emo-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@desert-ant-labs/emo",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@desert-ant-labs/emo",
-      "version": "0.10.2",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.3.0",

--- a/packages/emo-node/package.json
+++ b/packages/emo-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desert-ant-labs/emo",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "description": "On-device multilingual emoji suggestion for JavaScript. Runs in the browser (WebAssembly + LiteRT.js) and server-side in Node (native), from one import.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
@@ -65,7 +65,7 @@
   ],
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.3.0",
-    "@desert-ant-labs/core": "^0.7.0",
+    "@desert-ant-labs/core": "1.0.0",
     "koffi": "^2.9.0"
   },
   "peerDependencies": {

--- a/packages/emo-node/package.json
+++ b/packages/emo-node/package.json
@@ -65,7 +65,7 @@
   ],
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.3.0",
-    "@desert-ant-labs/core": "1.0.0",
+    "@desert-ant-labs/core": "^1.0.0",
     "koffi": "^2.9.0"
   },
   "peerDependencies": {

--- a/packages/redact-kotlin/build.gradle.kts
+++ b/packages/redact-kotlin/build.gradle.kts
@@ -3,9 +3,11 @@
 // plugin (published from desert-ant-core); this file supplies only Redact's
 // version and description. `mise run build-android` -> `mise run android-natives`
 // builds the prebuilt Swift JNI into src/main/jniLibs before packaging.
-plugins { id("ai.desertant.model-sdk") version "0.6.0" }
-version = "0.8.0"
+plugins { id("ai.desertant.model-sdk") version "1.0.0" }
+version = "1.0.0"
 desertAntSdk {
+    // Pinned exactly, like the npm package: one version across the repo.
+    coreVersion = "1.0.0"
     description = "On-device multilingual PII redaction for Android: names, addresses, emails, cards, " +
         "IBANs, national IDs, VAT numbers and more across 24 EU languages."
 }

--- a/packages/redact-node/README.md
+++ b/packages/redact-node/README.md
@@ -120,7 +120,7 @@ darwin-arm64 (Core ML). Other platforms fall back to a clear error at `load()`;
 use the default WebAssembly build, the Swift package, or a browser for those.
 
 The same model ships as a Swift package (iOS/macOS) and an Android AAR from the
-same repository: https://github.com/Desert-Ant-Labs/redact
+same repository: https://github.com/Desert-Ant-Labs/desert-ant-core
 
 ## License
 

--- a/packages/redact-node/package-lock.json
+++ b/packages/redact-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@desert-ant-labs/redact",
-  "version": "0.7.3",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@desert-ant-labs/redact",
-      "version": "0.7.3",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.3.0",

--- a/packages/redact-node/package.json
+++ b/packages/redact-node/package.json
@@ -66,7 +66,7 @@
   ],
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.3.0",
-    "@desert-ant-labs/core": "1.0.0"
+    "@desert-ant-labs/core": "^1.0.0"
   },
   "optionalDependencies": {
     "koffi": "^2.9.0"

--- a/packages/redact-node/package.json
+++ b/packages/redact-node/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@desert-ant-labs/redact",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "On-device multilingual PII redaction for JavaScript. Runs in the browser (WebAssembly + LiteRT.js) and server-side in Node (native), from one import.",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://desertant.com/models/redact/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Desert-Ant-Labs/redact.git",
+    "url": "git+https://github.com/Desert-Ant-Labs/desert-ant-core.git",
     "directory": "packages/redact-node"
   },
   "keywords": [
@@ -66,7 +66,7 @@
   ],
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.3.0",
-    "@desert-ant-labs/core": "^0.7.0"
+    "@desert-ant-labs/core": "1.0.0"
   },
   "optionalDependencies": {
     "koffi": "^2.9.0"

--- a/sdk-build/README.md
+++ b/sdk-build/README.md
@@ -2,8 +2,25 @@
 
 `model-sdk.toml` is the shared mise task catalog for the Desert Ant Labs model
 SDKs (shapes, emo, redact, ...). The identical build/publish/version logic lives
-here once; each model repo includes it from a pinned tag and supplies a few
-`[vars]` instead of copying ~500 lines of `mise.toml`.
+here once; a consumer includes it and supplies a few `[vars]` instead of copying
+~500 lines of `mise.toml`.
+
+**In this monorepo**, the catalog is included from `mise.model.toml` behind
+`MISE_ENV=model`, and the model is chosen at run time rather than by `[vars]`:
+
+```sh
+MISE_ENV=model DAL_MODEL=redact DAL_PRODUCT=Redact mise run build
+```
+
+Every build task is scoped to that model: `build-swift` builds its target alone,
+and the rest write only into `packages/<model>-{node,kotlin}`.
+
+Every artifact in the repo ships one version. `mise run set-version X.Y.Z` sets
+it everywhere (core, every model package, each `Catalog.swift`), the model
+packages pin `@desert-ant-labs/core` exactly, and `mise run check-version` fails
+if anything disagrees. One `vX.Y.Z` tag then publishes all of it.
+
+**In a standalone model repo**, `[vars]` names the one model, as below.
 
 ## Using it from a model repo
 

--- a/sdk-build/model-sdk.toml
+++ b/sdk-build/model-sdk.toml
@@ -18,6 +18,9 @@
 #   [task_config]
 #   includes = ["git::https://github.com/Desert-Ant-Labs/desert-ant-core.git//sdk-build/model-sdk.toml?ref=v0.4.0"]
 #
+# `[vars]` names the model in a single-model repo; the monorepo has several, so
+# the tasks fall back to `DAL_MODEL` / `DAL_PRODUCT`. `[vars]` still wins.
+#
 # The tasks derive every model-specific name from `model`/`product`. Test tasks
 # (test, test-node, test-web, test-android-firebase) stay in the model repo,
 # since their harnesses differ; this catalog owns the identical build, publish,
@@ -82,11 +85,16 @@ shell = "bash -c"
 depends = ["litert-libs"]
 run = """
 set -euo pipefail
+# Just this model's target: the monorepo holds several, and building one SDK
+# should not compile the others. `--target`, not `--product`: the model
+# libraries are automatic products, which SwiftPM refuses to select and then
+# silently builds everything instead.
+TARGET={{ vars.product | default(value=env.DAL_PRODUCT) }}
 # On Apple, Core ML is part of the OS. Linux links the vendored LiteRT runtime.
 if [ "$(uname)" = "Darwin" ]; then
-    swift build
+    swift build --target "$TARGET"
 else
-    swift build -Xlinker -LVendor/litert/lib/linux-x64
+    swift build --target "$TARGET" -Xlinker -LVendor/litert/lib/linux-x64
 fi
 """
 
@@ -97,18 +105,18 @@ tools = { java = "temurin-21" }
 shell = "bash -c"
 run = """
 set -euo pipefail
-module=packages/{{ vars.model }}-kotlin
+module=packages/{{ vars.model | default(value=env.DAL_MODEL) }}-kotlin
 ./gradlew -p "$module" assembleRelease
 aar=$(find "$module/build/outputs/aar" -name '*-release.aar' | head -1)
 [ -n "$aar" ] || { echo "error: release AAR not found" >&2; exit 1; }
 ! unzip -Z1 "$aar" | grep -Eq 'libLiteRt|libc\\+\\+_shared'
 for abi in arm64-v8a x86_64; do
-    unzip -Z1 "$aar" | grep -qx "jni/$abi/lib{{ vars.product }}Android.so"
+    unzip -Z1 "$aar" | grep -qx "jni/$abi/lib{{ vars.product | default(value=env.DAL_PRODUCT) }}Android.so"
 done
 """
 
 ["build-web"]
-description = "Build the WebAssembly core into packages/{{ vars.model }}-node/dist"
+description = "Build the WebAssembly core into packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/dist"
 dir = "{{ config_root }}"
 shell = "bash -c"
 tools = { "aqua:WebAssembly/binaryen" = "130" }  # wasm-opt
@@ -119,7 +127,7 @@ set -euo pipefail
 # version). wasm-opt (binaryen) comes from mise [tools]; the check below still
 # degrades gracefully if it is somehow absent (ships ~3x larger).
 OUT=.build/wasm-package
-DIST=packages/{{ vars.model }}-node/dist
+DIST=packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/dist
 
 # Match the SDK to the installed toolchain version. Download and install from the
 # local file (no --checksum needed that way), so any Swift version just works.
@@ -142,36 +150,36 @@ fi
 
 # --allow-writing-to-package-directory: the js packaging plugin writes $OUT under
 # .build/, which SwiftPM's plugin sandbox blocks on macOS without this.
-swift package -Xswiftc -Osize --swift-sdk "$SDK" --allow-writing-to-package-directory js --product {{ vars.product }}Web -c release --output "$OUT"
+swift package -Xswiftc -Osize --swift-sdk "$SDK" --allow-writing-to-package-directory js --product {{ vars.product | default(value=env.DAL_PRODUCT) }}Web -c release --output "$OUT"
 
 if command -v wasm-opt >/dev/null; then
-    wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext --enable-reference-types --strip-debug --strip-producers "$OUT/{{ vars.product }}Web.wasm" -o "$OUT/{{ vars.product }}Web.wasm"
+    wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext --enable-reference-types --strip-debug --strip-producers "$OUT/{{ vars.product | default(value=env.DAL_PRODUCT) }}Web.wasm" -o "$OUT/{{ vars.product | default(value=env.DAL_PRODUCT) }}Web.wasm"
 else
     echo "warning: wasm-opt not found; shipping unoptimized wasm (~3x larger)" >&2
 fi
 
 rm -rf "$DIST"
 mkdir -p "$DIST"
-cp "$OUT"/{{ vars.product }}Web.wasm "$OUT"/index.js "$OUT"/index.d.ts "$OUT"/instantiate.js "$OUT"/instantiate.d.ts "$OUT"/runtime.js "$OUT"/runtime.d.ts "$DIST/"
+cp "$OUT"/{{ vars.product | default(value=env.DAL_PRODUCT) }}Web.wasm "$OUT"/index.js "$OUT"/index.d.ts "$OUT"/instantiate.js "$OUT"/instantiate.d.ts "$OUT"/runtime.js "$OUT"/runtime.d.ts "$DIST/"
 cp -r "$OUT"/platforms "$DIST/platforms"
 # The npm tarball must carry the license (package.json: SEE LICENSE IN LICENSE.md).
-cp LICENSE.md packages/{{ vars.model }}-node/LICENSE.md
+cp LICENSE.md packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/LICENSE.md
 
-ls -la "$DIST/{{ vars.product }}Web.wasm"
-echo "done: packages/{{ vars.model }}-node is ready (npm pack in that directory to check the tarball)"
+ls -la "$DIST/{{ vars.product | default(value=env.DAL_PRODUCT) }}Web.wasm"
+echo "done: packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node is ready (npm pack in that directory to check the tarball)"
 """
 
 ["node-natives"]
-description = "Build the native server-side Node core into packages/{{ vars.model }}-node/native/<platform>-<arch> (run per OS)"
+description = "Build the native server-side Node core into packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/native/<platform>-<arch> (run per OS)"
 dir = "{{ config_root }}"
 shell = "bash -c"
 depends = ["litert-libs"]
 run = """
 set -euo pipefail
 # The Node package is isomorphic: browsers get the WebAssembly + LiteRT.js build,
-# Node gets this prebuilt native core (the {{ vars.product }}Node product = the C ABI in
+# Node gets this prebuilt native core (the {{ vars.product | default(value=env.DAL_PRODUCT) }}Node product = the C ABI in
 # CABI.swift; AndroidJNI.swift is #if os(Android), so a host build is just the
-# ABI). koffi in packages/{{ vars.model }}-node binds {{ vars.model }}_* over it. Cross-OS builds
+# ABI). koffi in packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node binds {{ vars.model | default(value=env.DAL_MODEL) }}_* over it. Cross-OS builds
 # aren't possible, so run this on each target OS; publish gathers them.
 #
 # Backend per OS matches the rest of the SDK: Linux uses LiteRT (.tflite, links
@@ -195,11 +203,11 @@ if [ "$(uname)" = "Darwin" ]; then
     # macOS: the Node native uses Core ML (against the OS-provided Swift runtime
     # and system frameworks) and loads the bundled .mlmodelc by path - so it
     # needs no LiteRT and ships no extra runtime.
-    KEY="darwin-$NARCH"; dest="packages/{{ vars.model }}-node/native/$KEY"; rm -rf "$dest" && mkdir -p "$dest"
-    swift build -c release --product {{ vars.product }}Node $TRAITS -Xlinker -rpath -Xlinker @loader_path
-    cp ".build/release/lib{{ vars.product }}Node.dylib" "$dest/"
+    KEY="darwin-$NARCH"; dest="packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/native/$KEY"; rm -rf "$dest" && mkdir -p "$dest"
+    swift build -c release --product {{ vars.product | default(value=env.DAL_PRODUCT) }}Node $TRAITS -Xlinker -rpath -Xlinker @loader_path
+    cp ".build/release/lib{{ vars.product | default(value=env.DAL_PRODUCT) }}Node.dylib" "$dest/"
 else
-    KEY="linux-$NARCH"; dest="packages/{{ vars.model }}-node/native/$KEY"; rm -rf "$dest" && mkdir -p "$dest"
+    KEY="linux-$NARCH"; dest="packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/native/$KEY"; rm -rf "$dest" && mkdir -p "$dest"
     # Static Foundation on Linux autolinks -lcurl/-lxml2/-lz; provide dev-name
     # symlinks to the runtime sonames (the recorded DT_NEEDED stays the soname,
     # which is present on any normal Linux).
@@ -210,14 +218,14 @@ else
         [ -n "$src" ] && ln -sf "$src" "$tmp/$(echo "$so" | sed 's/\\.so.*/.so/')" || true
     done
     LARCH=$([ "$NARCH" = "x64" ] && echo linux-x64 || echo linux-arm64)
-    swift build -c release --product {{ vars.product }}Node $TRAITS -Xswiftc -static-stdlib \\
+    swift build -c release --product {{ vars.product | default(value=env.DAL_PRODUCT) }}Node $TRAITS -Xswiftc -static-stdlib \\
         -Xlinker "-L$tmp" -Xlinker "-LVendor/litert/lib/$LARCH" -Xlinker -rpath -Xlinker '$ORIGIN' \\
         -Xlinker -z -Xlinker nodelete
-    cp ".build/release/lib{{ vars.product }}Node.so" "$dest/"
+    cp ".build/release/lib{{ vars.product | default(value=env.DAL_PRODUCT) }}Node.so" "$dest/"
     cp "Vendor/litert/lib/$LARCH/libLiteRt.so" "$dest/"
 fi
 ls -la "$dest"
-echo "done: packages/{{ vars.model }}-node/native/$KEY ready"
+echo "done: packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/native/$KEY ready"
 """
 
 # ---------------------------------------------------------------- test
@@ -241,7 +249,7 @@ fi
 description = "Instrumented AAR test suite on a connected device/emulator"
 dir = "{{ config_root }}"
 tools = { java = "temurin-21" }
-run = "./gradlew -p packages/{{ vars.model }}-kotlin connectedDebugAndroidTest"
+run = "./gradlew -p packages/{{ vars.model | default(value=env.DAL_MODEL) }}-kotlin connectedDebugAndroidTest"
 
 # ---------------------------------------------------------------- publish
 
@@ -259,14 +267,14 @@ VERSION="${usage_version:?version arg required}"
 echo "$VERSION" | grep -Eq '^[0-9]+\\.[0-9]+\\.[0-9]+$' || { echo "error: version must be X.Y.Z, got '$VERSION'" >&2; exit 1; }
 
 # npm keeps package.json and package-lock.json in sync.
-( cd packages/{{ vars.model }}-node && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null )
+( cd packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null )
 
 # The Gradle module (project version drives the Maven coordinates).
-kts=packages/{{ vars.model }}-kotlin/build.gradle.kts
+kts=packages/{{ vars.model | default(value=env.DAL_MODEL) }}-kotlin/build.gradle.kts
 sed -i.bak 's/^version = ".*"$/version = "'"$VERSION"'"/' "$kts" && rm -f "$kts.bak"
 
 # The SwiftPM install snippet in the README.
-sed -i.bak 's|\\(url: "https://github.com/Desert-Ant-Labs/{{ vars.model }}.git", from: "\\)[^"]*"|\\1'"$VERSION"'"|' README.md && rm -f README.md.bak
+sed -i.bak 's|\\(url: "https://github.com/Desert-Ant-Labs/{{ vars.model | default(value=env.DAL_MODEL) }}.git", from: "\\)[^"]*"|\\1'"$VERSION"'"|' README.md && rm -f README.md.bak
 
 mise run check-version >/dev/null
 echo "version set to $VERSION (package.json + lock, Gradle module, README)"
@@ -281,9 +289,9 @@ dir = "{{ config_root }}"
 shell = "bash -c"
 run = """
 set -euo pipefail
-npm_version=$(sed -n 's/^  "version": "\\([^"]*\\)",$/\\1/p' packages/{{ vars.model }}-node/package.json)
-[ -n "$npm_version" ] || { echo "error: no version in packages/{{ vars.model }}-node/package.json" >&2; exit 1; }
-f=packages/{{ vars.model }}-kotlin/build.gradle.kts
+npm_version=$(sed -n 's/^  "version": "\\([^"]*\\)",$/\\1/p' packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/package.json)
+[ -n "$npm_version" ] || { echo "error: no version in packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/package.json" >&2; exit 1; }
+f=packages/{{ vars.model | default(value=env.DAL_MODEL) }}-kotlin/build.gradle.kts
 gradle_version=$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' "$f")
 [ "$gradle_version" = "$npm_version" ] || { echo "error: $f has version $gradle_version, package.json has $npm_version" >&2; exit 1; }
 echo "$npm_version"
@@ -299,9 +307,9 @@ set -euo pipefail
 # SwiftPM releases are semver tags on the repo; consumers pin
 # .package(url: ..., from: "X.Y.Z"). Tag the pushed main, not local state, then
 # create the GitHub Release object so the release is visible on github.com.
-VERSION=$(sed -n 's/^  "version": "\\([^"]*\\)",$/\\1/p' packages/{{ vars.model }}-node/package.json)
+VERSION=$(sed -n 's/^  "version": "\\([^"]*\\)",$/\\1/p' packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node/package.json)
 TAG="v$VERSION"
-REPO="Desert-Ant-Labs/{{ vars.model }}"
+REPO="Desert-Ant-Labs/{{ vars.model | default(value=env.DAL_MODEL) }}"
 
 jj git fetch
 COMMIT=$(jj log -r main@origin --no-graph -T commit_id)
@@ -335,26 +343,26 @@ fi
 notes=$(mktemp)
 trap 'rm -f "$notes"' EXIT
 cat > "$notes" <<EOF
-{{ vars.product }} $VERSION release.
+{{ vars.product | default(value=env.DAL_PRODUCT) }} $VERSION release.
 
 ## Packages
 
-- SwiftPM: https://github.com/Desert-Ant-Labs/{{ vars.model }}.git, from $VERSION
-- Android: ai.desertant:{{ vars.model }}:$VERSION
-- npm: @desert-ant-labs/{{ vars.model }}@$VERSION
+- SwiftPM: https://github.com/Desert-Ant-Labs/{{ vars.model | default(value=env.DAL_MODEL) }}.git, from $VERSION
+- Android: ai.desertant:{{ vars.model | default(value=env.DAL_MODEL) }}:$VERSION
+- npm: @desert-ant-labs/{{ vars.model | default(value=env.DAL_MODEL) }}@$VERSION
 EOF
 
 if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
     echo "release exists: https://github.com/$REPO/releases/tag/$TAG"
 else
-    gh release create "$TAG" --repo "$REPO" --title "{{ vars.product }} $VERSION" --notes-file "$notes"
+    gh release create "$TAG" --repo "$REPO" --title "{{ vars.product | default(value=env.DAL_PRODUCT) }} $VERSION" --notes-file "$notes"
 fi
 
 echo "published: Swift package release $TAG -> $COMMIT"
 """
 
 ["publish-android"]
-description = "Publish ai.desertant:{{ vars.model }} to Maven Central"
+description = "Publish ai.desertant:{{ vars.model | default(value=env.DAL_MODEL) }} to Maven Central"
 dir = "{{ config_root }}"
 depends = ["check-version"]
 tools = { java = "temurin-21" }
@@ -367,12 +375,12 @@ set -euo pipefail
 #   ORG_GRADLE_PROJECT_signingInMemoryKey / ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
 : "${ORG_GRADLE_PROJECT_mavenCentralUsername:?set the Central portal token in mise.local.toml}"
 : "${ORG_GRADLE_PROJECT_signingInMemoryKey:?set the in-memory GPG signing key in mise.local.toml}"
-./gradlew -p packages/{{ vars.model }}-kotlin publishAndReleaseToMavenCentral --no-configuration-cache
+./gradlew -p packages/{{ vars.model | default(value=env.DAL_MODEL) }}-kotlin publishAndReleaseToMavenCentral --no-configuration-cache
 """
 
 ["publish-web"]
-description = "Publish @desert-ant-labs/{{ vars.model }} to npm"
-dir = "{{ config_root }}/packages/{{ vars.model }}-node"
+description = "Publish @desert-ant-labs/{{ vars.model | default(value=env.DAL_MODEL) }} to npm"
+dir = "{{ config_root }}/packages/{{ vars.model | default(value=env.DAL_MODEL) }}-node"
 depends = ["check-version", "build-web"]
 tools = { node = "22" }
 shell = "bash -c"
@@ -394,7 +402,7 @@ fi
 # ---------------------------------------------------------------- internal
 
 ["android-natives"]
-description = "Cross-compile the Android native libs into packages/{{ vars.model }}-kotlin/src/main/jniLibs (invoked by the Gradle build)"
+description = "Cross-compile the Android native libs into packages/{{ vars.model | default(value=env.DAL_MODEL) }}-kotlin/src/main/jniLibs (invoked by the Gradle build)"
 dir = "{{ config_root }}"
 shell = "bash -c"
 usage = '''
@@ -418,7 +426,7 @@ set -euo pipefail
 # Vendor/litert/lib/android-<arch>/. The Swift Android SDK and the NDK it depends
 # on (r27d+) install on demand below.
 API="${usage_android_api:-24}"
-KOTLIN=packages/{{ vars.model }}-kotlin/src/main
+KOTLIN=packages/{{ vars.model | default(value=env.DAL_MODEL) }}-kotlin/src/main
 NDK_VER=r27d
 export SWIFT_ANDROID_STATIC_BUILD=1
 
@@ -529,7 +537,7 @@ for pair in "arm64-v8a:aarch64" "x86_64:x86_64"; do
     ln -s "$cxx_static" "$cxx_link/libstdc++.a"
     ln -s "$cxx_static" "$cxx_link/libstdc++_shared.a"
 
-    SWIFT swift build -c release --product {{ vars.product }}Android --swift-sdk "$arch-unknown-linux-android$API" --static-swift-stdlib \
+    SWIFT swift build -c release --product {{ vars.product | default(value=env.DAL_PRODUCT) }}Android --swift-sdk "$arch-unknown-linux-android$API" --static-swift-stdlib \
         -Xlinker -LVendor/litert/lib/android-$arch -Xlinker "-L$cxx_link"
     rm -rf "$cxx_link"
 
@@ -538,11 +546,11 @@ for pair in "arm64-v8a:aarch64" "x86_64:x86_64"; do
     # Locate the built library rather than hardcoding a layout: Swift 6.4's build
     # system emits .build/out/Products/Release-android-<arch>/, older SwiftPM used
     # .build/<triple>/release/. Both contain the arch, so match on that.
-    built=$(find .build -type f -name "lib{{ vars.product }}Android.so" -path "*$arch*" 2>/dev/null | head -1)
-    [ -n "$built" ] || { echo "error: lib{{ vars.product }}Android.so for $arch not found under .build" >&2; exit 1; }
+    built=$(find .build -type f -name "lib{{ vars.product | default(value=env.DAL_PRODUCT) }}Android.so" -path "*$arch*" 2>/dev/null | head -1)
+    [ -n "$built" ] || { echo "error: lib{{ vars.product | default(value=env.DAL_PRODUCT) }}Android.so for $arch not found under .build" >&2; exit 1; }
     cp "$built" "$dest/"
 
-    so="$dest/lib{{ vars.product }}Android.so"
+    so="$dest/lib{{ vars.product | default(value=env.DAL_PRODUCT) }}Android.so"
     if [ "$strip_mode" = objcopy ]; then
         "$strip_bin" --strip-unneeded "$so" "$so.s" && mv "$so.s" "$so"
     elif [ "$strip_mode" = strip ]; then
@@ -557,5 +565,5 @@ done
 rm -rf "$KOTLIN/resources"
 
 du -sh "$KOTLIN/jniLibs"
-echo "done: {{ vars.model }}-kotlin native libs are ready for the AAR build"
+echo "done: {{ vars.model | default(value=env.DAL_MODEL) }}-kotlin native libs are ready for the AAR build"
 """

--- a/sdk-build/model-sdk.toml
+++ b/sdk-build/model-sdk.toml
@@ -375,7 +375,15 @@ set -euo pipefail
 #   ORG_GRADLE_PROJECT_signingInMemoryKey / ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
 : "${ORG_GRADLE_PROJECT_mavenCentralUsername:?set the Central portal token in mise.local.toml}"
 : "${ORG_GRADLE_PROJECT_signingInMemoryKey:?set the in-memory GPG signing key in mise.local.toml}"
-./gradlew -p packages/{{ vars.model | default(value=env.DAL_MODEL) }}-kotlin publishAndReleaseToMavenCentral --no-configuration-cache
+M={{ vars.model | default(value=env.DAL_MODEL) }}
+V=$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' "packages/$M-kotlin/build.gradle.kts")
+# Re-runnable: Central rejects a duplicate version, which on a re-run of a
+# partly-failed tag would hide the job that actually failed.
+if curl -sfIL "https://repo1.maven.org/maven2/ai/desertant/$M/$V/$M-$V.pom" >/dev/null 2>&1; then
+    echo "ai.desertant:$M:$V is already published; nothing to do"
+    exit 0
+fi
+./gradlew -p "packages/$M-kotlin" publishAndReleaseToMavenCentral --no-configuration-cache
 """
 
 ["publish-web"]
@@ -386,6 +394,14 @@ tools = { node = "22" }
 shell = "bash -c"
 run = """
 set -euo pipefail
+# Re-runnable: npm rejects a duplicate version, which on a re-run of a
+# partly-failed tag would hide the job that actually failed.
+PKG=$(node -p 'require("./package.json").name')
+V=$(node -p 'require("./package.json").version')
+if npm view "$PKG@$V" version >/dev/null 2>&1; then
+    echo "$PKG@$V is already published; nothing to do"
+    exit 0
+fi
 # Auth: NPM_TOKEN from mise.local.toml, or `npm login`.
 # The token goes through a throwaway userconfig so normal npm commands and
 # checked-in files never carry auth.


### PR DESCRIPTION
Adds a per-model release path alongside core's own.

Every artifact now ships the same version, and one vX.Y.Z tag publishes all of them: SwiftPM, @desert-ant-labs/core, ai.desertant:core, the Gradle plugin, and each model SDK's npm and Maven packages.

  - set-version X.Y.Z sets it across core, every model package, and each Catalog.swift. Model packages pin @desert-ant-labs/core exactly.
  - check-version fails and names each site if anything disagrees.
  - Nothing is skipped for being unchanged — an exact pin to a version that was never published would not resolve.
  - Model tasks live behind MISE_ENV=model, since core's own release tasks share their names.
 
Unified at 1.0.0, which clears the previous high-water mark across the packages; registries reject a version below one already published.
 
mise run check-version reports a single version, and ModelCatalogTests cross-checks each sdkVersion against its npm and Gradle manifests.

Local npm install inside a model package won't resolve until core 1.0.0 is on npm. Publishing is unaffected. npm workspaces at the repo root would fix it properly — worth its own PR, since there's no root  package.json today and workspaces change publish-time resolution.