### PR TITLE
Coverage wording on the npm and repo READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 | Model | What it does | Swift | Android | Web and Node | Weights |
 |---|---|---|---|---|---|
 | **Emo** | Multilingual emoji suggestion from short text, 23 languages | `Emo` | `ai.desertant:emo` | `@desert-ant-labs/emo` | [Hugging Face](https://huggingface.co/desert-ant-labs/emo) |
-| **Redact** | PII detection and reversible redaction, 24 EU languages | `Redact` | `ai.desertant:redact` | `@desert-ant-labs/redact` | [Hugging Face](https://huggingface.co/desert-ant-labs/redact) |
+| **Redact** | PII detection and reversible redaction, 24 EU languages and more | `Redact` | `ai.desertant:redact` | `@desert-ant-labs/redact` | [Hugging Face](https://huggingface.co/desert-ant-labs/redact) |
 | **Clear** | Speech enhancement: denoise, dereverb, podcast-ready 48 kHz | `Clear` | soon | soon | [Hugging Face](https://huggingface.co/desert-ant-labs/clear) |
 
 Each model behaves the same on every platform, so you can build a feature once

--- a/packages/redact-node/README.md
+++ b/packages/redact-node/README.md
@@ -1,8 +1,9 @@
 # @desert-ant-labs/redact
 
 On-device multilingual PII redaction for JavaScript. Finds names, addresses,
-emails, phone numbers, cards, IBANs, national IDs and more across the 24 official
-EU languages, fully locally.
+emails, phone numbers, cards, IBANs, national IDs and more across 24 EU
+languages and more, fully locally.
+[Full language list](https://huggingface.co/desert-ant-labs/redact#languages).
 
 Two entries share one `Redact` API:
 


### PR DESCRIPTION
The package README and the model table still said the 24 official EU languages. Both now say 24 EU languages and more, with the npm README linking to the full list on the model card.