### PR TITLE
Fix the darwin release build, and prove it on the release runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ name: CI
 # the same task you run locally. The question it answers is the only one that
 # matters here: does every model still work on every platform?
 #
-#   apple    Swift on macOS (Core ML), an iOS Simulator, and the darwin native
+#   apple    Swift on macOS (Core ML) and on an iOS Simulator
+#   darwin-native  the prebuilt native the npm package ships, on the release runner
 #   linux    Swift on Linux (LiteRT)
 #   js       wasm + native cores, then every npm package: Node, browser, SSR
 #   android  the Swift JNI natives, both AARs, and the on-device suites
@@ -62,10 +63,21 @@ jobs:
       - run: mise run build:swift
       - run: mise run test:swift
       - run: mise run test:ios
-      # The darwin-arm64 native the npm package ships was previously built only
-      # during a release, on a runner nothing else exercised - so a macOS-only
-      # break in it surfaced mid-publish. Build it here every push. (macOS ships
-      # bash 3.2, so this also covers script portability the Linux jobs cannot.)
+
+  darwin-native:
+    name: darwin native (npm)
+    # macos-14 on purpose: this is the runner release.yml publishes the
+    # darwin-arm64 native from, and it carries an older Swift than the `apple`
+    # job's macos-26. Building it anywhere else proves the wrong thing - a
+    # concurrency diagnostic that only the older compiler emits shipped a broken
+    # release exactly this way. Same reasoning as ubuntu-22.04 for the Linux
+    # floor. macOS also ships bash 3.2, so this is the task set's only cover for
+    # the empty-array expansion the Linux jobs accept.
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+      - uses: astral-sh/setup-uv@v5
       - run: mise run build:node-native
 
   linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,9 @@ jobs:
         include:
           - { target: linux-x64, runner: ubuntu-22.04 }
           - { target: linux-arm64, runner: ubuntu-22.04-arm }
+          # macos-14 sets the compatibility floor for the published darwin
+          # native. CI's `darwin-native` job uses the same runner, so the
+          # toolchain that ships is the one CI proves.
           - { target: darwin-arm64, runner: macos-14 }
     runs-on: ${{ matrix.runner }}
     steps:

--- a/Sources/Inference/UsageTracking.swift
+++ b/Sources/Inference/UsageTracking.swift
@@ -135,8 +135,14 @@ actor TrackedSession: InferenceSession {
     private func startIfNeeded() {
         guard !started else { return }
         started = true
+        // Bind `self` before the Task rather than writing `self?.suspend()`
+        // inside it: the weak capture is a var, and referencing a captured var
+        // from concurrently-executing code is an error on the Swift versions we
+        // build the published darwin native with. Holding it for the duration of
+        // the suspend is also what we want - the flush should finish.
         lifecycle = LifecycleObserver(onBackground: { [weak self] in
-            Task { await self?.suspend() }
+            guard let self else { return }
+            Task { await self.suspend() }
         })
     }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,7 +42,7 @@ The point of CI is one question: does every model still work on every platform?
 | Linux | LiteRT | `test:swift` | `linux` |
 | Browser | WebAssembly + LiteRT.js | `test:wasi`, `build:wasm`, `test:browser`, `test:bundles` | `js` |
 | SSR (framework server pass) | none - must import cleanly | `test:node`, `test:bundles` | `js` |
-| Node (server-side inference) | prebuilt native core | `build:node-native`, `test:node` | `js` |
+| Node (server-side inference) | prebuilt native core | `build:node-native`, `test:node` | `js`, `darwin-native` |
 | Android | LiteRT | `build:android`, `test:android` | `android` |
 
 Every model with an npm package runs real inference in a real browser
@@ -60,6 +60,12 @@ Plus two invariants, in the `checks` job:
   audio stack unless it imports one. An app that adds one SDK pays for that SDK
   alone, and this reads the resolved SwiftPM graph, so it cannot be fooled by an
   incremental build.
+
+CI pins each job to the runner the release publishes from, so the toolchain that
+ships is the one CI proves: `ubuntu-22.04` for the Linux natives (glibc 2.35) and
+`macos-14` for the darwin native (an older Swift than the `apple` job's
+`macos-26`, and bash 3.2 rather than 5.x). Building a shipped artifact on a
+newer image than the release uses proves the wrong thing.
 
 ## Toolchains
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,7 +155,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.3.0",
-        "@desert-ant-labs/core": "^1.0.2"
+        "@desert-ant-labs/core": "^1.0.3"
       },
       "devDependencies": {
         "@litertjs/core": "^2.5.2"


### PR DESCRIPTION
The 1.0.3 release failed building the `darwin-arm64` native:

```
Sources/Inference/UsageTracking.swift:139:26: error: reference to captured var 'self'
in concurrently-executing code
```

`Task { await self?.suspend() }` inside a `[weak self]` closure references the weak capture — a **var** — from concurrent code. The Swift on `macos-14` rejects that; the newer Swift on `macos-26` accepts it. Binding `self` first fixes it, and holding it for the duration of the suspend is what we want anyway, since the flush should finish.

## Why it reached a release

CI built the darwin native on **macos-26**; `release.yml` publishes it from **macos-14**. So CI was proving a different compiler than the one that ships. My previous PR added the darwin build to the `apple` job, which is macos-26 — it went green and the release still broke.

Fixed properly: a `darwin-native` job on **macos-14**, the release runner. This is the same reasoning that puts the Linux natives on `ubuntu-22.04` for the glibc 2.35 floor. It also keeps the task set covered against **bash 3.2** — every other job is Linux with bash 5, which is what let the `traits[@]` unbound-variable bug through in the first place.

## Version

Still **1.0.3**. The run was cancelled before its Maven publish step, so nothing shipped at that version and the tag moves to this commit — verified 404 on Central for core/emo/redact at 1.0.3.

1.0.2 remains Maven-only and its tag stays put, since those artifacts are on Central built from that commit.