### PR TITLE
Clear the CI and compiler warnings, one of which was a real overflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
     name: checks (versions, JS units)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@v5
+      - uses: jdx/mise-action@v4
       # One version across the repo is only a property if something checks it
       # before release day.
       - run: mise run check:version
@@ -42,11 +42,11 @@ jobs:
     name: Apple (macOS + iOS Simulator)
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 26.6
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
 
       # No model artifact is committed, so the model-backed suites download the
       # pinned revision on a cold cache. Cache the store so that happens once
@@ -54,7 +54,7 @@ jobs:
       # independent of Hugging Face being reachable. Each model's revision lives
       # in its Catalog.swift, so those files are the key.
       - name: Cache downloaded models
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/Library/Caches/desert-ant-models
           key: models-${{ runner.os }}-${{ hashFiles('Sources/*/Catalog.swift') }}
@@ -75,24 +75,36 @@ jobs:
     # the empty-array expansion the Linux jobs accept.
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: jdx/mise-action@v4
+      # v7 is the newest floating major tag this action publishes (its later
+      # releases ship no vN alias), and it already runs on node24.
+      - uses: astral-sh/setup-uv@v7
+        with:
+          # uv only unpacks a wheel here; there is no uv.lock or
+          # requirements.txt to key a cache on, and asking for one warns
+          # that it can never be invalidated.
+          enable-cache: false
       - run: mise run build:node-native
 
   linux:
     name: Linux (Swift + LiteRT)
     runs-on: ubuntu-22.04 # glibc 2.35, the floor the published natives target
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build deps (static Foundation autolinks these)
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
             libcurl4-openssl-dev libxml2-dev zlib1g-dev
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
       # `mise run` vendors libLiteRt.so out of the ai-edge-litert wheel with uv.
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
+        with:
+          # uv only unpacks a wheel here; there is no uv.lock or
+          # requirements.txt to key a cache on, and asking for one warns
+          # that it can never be invalidated.
+          enable-cache: false
 
       # An app that adds one SDK must pay for that SDK alone; this reads the
       # resolved SwiftPM graph, so it needs the toolchain this job already has.
@@ -105,15 +117,20 @@ jobs:
     # glibc 2.35, matching the floor the published Linux natives target.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build deps (static Foundation autolinks these)
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
             libcurl4-openssl-dev libxml2-dev zlib1g-dev
-      - uses: jdx/mise-action@v2
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/cache@v4
+      - uses: jdx/mise-action@v4
+      - uses: astral-sh/setup-uv@v7
+        with:
+          # uv only unpacks a wheel here; there is no uv.lock or
+          # requirements.txt to key a cache on, and asking for one warns
+          # that it can never be invalidated.
+          enable-cache: false
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.swiftpm/swift-sdks
@@ -149,7 +166,7 @@ jobs:
     # the emulator can share one job.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # The emulator needs ~7.4 GB for userdata, and the Swift Android SDK, NDK,
       # and snapshot toolchain land on top of that. Drop toolchains we never use
