### PR TITLE
Redact: 27 languages, everywhere the coverage is stated

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 | Model | What it does | Swift | Android | Web and Node | Weights |
 |---|---|---|---|---|---|
 | **Emo** | Multilingual emoji suggestion from short text, 23 languages | `Emo` | `ai.desertant:emo` | `@desert-ant-labs/emo` | [Hugging Face](https://huggingface.co/desert-ant-labs/emo) |
-| **Redact** | PII detection and reversible redaction, 24 EU languages | `Redact` | `ai.desertant:redact` | `@desert-ant-labs/redact` | [Hugging Face](https://huggingface.co/desert-ant-labs/redact) |
+| **Redact** | PII detection and reversible redaction, 27 languages | `Redact` | `ai.desertant:redact` | `@desert-ant-labs/redact` | [Hugging Face](https://huggingface.co/desert-ant-labs/redact) |
 | **Clear** | Speech enhancement: denoise, dereverb, podcast-ready 48 kHz | `Clear` | soon | soon | [Hugging Face](https://huggingface.co/desert-ant-labs/clear) |
 
 Each model behaves the same on every platform, so you can build a feature once

--- a/Sources/Redact/Redact.swift
+++ b/Sources/Redact/Redact.swift
@@ -76,7 +76,7 @@ public enum RedactError: MessageError, Sendable {
 /// On-device, multilingual PII redaction.
 ///
 /// `Redact` finds names, addresses, emails, phone numbers, cards, IBANs,
-/// national IDs and more across 24 EU languages and more, fully on device.
+/// national IDs and more across 27 languages, fully on device.
 /// Create one once and reuse it.
 ///
 /// ```swift

--- a/examples/redact/RedactSwiftExample/RedactExample/ContentView.swift
+++ b/examples/redact/RedactSwiftExample/RedactExample/ContentView.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
             Text("On-device PII redaction")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.tint)
-            Text("Names, addresses, emails, phones, cards, IBANs and IDs, masked on device, across all 24 EU languages. Your text never leaves the phone.")
+            Text("Names, addresses, emails, phones, cards, IBANs and IDs, masked on device, across 27 languages. Your text never leaves the phone.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
         }

--- a/packages/redact-kotlin/build.gradle.kts
+++ b/packages/redact-kotlin/build.gradle.kts
@@ -7,5 +7,5 @@ plugins { id("ai.desertant.model-sdk") }
 
 desertAntSdk {
     description = "On-device multilingual PII redaction for Android: names, addresses, emails, cards, " +
-        "IBANs, national IDs and VAT numbers, across 24 EU languages and more."
+        "IBANs, national IDs and VAT numbers, across 27 languages."
 }

--- a/packages/redact-node/README.md
+++ b/packages/redact-node/README.md
@@ -1,8 +1,9 @@
 # @desert-ant-labs/redact
 
 On-device multilingual PII redaction for JavaScript. Finds names, addresses,
-emails, phone numbers, cards, IBANs, national IDs and more across the 24 official
-EU languages, fully locally.
+emails, phone numbers, cards, IBANs, national IDs and more across 27 languages,
+fully locally.
+[Full language list](https://huggingface.co/desert-ant-labs/redact#languages).
 
 Two entries share one `Redact` API:
 


### PR DESCRIPTION
One phrasing across every surface that states Redact's coverage: the repo model table, the npm README, the Maven POM description, the Swift doc comment and the example app.

Supersedes #62, which carried the earlier wording.