@@ -174,11 +191,11 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
 
       # The snapshot toolchain (~1.2 GB), the Android SDK bundles (~330 MB), and
       # the NDK install on demand; cache them so only the first run pays.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cache/desert-ant/toolchains

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
     outputs:
       publish: ${{ steps.gate.outputs.publish }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@v5
+      - uses: jdx/mise-action@v4
       - id: gate
         run: |
           set -euo pipefail
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment: maven-central
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
@@ -81,9 +81,16 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
             libcurl4-openssl-dev libxml2-dev zlib1g-dev
-      - uses: jdx/mise-action@v2
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/cache@v4
+      - uses: jdx/mise-action@v4
+      # v7 is the newest floating major tag this action publishes (its later
+      # releases ship no vN alias), and it already runs on node24.
+      - uses: astral-sh/setup-uv@v7
+        with:
+          # uv only unpacks a wheel here; there is no uv.lock or
+          # requirements.txt to key a cache on, and asking for one warns
+          # that it can never be invalidated.
+          enable-cache: false
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cache/desert-ant/toolchains
@@ -125,17 +132,22 @@ jobs:
           - { target: darwin-arm64, runner: macos-14 }
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Linux build deps (static Foundation autolinks these)
         if: startsWith(matrix.target, 'linux')
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
             libcurl4-openssl-dev libxml2-dev zlib1g-dev binutils file
-      - uses: jdx/mise-action@v2
-      - uses: astral-sh/setup-uv@v5
+      - uses: jdx/mise-action@v4
+      - uses: astral-sh/setup-uv@v7
+        with:
+          # uv only unpacks a wheel here; there is no uv.lock or
+          # requirements.txt to key a cache on, and asking for one warns
+          # that it can never be invalidated.
+          enable-cache: false
       - run: mise run build:node-native
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: natives-${{ matrix.target }}
           path: packages/*-node/native/${{ matrix.target }}/
@@ -148,13 +160,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: jdx/mise-action@v4
+      - uses: astral-sh/setup-uv@v7
+        with:
+          # uv only unpacks a wheel here; there is no uv.lock or
+          # requirements.txt to key a cache on, and asking for one warns
+          # that it can never be invalidated.
+          enable-cache: false
 
       # Gather every prebuilt native back into its package, so each tarball
       # carries all three server-side targets.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: natives-*
           path: /tmp/natives
@@ -187,8 +204,8 @@ jobs:
     if: needs.gate.outputs.publish == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@v5
+      - uses: jdx/mise-action@v4
       - env:
           GH_TOKEN: ${{ github.token }}
         run: mise run publish:github

--- a/Sources/Clear/DSP.swift
+++ b/Sources/Clear/DSP.swift
@@ -399,8 +399,8 @@ final class ClearSTFT {
         var rTime = [Float](repeating: 0, count: n), iTime = [Float](repeating: 0, count: n)
         for t in 0..<nFrames {
             let base = t * f
-            real.withUnsafeBufferPointer { memcpy(&rSpec, $0.baseAddress! + base, f * 4) }
-            imag.withUnsafeBufferPointer { memcpy(&iSpec, $0.baseAddress! + base, f * 4) }
+            real.withUnsafeBufferPointer { _ = memcpy(&rSpec, $0.baseAddress! + base, f * 4) }
+            imag.withUnsafeBufferPointer { _ = memcpy(&iSpec, $0.baseAddress! + base, f * 4) }
             if mirror > 0 {
                 real.withUnsafeBufferPointer { rp in
                     rSpec.withUnsafeMutableBufferPointer { dp in

--- a/Sources/Inference/CoreMLSession.swift
+++ b/Sources/Inference/CoreMLSession.swift
@@ -114,7 +114,15 @@ final class CoreMLSession: InferenceSession, @unchecked Sendable {
                                       width: vImagePixelCount(count), rowBytes: count * 2)
                 vImageConvert_PlanarFtoPlanar16F(&s, &d, 0)
             } else {
-                array.dataPointer.copyMemory(from: raw.baseAddress!, byteCount: count * array.dataType.byteWidth)
+                // Copy exactly the source bytes. Only .int32 and .float32 reach
+                // here (see dataType(for:)) and both are 4 bytes per element, so
+                // this is the same size the destination was allocated for.
+                //
+                // Deliberately not derived from array.dataType: switching on
+                // MLMultiArrayDataType means guessing a width for whatever case
+                // a future SDK adds, and guessing too wide overruns the array's
+                // buffer. Core ML added .int8 (1 byte) exactly that way.
+                array.dataPointer.copyMemory(from: raw.baseAddress!, byteCount: raw.count)
             }
         }
     }
@@ -167,14 +175,4 @@ extension ComputeUnits {
     }
 }
 
-private extension MLMultiArrayDataType {
-    var byteWidth: Int {
-        switch self {
-        case .float16: return 2
-        case .int32, .float32: return 4
-        case .double: return 8
-        @unknown default: return 4
-        }
-    }
-}
 #endif

--- a/Sources/WasmBindings/WasmABI.swift
+++ b/Sources/WasmBindings/WasmABI.swift
@@ -91,6 +91,19 @@ private nonisolated(unsafe) var models: [Int: any BoundModel] = [:]
 private nonisolated(unsafe) var nextHandle = 1
 private nonisolated(unsafe) var retained: [JSClosure] = []
 
+/// Carries a JS value into a `@Sendable` closure on wasm.
+///
+/// `JSObject` is deliberately not `Sendable`: a JS reference belongs to the
+/// thread whose JS context created it. This module is `#if os(WASI)` and that
+/// runtime is single-threaded, so there is no second thread to reach - but the
+/// compiler cannot know that, and the capture is an error in the Swift 6
+/// language mode rather than a warning. This states the reasoning in one place
+/// instead of scattering unchecked captures.
+private struct SingleThreadedJS<Value>: @unchecked Sendable {
+    let value: Value
+    init(_ value: Value) { self.value = value }
+}
+
 private func store(_ model: any BoundModel) -> Int {
     let handle = nextHandle
     nextHandle += 1
@@ -148,9 +161,14 @@ private func exports(for model: WasmModel) -> JSObject {
     // so the first `run` is instant and load errors surface here. A no-op once
     // available. `onProgress`, when a function, gets the fraction in [0, 1].
     exports.download = promise { args in
-        let onProgress: JSFunction? = args.count > 1 ? args[1].function : nil
+        // `download`'s progress closure is @Sendable and JSObject is not
+        // Sendable, which is a warning today and an error in the Swift 6
+        // language mode. wasm here is single-threaded, so there is no other
+        // thread for the callback to reach; say that explicitly rather than
+        // leaning on a diagnostic that is about to become fatal.
+        let onProgress = SingleThreadedJS(args.count > 1 ? args[1].function : nil)
         try await loaded(handle(args, 0)).download { fraction in
-            if let onProgress { _ = onProgress(fraction) }
+            if let callback = onProgress.value { _ = callback(fraction) }
         }
         return .boolean(true)
     }


### PR DESCRIPTION
Went through every warning in a full CI run and split ours from third-party noise.

## The one that mattered

`MLMultiArrayDataType.byteWidth` wasn't exhaustive — Core ML added `.int8` — and its `@unknown default` guessed **4**. Its only caller copies into an `MLMultiArray`:

```swift
array.dataPointer.copyMemory(from: raw.baseAddress!, byteCount: count * array.dataType.byteWidth)
```

Guessing too wide overruns the destination, so `switch must be exhaustive` was a heap overflow waiting for a model with a narrower input type. Only `.int32` and `.float32` reach that path and both are 4 bytes, so it now copies the source's own byte count and the enum switch is gone — there's no case left for a future SDK to add.

## Swift 6 blocker

The wasm download progress callback captured a `JSObject` in a `@Sendable` closure, which is *an error in the Swift 6 language mode*, not just a warning. wasm is single-threaded, so that assumption is now named once in a `SingleThreadedJS` wrapper rather than left implicit. Also drops the deprecated `JSFunction` spelling.

## Actions

Everything was on node20, which runners now force onto node24 with a deprecation notice. Bumped `checkout`, `cache`, `upload-artifact`, `download-artifact`, `setup-uv`, and `mise-action` to their node24 majors — I checked each action's `action.yml` and every input in use still exists.

Also turned setup-uv's cache **off**: it keys on `uv.lock`/`requirements*.txt`, this repo has neither (uv only unpacks a wheel), so it warned on every run that the cache could never be invalidated.

## Also

`Clear/DSP.swift` discarded `memcpy`'s result inside the closure, so `withUnsafeBufferPointer`'s own result is no longer unused.

## Deliberately left

- **`TaskLocal.withValue` deprecation** (`InferenceContext`) — the preferred overload needs `nonisolated(nonsending)`, Swift 6.2 syntax that would break the Swift 5.9 floor the README promises. Worth revisiting when that floor moves.
- **`duplicate -rpath '@loader_path' ignored`** — SwiftPM already adds it; removing ours would change the link line of a just-published dylib for a cosmetic gain.
- **Third-party**: LiteRT's NPU/GPU accelerator probes (expected CPU fallback), Foundation's static-link `mktemp` notice, `punycode`/`url.parse` from the bundlers' own deps, Xcode's AppIntents note.

Verified `build:swift` and `check:isolation` locally; the Core ML, Accelerate, and wasm paths are all platform-gated, so CI is the check.