### PR TITLE
clear: Stream file enhancement so peak memory stops tracking duration

### DIFF
--- a/Sources/AudioDSP/Loudness.swift
+++ b/Sources/AudioDSP/Loudness.swift
@@ -24,28 +24,45 @@ public enum Loudness {
     private static let s2b: [Float] = [1.0, -2.0, 1.0]
     private static let s2a: [Float] = [-1.99004745483398, 0.99007225036621]
 
-    private static func biquad(_ x: [Float], _ b: [Float], _ a: [Float]) -> [Float] {
-        var y = [Float](repeating: 0, count: x.count)
+    /// Filters `x` through one biquad stage in place. The K-weighting cascade
+    /// runs two of these back to back, and allocating a fresh output per stage
+    /// cost two full-signal buffers (726 MB for 33 minutes at 48 kHz).
+    private static func biquadInPlace(_ x: inout [Float], _ b: [Float], _ a: [Float]) {
+        var delays = [Float](repeating: 0, count: 4)
+        biquadInPlace(&x, b, a, delays: &delays)
+    }
+
+    /// Filters in place, threading the filter state through `delays` so a
+    /// caller can run the same filter over a signal delivered in pieces. The
+    /// layout matches `vDSP_biquad`'s: `2 * sections + 2` floats, zeroed to
+    /// start a fresh signal.
+    fileprivate static func biquadInPlace(_ x: inout [Float], _ b: [Float], _ a: [Float],
+                                          delays: inout [Float]) {
         #if canImport(Accelerate)
         let coeffs: [Double] = [Double(b[0]), Double(b[1]), Double(b[2]), Double(a[0]), Double(a[1])]
-        guard let setup = vDSP_biquad_CreateSetup(coeffs, 1) else { return y }
+        // Preserve the old failure behaviour: no filter means no measurement,
+        // which the caller reads as silence rather than as unweighted audio.
+        guard let setup = vDSP_biquad_CreateSetup(coeffs, 1) else {
+            for i in 0..<x.count { x[i] = 0 }
+            return
+        }
         defer { vDSP_biquad_DestroySetup(setup) }
-        var delays = [Float](repeating: 0, count: 2 + 2)
-        x.withUnsafeBufferPointer { xp in
-            y.withUnsafeMutableBufferPointer { yp in
-                vDSP_biquad(setup, &delays, xp.baseAddress!, 1, yp.baseAddress!, 1, vDSP_Length(x.count))
-            }
+        // vDSP_biquad permits the same buffer as input and output, and updates
+        // `delays` in place so the next call continues the same filter.
+        x.withUnsafeMutableBufferPointer { xp in
+            vDSP_biquad(setup, &delays, xp.baseAddress!, 1, xp.baseAddress!, 1, vDSP_Length(xp.count))
         }
         #else
-        var x1: Float = 0, x2: Float = 0, y1: Float = 0, y2: Float = 0
+        // delays = [x1, x2, y1, y2] in the portable path.
+        var x1 = delays[0], x2 = delays[1], y1 = delays[2], y2 = delays[3]
         for i in 0..<x.count {
             let xn = x[i]
             let yn = b[0] * xn + b[1] * x1 + b[2] * x2 - a[0] * y1 - a[1] * y2
             x2 = x1; x1 = xn; y2 = y1; y1 = yn
-            y[i] = yn
+            x[i] = yn
         }
+        delays[0] = x1; delays[1] = x2; delays[2] = y1; delays[3] = y2
         #endif
-        return y
     }
 
     /// Integrated loudness in LUFS of mono `samples` at `sampleRate`, or nil for
@@ -53,37 +70,105 @@ public enum Loudness {
     /// on-device audio rate); pass 48 kHz audio.
     public static func integratedLUFS(_ samples: [Float], sampleRate: Double) -> Double? {
         guard sampleRate == 48_000, samples.count > 0 else { return nil }
-        let weighted = biquad(biquad(samples, s1b, s1a), s2b, s2a)
-        let block = Int(0.4 * sampleRate)      // 400 ms
-        let step = Int(0.1 * sampleRate)       // 100 ms (75% overlap)
-        guard weighted.count >= block else { return nil }
+        let meter = StreamingMeter(sampleRate: sampleRate)
+        guard meter != nil else { return nil }
+        meter!.consume(samples)
+        return meter!.finalize()
+    }
 
-        var blockLoud: [Double] = []
-        var meanSq: [Double] = []
-        var start = 0
-        while start + block <= weighted.count {
-            var ms: Double
-            #if canImport(Accelerate)
-            var msF: Float = 0
-            weighted.withUnsafeBufferPointer { vDSP_measqv($0.baseAddress! + start, 1, &msF, vDSP_Length(block)) }
-            ms = Double(msF)
-            #else
-            var sum = 0.0
-            for i in start..<(start + block) { sum += Double(weighted[i]) * Double(weighted[i]) }
-            ms = sum / Double(block)
-            #endif
-            meanSq.append(ms)
-            blockLoud.append(-0.691 + 10 * log10(ms + 1e-12))
-            start += step
+    /// BS.1770-4 integrated loudness over a signal delivered in pieces, so a
+    /// caller can measure a long file without ever holding it.
+    ///
+    /// Feeding the whole signal in one `consume` produces the same number as
+    /// ``Loudness/integratedLUFS(_:sampleRate:)`` - that function is now a
+    /// wrapper around this - because the K-weighting biquad state carries
+    /// across calls and the 400 ms blocks are cut at absolute sample positions,
+    /// not at chunk boundaries.
+    ///
+    /// Not thread safe; feed it from one place.
+    public final class StreamingMeter {
+        private let block: Int          // 400 ms
+        private let step: Int           // 100 ms (75% overlap)
+
+        // K-weighting state, carried across `consume` calls. This is what makes
+        // chunked measurement identical to whole-signal measurement.
+        private var s1Delays = [Float](repeating: 0, count: 4)
+        private var s2Delays = [Float](repeating: 0, count: 4)
+
+        // Weighted samples not yet consumed by a full block. Never longer than
+        // `block`, so memory is bounded regardless of signal length.
+        private var pending = [Float]()
+
+        // One `Double` pair per 100 ms of signal: about 317 KB per hour, which
+        // is small enough to keep for the gating passes.
+        private var blockLoud = [Double]()
+        private var meanSq = [Double]()
+
+        /// Peak absolute sample seen, for callers that also need peak-ceiling
+        /// headroom and would otherwise need a second traversal.
+        public private(set) var peak: Float = 0
+
+        /// Returns nil unless `sampleRate` is 48 kHz, which is what the
+        /// K-weighting coefficients are derived for.
+        public init?(sampleRate: Double) {
+            guard sampleRate == 48_000 else { return nil }
+            block = Int(0.4 * sampleRate)
+            step = Int(0.1 * sampleRate)
+            pending.reserveCapacity(block + step)
         }
-        // Absolute gate -70 LUFS, then relative gate at (gated mean - 10 LU).
-        func gatedLoudness(_ threshold: Double) -> Double? {
-            var acc = 0.0; var n = 0
-            for (i, l) in blockLoud.enumerated() where l > threshold { acc += meanSq[i]; n += 1 }
-            return n > 0 ? -0.691 + 10 * log10(acc / Double(n) + 1e-12) : nil
+
+        /// Feed the next span of samples. Any length is fine.
+        public func consume(_ samples: [Float]) {
+            samples.withUnsafeBufferPointer { consume($0) }
         }
-        guard let firstPass = gatedLoudness(-70) else { return nil }
-        return gatedLoudness(firstPass - 10) ?? firstPass
+
+        public func consume(_ samples: UnsafeBufferPointer<Float>) {
+            guard let base = samples.baseAddress, !samples.isEmpty else { return }
+            for i in 0..<samples.count { peak = max(peak, abs(base[i])) }
+
+            var weighted = [Float](repeating: 0, count: samples.count)
+            weighted.withUnsafeMutableBufferPointer { dp in
+                dp.baseAddress!.update(from: base, count: samples.count)
+            }
+            Loudness.biquadInPlace(&weighted, Loudness.s1b, Loudness.s1a, delays: &s1Delays)
+            Loudness.biquadInPlace(&weighted, Loudness.s2b, Loudness.s2a, delays: &s2Delays)
+
+            pending.append(contentsOf: weighted)
+            drainBlocks()
+        }
+
+        private func drainBlocks() {
+            var start = 0
+            while start + block <= pending.count {
+                var ms: Double
+                #if canImport(Accelerate)
+                var msF: Float = 0
+                pending.withUnsafeBufferPointer { vDSP_measqv($0.baseAddress! + start, 1, &msF, vDSP_Length(block)) }
+                ms = Double(msF)
+                #else
+                var sum = 0.0
+                for i in start..<(start + block) { sum += Double(pending[i]) * Double(pending[i]) }
+                ms = sum / Double(block)
+                #endif
+                meanSq.append(ms)
+                blockLoud.append(-0.691 + 10 * log10(ms + 1e-12))
+                start += step
+            }
+            if start > 0 { pending.removeFirst(start) }
+        }
+
+        /// The gated integrated loudness, or nil when nothing passed the gate
+        /// (silence, or a signal shorter than one 400 ms block).
+        public func finalize() -> Double? {
+            // Absolute gate -70 LUFS, then relative gate at (gated mean - 10 LU).
+            func gatedLoudness(_ threshold: Double) -> Double? {
+                var acc = 0.0; var n = 0
+                for (i, l) in blockLoud.enumerated() where l > threshold { acc += meanSq[i]; n += 1 }
+                return n > 0 ? -0.691 + 10 * log10(acc / Double(n) + 1e-12) : nil
+            }
+            guard let firstPass = gatedLoudness(-70) else { return nil }
+            return gatedLoudness(firstPass - 10) ?? firstPass
+        }
     }
 
     /// Normalize `samples` to `targetLUFS`, capping the applied gain at
@@ -94,7 +179,21 @@ public enum Loudness {
                                  targetLUFS: Double, maxGainDB: Double, peakCeilingDBFS: Double)
         -> (samples: [Float], measuredLUFS: Double?)
     {
-        guard let lufs = integratedLUFS(samples, sampleRate: sampleRate) else { return (samples, nil) }
+        var out = samples
+        let lufs = normalizeInPlace(&out, sampleRate: sampleRate, targetLUFS: targetLUFS,
+                                    maxGainDB: maxGainDB, peakCeilingDBFS: peakCeilingDBFS)
+        return (out, lufs)
+    }
+
+    /// `normalize` without the extra output buffer, for callers that own their
+    /// signal and can have it rewritten. A full-length master is 363 MB at 33
+    /// minutes, and the copy is live alongside the input.
+    @discardableResult
+    public static func normalizeInPlace(_ samples: inout [Float], sampleRate: Double,
+                                        targetLUFS: Double, maxGainDB: Double,
+                                        peakCeilingDBFS: Double) -> Double?
+    {
+        guard let lufs = integratedLUFS(samples, sampleRate: sampleRate) else { return nil }
         var gainDB = targetLUFS - lufs
         if gainDB > maxGainDB { gainDB = maxGainDB }
         var gain = Float(pow(10, gainDB / 20))
@@ -104,8 +203,7 @@ public enum Loudness {
         let ceiling = Float(pow(10, peakCeilingDBFS / 20))
         if peak * gain > ceiling, peak > 0 { gain = ceiling / peak }
 
-        var out = [Float](repeating: 0, count: samples.count)
-        for i in 0..<samples.count { out[i] = max(-1, min(1, samples[i] * gain)) }
-        return (out, lufs)
+        for i in 0..<samples.count { samples[i] = max(-1, min(1, samples[i] * gain)) }
+        return lufs
     }
 }

--- a/Sources/AudioIO/AppleAudioEncode.swift
+++ b/Sources/AudioIO/AppleAudioEncode.swift
@@ -1,0 +1,123 @@
+#if canImport(AVFoundation)
+import AVFoundation
+import Foundation
+
+// Apple encode backend: AVAudioFile writes whatever container/codec the output
+// extension implies (m4a/mp4 -> AAC, caf/aiff -> PCM), converting from the
+// float32 samples the pipeline carries. Written in blocks so a long file never
+// needs a second full-size buffer: 33 minutes of 48 kHz mono is 363 MB.
+
+extension AudioFileFormat {
+    /// The `AVAudioFile` settings dictionary for this encoding. The container
+    /// itself comes from the destination's extension.
+    internal func settings(sampleRate: Int, channels: Int) -> [String: Any] {
+        switch self {
+        case .wav:
+            return [AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: channels,
+                    AVLinearPCMBitDepthKey: 16,
+                    AVLinearPCMIsFloatKey: false,
+                    AVLinearPCMIsBigEndianKey: false,
+                    AVLinearPCMIsNonInterleaved: false]
+        case .aac(let bitRate):
+            // A hint, not a contract: AVAudioFile's encoder runs variable rate
+            // and routinely lands above the requested figure. It still moves
+            // the size meaningfully, so it is worth setting.
+            return [AVFormatIDKey: kAudioFormatMPEG4AAC,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: channels,
+                    AVEncoderBitRateKey: bitRate]
+        case .pcm:
+            return [AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: channels,
+                    AVLinearPCMBitDepthKey: 16,
+                    AVLinearPCMIsFloatKey: false,
+                    AVLinearPCMIsBigEndianKey: false,
+                    AVLinearPCMIsNonInterleaved: false]
+        }
+    }
+
+    /// Settings to retry with when the primary ones are refused. AAC takes an
+    /// explicit bit rate at 48 kHz but rejects one at some lower rates (16 kHz
+    /// mono fails in `AudioConverterSetProperty`), so fall back to a
+    /// quality-driven encode instead of failing the write.
+    internal func fallbackSettings(sampleRate: Int, channels: Int) -> [String: Any]? {
+        guard case .aac = self else { return nil }
+        return [AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: sampleRate,
+                AVNumberOfChannelsKey: channels,
+                AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue]
+    }
+}
+
+extension AudioIO {
+    /// Frames pushed per `write`. Large enough that the per-call overhead is
+    /// irrelevant, small enough that the staging buffer stays under a megabyte.
+    private static let encodeBlockFrames = 1 << 16
+
+    static func appleWrite(_ samples: [Float], sampleRate: Int, channels: Int,
+                           to path: String, format: AudioFileFormat) throws {
+        let url = URL(fileURLWithPath: path)
+        // AVAudioFile refuses to overwrite, and a stale file at the destination
+        // would otherwise surface as an opaque CoreAudio error.
+        try? FileManager.default.removeItem(at: url)
+
+        guard let source = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                         sampleRate: Double(sampleRate),
+                                         channels: AVAudioChannelCount(channels),
+                                         interleaved: false) else {
+            throw AudioIOError.unsupported("cannot describe \(channels)ch @ \(sampleRate) Hz")
+        }
+
+        // `commonFormat`/`interleaved` describe what we hand to `write`;
+        // AVAudioFile converts to the file's own encoding on the way out.
+        func open(_ settings: [String: Any]) throws -> AVAudioFile {
+            try AVAudioFile(forWriting: url, settings: settings,
+                            commonFormat: .pcmFormatFloat32, interleaved: false)
+        }
+
+        let file: AVAudioFile
+        do {
+            file = try open(format.settings(sampleRate: sampleRate, channels: channels))
+        } catch {
+            guard let fallback = format.fallbackSettings(sampleRate: sampleRate, channels: channels) else {
+                throw AudioIOError.unsupported("cannot open \(path) for writing: \(error)")
+            }
+            do { file = try open(fallback) }
+            catch { throw AudioIOError.unsupported("cannot open \(path) for writing: \(error)") }
+        }
+
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: source,
+                                            frameCapacity: AVAudioFrameCount(encodeBlockFrames)) else {
+            throw AudioIOError.unsupported("cannot allocate encode buffer")
+        }
+
+        let frames = samples.count / max(1, channels)
+        var frame = 0
+        while frame < frames {
+            let n = min(encodeBlockFrames, frames - frame)
+            buffer.frameLength = AVAudioFrameCount(n)
+            guard let channelData = buffer.floatChannelData else {
+                throw AudioIOError.unsupported("encode buffer has no float storage")
+            }
+            samples.withUnsafeBufferPointer { sp in
+                let base = sp.baseAddress! + frame * channels
+                if channels == 1 {
+                    channelData[0].update(from: base, count: n)
+                } else {
+                    // De-interleave: AVAudioPCMBuffer is planar here.
+                    for c in 0..<channels {
+                        let dst = channelData[c]
+                        for i in 0..<n { dst[i] = base[i * channels + c] }
+                    }
+                }
+            }
+            do { try file.write(from: buffer) }
+            catch { throw AudioIOError.unsupported("write failed at frame \(frame): \(error)") }
+            frame += n
+        }
+    }
+}
+#endif

--- a/Sources/AudioIO/AppleStreaming.swift
+++ b/Sources/AudioIO/AppleStreaming.swift
@@ -1,0 +1,216 @@
+#if canImport(AVFoundation)
+import AVFoundation
+import Foundation
+
+// Chunked file I/O for the Apple platforms, so a long file can be processed
+// without ever being resident. `AudioIO.decode`/`write` remain the whole-file
+// convenience API; these are what a streaming pipeline drives.
+
+public extension AudioIO {
+    /// Reads an audio file as mono `Float` at a fixed sample rate, a chunk at a
+    /// time. Single pass: make a new one to read the file again.
+    ///
+    /// Mirrors what ``AudioIO/decode(path:sampleRate:)`` produces, so a caller
+    /// can swap one for the other and get the same samples - just never all at
+    /// once. Not thread safe.
+    final class StreamingReader {
+        private let file: AVAudioFile
+        private let target: AVAudioFormat
+        private let converter: AVAudioConverter?
+        private final class EOFFlag: @unchecked Sendable { var reached = false }
+        private let sourceEOF = EOFFlag()
+        private var finished = false
+
+        /// Total frames in the source, at the source's own rate. For progress.
+        public let totalSourceFrames: AVAudioFramePosition
+        public let sourceSampleRate: Double
+
+        /// Frames already read from the source, at the source's own rate.
+        public var sourceFramePosition: AVAudioFramePosition { file.framePosition }
+
+        public init(path: String, sampleRate: Double) throws {
+            do {
+                file = try AVAudioFile(forReading: URL(fileURLWithPath: path))
+            } catch {
+                throw AudioIOError.decodeFailed("open \(path): \(error)")
+            }
+            let source = file.processingFormat
+            totalSourceFrames = file.length
+            sourceSampleRate = source.sampleRate
+            guard let target = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                             sampleRate: sampleRate, channels: 1,
+                                             interleaved: false) else {
+                throw AudioIOError.decodeFailed("cannot build \(sampleRate) Hz mono format")
+            }
+            self.target = target
+            // Already mono at the target rate in float32? Then read straight
+            // through and skip the converter entirely.
+            let matches = source.sampleRate == sampleRate
+                && source.channelCount == 1
+                && source.commonFormat == .pcmFormatFloat32
+                && !source.isInterleaved
+            if matches {
+                converter = nil
+            } else {
+                guard let c = AVAudioConverter(from: source, to: target) else {
+                    throw AudioIOError.decodeFailed("cannot convert \(source) to mono \(sampleRate) Hz")
+                }
+                converter = c
+            }
+        }
+
+        /// The next up-to-`maxFrames` samples, or nil once the file is drained.
+        public func next(maxFrames: Int) throws -> [Float]? {
+            if finished { return nil }
+            // AVAudioFile.read throws rather than returning nothing when the
+            // position is already at the end, so stop before asking.
+            if converter == nil, file.framePosition >= file.length {
+                finished = true
+                return nil
+            }
+            return try autoreleasepool { () throws -> [Float]? in
+                guard let out = AVAudioPCMBuffer(pcmFormat: target,
+                                                 frameCapacity: AVAudioFrameCount(maxFrames)) else {
+                    throw AudioIOError.decodeFailed("cannot allocate a \(maxFrames)-frame buffer")
+                }
+                if let converter {
+                    let eof = sourceEOF
+                    let file = self.file
+                    let sourceFormat = file.processingFormat
+                    var error: NSError?
+                    let status = converter.convert(to: out, error: &error) { need, inStatus in
+                        if eof.reached { inStatus.pointee = .endOfStream; return nil }
+                        guard let inBuf = AVAudioPCMBuffer(pcmFormat: sourceFormat,
+                                                           frameCapacity: need) else {
+                            inStatus.pointee = .endOfStream
+                            return nil
+                        }
+                        do {
+                            try file.read(into: inBuf, frameCount: need)
+                        } catch {
+                            eof.reached = true
+                            inStatus.pointee = .endOfStream
+                            return nil
+                        }
+                        if inBuf.frameLength == 0 {
+                            eof.reached = true
+                            inStatus.pointee = .endOfStream
+                            return nil
+                        }
+                        inStatus.pointee = .haveData
+                        return inBuf
+                    }
+                    if let error { throw AudioIOError.decodeFailed("\(error)") }
+                    if status == .endOfStream { finished = true }
+                } else {
+                    let remaining = file.length - file.framePosition
+                    let want = AVAudioFrameCount(min(AVAudioFramePosition(maxFrames), max(0, remaining)))
+                    if want == 0 {
+                        finished = true
+                        return nil
+                    }
+                    do {
+                        try file.read(into: out, frameCount: want)
+                    } catch {
+                        throw AudioIOError.decodeFailed("read: \(error)")
+                    }
+                    if out.frameLength == 0 { finished = true }
+                }
+
+                let n = Int(out.frameLength)
+                if n == 0 { return nil }
+                guard let channel = out.floatChannelData?[0] else { return nil }
+                return Array(UnsafeBufferPointer(start: channel, count: n))
+            }
+        }
+    }
+
+    /// Writes an audio file incrementally, encoding per the destination's
+    /// extension the same way ``AudioIO/write(_:sampleRate:channels:to:)`` does.
+    /// Call ``finish()`` (or let it deinit) to close the file.
+    final class StreamingWriter {
+        private var file: AVAudioFile?
+        private let source: AVAudioFormat
+        private let channels: Int
+        private let blockFrames = 1 << 16
+        private var buffer: AVAudioPCMBuffer?
+
+        public init(to path: String, sampleRate: Int, channels: Int = 1,
+                    format: AudioFileFormat? = nil) throws {
+            let url = URL(fileURLWithPath: path)
+            try? FileManager.default.removeItem(at: url)
+            self.channels = channels
+
+            let resolved = format
+                ?? AudioFileFormat.inferred(fromPathExtension: url.pathExtension)
+                ?? .wav
+            guard let source = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                             sampleRate: Double(sampleRate),
+                                             channels: AVAudioChannelCount(channels),
+                                             interleaved: false) else {
+                throw AudioIOError.unsupported("cannot describe \(channels)ch @ \(sampleRate) Hz")
+            }
+            self.source = source
+
+            func open(_ settings: [String: Any]) throws -> AVAudioFile {
+                try AVAudioFile(forWriting: url, settings: settings,
+                                commonFormat: .pcmFormatFloat32, interleaved: false)
+            }
+            do {
+                file = try open(resolved.settings(sampleRate: sampleRate, channels: channels))
+            } catch {
+                guard let fallback = resolved.fallbackSettings(sampleRate: sampleRate, channels: channels) else {
+                    throw AudioIOError.unsupported("cannot open \(path) for writing: \(error)")
+                }
+                do { file = try open(fallback) }
+                catch { throw AudioIOError.unsupported("cannot open \(path) for writing: \(error)") }
+            }
+        }
+
+        /// Append `samples` (interleaved when `channels > 1`).
+        public func write(_ samples: ArraySlice<Float>) throws {
+            guard let file else { throw AudioIOError.unsupported("writer already finished") }
+            let frames = samples.count / max(1, channels)
+            var offset = 0
+            try samples.withUnsafeBufferPointer { sp in
+                guard let base = sp.baseAddress else { return }
+                while offset < frames {
+                    let n = min(blockFrames, frames - offset)
+                    let buf: AVAudioPCMBuffer
+                    if let existing = buffer, existing.frameCapacity >= AVAudioFrameCount(n) {
+                        buf = existing
+                    } else {
+                        guard let fresh = AVAudioPCMBuffer(pcmFormat: source,
+                                                           frameCapacity: AVAudioFrameCount(blockFrames)) else {
+                            throw AudioIOError.unsupported("cannot allocate write buffer")
+                        }
+                        buffer = fresh
+                        buf = fresh
+                    }
+                    buf.frameLength = AVAudioFrameCount(n)
+                    guard let channelData = buf.floatChannelData else {
+                        throw AudioIOError.unsupported("write buffer has no float storage")
+                    }
+                    let src = base + offset * channels
+                    if channels == 1 {
+                        channelData[0].update(from: src, count: n)
+                    } else {
+                        for c in 0..<channels {
+                            let dst = channelData[c]
+                            for i in 0..<n { dst[i] = src[i * channels + c] }
+                        }
+                    }
+                    do { try autoreleasepool { try file.write(from: buf) } }
+                    catch { throw AudioIOError.unsupported("write failed: \(error)") }
+                    offset += n
+                }
+            }
+        }
+
+        public func write(_ samples: [Float]) throws { try write(samples[...]) }
+
+        /// Closes the file. Further writes throw.
+        public func finish() { file = nil; buffer = nil }
+    }
+}
+#endif

--- a/Sources/AudioIO/AudioIO.swift
+++ b/Sources/AudioIO/AudioIO.swift
@@ -16,6 +16,28 @@ public enum AudioIOError: Error, Sendable {
     case unsupported(String)
 }
 
+/// The output encodings ``AudioIO/write(_:sampleRate:channels:to:)`` can
+/// produce, chosen from the destination's path extension.
+public enum AudioFileFormat: Sendable, Equatable {
+    /// 16-bit PCM WAV. The portable encoding: available on every platform.
+    case wav
+    /// AAC in an MPEG-4 container (`.m4a`, `.mp4`, `.aac`). Apple only.
+    case aac(bitRate: Int)
+    /// Uncompressed PCM in a CAF or AIFF container. Apple only.
+    case pcm
+
+    /// Maps a path extension onto an encoding. Unknown extensions are `nil`, so
+    /// a caller can decide between defaulting and rejecting.
+    public static func inferred(fromPathExtension ext: String) -> AudioFileFormat? {
+        switch ext.lowercased() {
+        case "wav", "wave": .wav
+        case "m4a", "mp4", "aac": .aac(bitRate: 128_000)
+        case "caf", "aif", "aiff": .pcm
+        default: nil
+        }
+    }
+}
+
 public enum AudioIO {
     /// Decode the audio file at `path` to mono `Float` samples at
     /// `sampleRate`, resampling and mixing to mono as needed.
@@ -71,9 +93,56 @@ public extension AudioIO {
     /// Write mono (or interleaved) `samples` as a 16-bit PCM WAV file. Uses the
     /// portable encoder, so the bytes match `encodeWAV`. Available where a
     /// filesystem is (Apple/Linux); on Android/wasm write through the host.
+    /// Streams the file out in fixed-size blocks. Encoding to `[UInt8]` and then
+    /// copying into `Data` held two more full-size buffers (about 362 MB
+    /// combined for 33 minutes of 48 kHz mono) on top of the samples.
     static func writeWAV(_ samples: [Float], sampleRate: Int, channels: Int = 1, to path: String) throws {
-        let bytes = WAV.encode(samples, sampleRate: sampleRate, channels: channels)
-        try Data(bytes).write(to: URL(fileURLWithPath: path))
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.createFile(atPath: path, contents: nil) else {
+            throw AudioIOError.decodeFailed("cannot create \(path)")
+        }
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+
+        try handle.write(contentsOf: WAV.header(sampleCount: samples.count,
+                                                sampleRate: sampleRate, channels: channels))
+        let blockSamples = 1 << 16
+        var block = [UInt8]()
+        block.reserveCapacity(blockSamples * 2)
+        var index = samples.startIndex
+        while index < samples.endIndex {
+            let end = min(index + blockSamples, samples.endIndex)
+            block.removeAll(keepingCapacity: true)
+            WAV.appendPCM16(samples[index..<end], to: &block)
+            try handle.write(contentsOf: block)
+            index = end
+        }
+    }
+}
+
+public extension AudioIO {
+    /// Write `samples` to `path`, choosing the encoding from the path extension
+    /// (`.wav` -> 16-bit PCM, `.m4a`/`.mp4`/`.aac` -> AAC, `.caf`/`.aiff` ->
+    /// PCM). Unrecognized extensions fall back to `defaultFormat`.
+    ///
+    /// Only `.wav` exists off Apple platforms; anything else throws
+    /// `AudioIOError.unsupported` there rather than silently writing WAV bytes
+    /// under a misleading extension.
+    static func write(_ samples: [Float], sampleRate: Int, channels: Int = 1,
+                      to path: String, defaultFormat: AudioFileFormat = .wav) throws {
+        let ext = URL(fileURLWithPath: path).pathExtension
+        let format = AudioFileFormat.inferred(fromPathExtension: ext) ?? defaultFormat
+        switch format {
+        case .wav:
+            try writeWAV(samples, sampleRate: sampleRate, channels: channels, to: path)
+        case .aac, .pcm:
+            #if canImport(AVFoundation)
+            try appleWrite(samples, sampleRate: sampleRate, channels: channels,
+                           to: path, format: format)
+            #else
+            throw AudioIOError.unsupported("\(ext) encoding needs AVFoundation; only WAV is portable")
+            #endif
+        }
     }
 }
 

--- a/Sources/AudioIO/WAV.swift
+++ b/Sources/AudioIO/WAV.swift
@@ -120,25 +120,40 @@ public enum WAV {
 
     // MARK: Encode
 
-    /// Encode interleaved `samples` (in `[-1, 1]`) as a 16-bit PCM WAV buffer.
-    public static func encode(_ samples: [Float], sampleRate: Int, channels: Int = 1) -> [UInt8] {
+    /// The 44-byte canonical PCM header for `sampleCount` frames-worth of
+    /// 16-bit samples. Split out so a file writer can emit the header and then
+    /// stream the body without building the whole file in memory.
+    static func header(sampleCount: Int, sampleRate: Int, channels: Int = 1) -> [UInt8] {
         var out = [UInt8]()
-        out.reserveCapacity(44 + samples.count * 2)
+        out.reserveCapacity(44)
         func u16(_ v: Int) { out.append(UInt8(v & 0xFF)); out.append(UInt8((v >> 8) & 0xFF)) }
         func u32(_ v: Int) { for s in 0..<4 { out.append(UInt8((v >> (8 * s)) & 0xFF)) } }
         func tag(_ s: String) { out.append(contentsOf: s.utf8) }
 
-        let dataSize = samples.count * 2
+        let dataSize = sampleCount * 2
         let byteRate = sampleRate * channels * 2
         tag("RIFF"); u32(36 + dataSize); tag("WAVE")
         tag("fmt "); u32(16); u16(1); u16(channels); u32(sampleRate)
         u32(byteRate); u16(channels * 2); u16(16)
         tag("data"); u32(dataSize)
+        return out
+    }
+
+    /// Append `samples` to `out` as little-endian 16-bit PCM.
+    static func appendPCM16(_ samples: ArraySlice<Float>, to out: inout [UInt8]) {
         for v in samples {
             let clamped = max(-1, min(1, v))
             let s = Int16((clamped * 32767).rounded())
-            u16(Int(UInt16(bitPattern: s)))
+            let u = UInt16(bitPattern: s)
+            out.append(UInt8(u & 0xFF)); out.append(UInt8((u >> 8) & 0xFF))
         }
+    }
+
+    /// Encode interleaved `samples` (in `[-1, 1]`) as a 16-bit PCM WAV buffer.
+    public static func encode(_ samples: [Float], sampleRate: Int, channels: Int = 1) -> [UInt8] {
+        var out = header(sampleCount: samples.count, sampleRate: sampleRate, channels: channels)
+        out.reserveCapacity(44 + samples.count * 2)
+        appendPCM16(samples[...], to: &out)
         return out
     }
 }

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -114,7 +114,9 @@ public final class Clear: @unchecked Sendable {
     // Resolving, downloading, single-flighting, and offline availability are
     // `LoadedModel`; Clear adds only how a resolved directory becomes its
     // session pool.
-    private let model: LoadedModel<ModelAssets>
+    // `internal` so the Apple streaming path (Streaming.swift) can drive the
+    // same loader.
+    let model: LoadedModel<ModelAssets>
 
     /// Default model sessions to run chunks in parallel over. Native LiteRT is
     /// single-threaded per run, so a pool uses multiple cores; Apple (fast) and
@@ -240,11 +242,11 @@ public final class Clear: @unchecked Sendable {
         var measured: Double? = nil
         let mastering = options.mastering
         if mastering.enabled {
-            let (mastered, lufs) = Loudness.normalize(
-                out, sampleRate: ClearDSP.sampleRate, targetLUFS: mastering.integratedLUFS,
+            // In place: a returned master would sit alongside `out`, and both
+            // are full length.
+            measured = Loudness.normalizeInPlace(
+                &out, sampleRate: ClearDSP.sampleRate, targetLUFS: mastering.integratedLUFS,
                 maxGainDB: mastering.maxLoudnessGainDB, peakCeilingDBFS: mastering.truePeakDBTP)
-            out = mastered
-            measured = lufs
         }
         // Mastering is the tail of `enhancing`, so the phase ends at 1 only
         // once the audio is actually final.
@@ -255,23 +257,39 @@ public final class Clear: @unchecked Sendable {
                       modelVariant: assets.variant)
     }
 
-    private func elapsedSeconds(since start: ContinuousClock.Instant) -> Double {
+    func elapsedSeconds(since start: ContinuousClock.Instant) -> Double {
         let components = start.duration(to: .now).components
         return Double(components.seconds) + Double(components.attoseconds) / 1e18
     }
 
     #if canImport(Foundation) && !os(Android) && !os(WASI)
-    /// Decode any audio file, enhance it, and (optionally) write a 48 kHz WAV.
+    /// Decode any audio file, enhance it, and (optionally) write the result at
+    /// 48 kHz mono. The output encoding follows `outputPath`'s extension:
+    /// `.wav` gives 16-bit PCM, `.m4a`/`.mp4`/`.aac` gives AAC, `.caf`/`.aiff`
+    /// gives PCM. An unrecognized extension writes WAV.
+    ///
+    /// AAC and CAF/AIFF need AVFoundation, so off Apple platforms anything but
+    /// `.wav` throws rather than writing WAV bytes under a misleading name.
     /// Filesystem platforms (Apple/Linux); on Android/web use `enhance(bytes:)`.
     @discardableResult
     public func enhance(path: String, to outputPath: String? = nil,
                         options: Options = .default,
                         progress: ProgressHandler? = nil) async throws -> Result {
+        #if canImport(AVFoundation)
+        // Bounded-memory path: peak stays flat instead of growing with the
+        // file. Only when writing a file - a caller that wants the samples back
+        // is asking for the whole signal by definition. `Result.samples` is
+        // empty here; `durationSec` carries the length.
+        if let outputPath {
+            return try await enhanceStreaming(path: path, to: outputPath,
+                                              options: options, progress: progress)
+        }
+        #endif
         let samples = try await AudioIO.decode(path: path, sampleRate: ClearDSP.sampleRate)
         let result = try await enhance(samples: samples, sampleRate: ClearDSP.sampleRate,
                                        options: options, progress: progress)
         if let outputPath {
-            try AudioIO.writeWAV(result.samples, sampleRate: Int(ClearDSP.sampleRate), to: outputPath)
+            try AudioIO.write(result.samples, sampleRate: Int(ClearDSP.sampleRate), to: outputPath)
         }
         return result
     }

--- a/Sources/Clear/DSP.swift
+++ b/Sources/Clear/DSP.swift
@@ -342,7 +342,20 @@ final class ClearSTFT {
     func forward(_ audio: [Float]) -> (real: [Float], imag: [Float], nFrames: Int) {
         let prePad = fftSize - hopSize
         var padded = [Float](repeating: 0, count: prePad + audio.count)
-        for i in 0..<audio.count { padded[prePad + i] = audio[i] }
+        padded.withUnsafeMutableBufferPointer { dp in
+            audio.withUnsafeBufferPointer { sp in
+                if let s = sp.baseAddress { dp.baseAddress!.advanced(by: prePad).update(from: s, count: audio.count) }
+            }
+        }
+        return forward(prePadded: padded)
+    }
+
+    /// Same transform over a buffer the caller already laid out with the
+    /// `fftSize - hopSize` analysis prepad in front (and whatever tail padding
+    /// it needs). Lets a long-file pipeline build that buffer once instead of
+    /// paying a second full-signal copy here: at 48 kHz a 33-minute signal is
+    /// 363 MB, so the copy is worth avoiding.
+    func forward(prePadded padded: [Float]) -> (real: [Float], imag: [Float], nFrames: Int) {
         guard padded.count >= fftSize else { return ([], [], 0) }
         let nFrames = (padded.count - fftSize) / hopSize + 1
         var re = [Float](repeating: 0, count: nFrames * nFreq)
@@ -388,6 +401,17 @@ final class ClearSTFT {
     /// (real, imag) spectrogram -> time signal (windowed COLA overlap-add),
     /// dropping the analysis-synthesis prepad.
     func inverse(real: [Float], imag: [Float], nFrames: Int) -> [Float] {
+        real.withUnsafeBufferPointer { rp in
+            imag.withUnsafeBufferPointer { ip in
+                inverse(real: rp.baseAddress!, imag: ip.baseAddress!, nFrames: nFrames)
+            }
+        }
+    }
+
+    /// Pointer form, so a caller holding the spectrum in its own scratch buffers
+    /// can synthesize without first copying them into `Array`s. Two full
+    /// spectrogram planes are 726 MB for a 33-minute file.
+    func inverse(real: UnsafePointer<Float>, imag: UnsafePointer<Float>, nFrames: Int) -> [Float] {
         let prePad = fftSize - hopSize
         guard nFrames > 0 else { return [] }
         let rawLen = (nFrames - 1) * hopSize + fftSize
@@ -399,21 +423,17 @@ final class ClearSTFT {
         var rTime = [Float](repeating: 0, count: n), iTime = [Float](repeating: 0, count: n)
         for t in 0..<nFrames {
             let base = t * f
-            real.withUnsafeBufferPointer { _ = memcpy(&rSpec, $0.baseAddress! + base, f * 4) }
-            imag.withUnsafeBufferPointer { _ = memcpy(&iSpec, $0.baseAddress! + base, f * 4) }
+            _ = memcpy(&rSpec, real + base, f * 4)
+            _ = memcpy(&iSpec, imag + base, f * 4)
             if mirror > 0 {
-                real.withUnsafeBufferPointer { rp in
-                    rSpec.withUnsafeMutableBufferPointer { dp in
-                        memcpy(dp.baseAddress! + f, rp.baseAddress! + base + 1, mirror * 4)
-                        vDSP_vrvrs(dp.baseAddress! + f, 1, vDSP_Length(mirror))
-                    }
+                rSpec.withUnsafeMutableBufferPointer { dp in
+                    memcpy(dp.baseAddress! + f, real + base + 1, mirror * 4)
+                    vDSP_vrvrs(dp.baseAddress! + f, 1, vDSP_Length(mirror))
                 }
-                imag.withUnsafeBufferPointer { ip in
-                    iSpec.withUnsafeMutableBufferPointer { dp in
-                        memcpy(dp.baseAddress! + f, ip.baseAddress! + base + 1, mirror * 4)
-                        vDSP_vrvrs(dp.baseAddress! + f, 1, vDSP_Length(mirror))
-                        vDSP_vneg(dp.baseAddress! + f, 1, dp.baseAddress! + f, 1, vDSP_Length(mirror))
-                    }
+                iSpec.withUnsafeMutableBufferPointer { dp in
+                    memcpy(dp.baseAddress! + f, imag + base + 1, mirror * 4)
+                    vDSP_vrvrs(dp.baseAddress! + f, 1, vDSP_Length(mirror))
+                    vDSP_vneg(dp.baseAddress! + f, 1, dp.baseAddress! + f, 1, vDSP_Length(mirror))
                 }
             }
             vDSP_DFT_Execute(inv, rSpec, iSpec, &rTime, &iTime)
@@ -450,6 +470,9 @@ final class ClearSTFT {
             for t in 0..<nFrames { let off = t * hopSize; for n in 0..<fft { out[off + n] += rcb[t * fft + n] } }
         }
         #endif
-        return rawLen > prePad ? Array(out[prePad..<rawLen]) : out
+        // Dropping the prepad in place: `Array(out[prePad...])` would hold a
+        // second full-length buffer alongside `out`.
+        if rawLen > prePad { out.removeFirst(prePad) }
+        return out
     }
 }

--- a/Sources/Clear/Enhancer.swift
+++ b/Sources/Clear/Enhancer.swift
@@ -76,10 +76,12 @@ struct ClearEnhancer {
                  onAnalysis: (@Sendable (Double) -> Void)? = nil,
                  onChunk: (@Sendable (Double) -> Void)? = nil) async throws -> [Float] {
         guard !samples.isEmpty, !sessions.isEmpty else { return samples }
-        let clean = sanitize(samples)
-        let padded = padToWindowMultiple(clean)
-        let (real, imag, nFrames) = stft.forward(padded)
-        guard nFrames > 0 else { return clean }
+        // Sanitize, tail-pad, and lay in the STFT prepad in a single buffer.
+        // Doing these as three passes cost three full-signal copies, and at
+        // 48 kHz mono each one is 363 MB for a 33-minute file.
+        let padded = Self.prepareInput(samples)
+        let (real, imag, nFrames) = stft.forward(prePadded: padded)
+        guard nFrames > 0 else { return sanitize(samples) }
         onAnalysis?(0.5)
 
         let (featErb, featSpecReal, featSpecImag) =
@@ -118,10 +120,12 @@ struct ClearEnhancer {
             try await group.waitForAll()
         }
 
-        let outReal = Array(UnsafeBufferPointer(start: outRe, count: count))
-        let outImag = Array(UnsafeBufferPointer(start: outIm, count: count))
-        let enhanced = stft.inverse(real: outReal, imag: outImag, nFrames: nFrames)
-        return Array(enhanced.prefix(samples.count))
+        // Synthesize straight from the scratch buffers. Copying them into
+        // `Array`s first held a second pair of spectrogram planes (726 MB at 33
+        // minutes) while the originals were still live until the `defer`.
+        var enhanced = stft.inverse(real: outRe, imag: outIm, nFrames: nFrames)
+        if enhanced.count > samples.count { enhanced.removeLast(enhanced.count - samples.count) }
+        return enhanced
     }
 
     private static func runChunk(session: any InferenceSession, start: Int, end: Int, nFrames: Int, chunkLen: Int,
@@ -219,10 +223,23 @@ struct ClearEnhancer {
         return out
     }
 
-    private func padToWindowMultiple(_ samples: [Float]) -> [Float] {
+    /// One allocation carrying, in order: the `fftSize - hopSize` analysis
+    /// prepad, the sanitized signal, and enough tail zeros to reach a whole
+    /// number of windows. Same layout the old
+    /// `stft.forward(padToWindowMultiple(sanitize(x)))` chain produced, without
+    /// the intermediate copies.
+    private static func prepareInput(_ samples: [Float]) -> [Float] {
         let hop = ClearDSP.hopSize, fft = ClearDSP.fftSize
-        let needed = max(fft, ((samples.count + hop - 1) / hop) * hop + fft)
-        if samples.count >= needed { return samples }
-        return samples + [Float](repeating: 0, count: needed - samples.count)
+        let prePad = fft - hop
+        let windowed = max(fft, ((samples.count + hop - 1) / hop) * hop + fft)
+        var padded = [Float](repeating: 0, count: prePad + max(windowed, samples.count))
+        padded.withUnsafeMutableBufferPointer { dp in
+            let body = dp.baseAddress! + prePad
+            samples.withUnsafeBufferPointer { sp in
+                if let s = sp.baseAddress { body.update(from: s, count: samples.count) }
+            }
+            for i in 0..<samples.count where !body[i].isFinite { body[i] = 0 }
+        }
+        return padded
     }
 }

--- a/Sources/Clear/Streaming.swift
+++ b/Sources/Clear/Streaming.swift
@@ -1,0 +1,181 @@
+#if canImport(AVFoundation) && canImport(Foundation)
+import AVFoundation
+import AudioDSP
+import AudioIO
+import DesertAnt
+import Foundation
+
+// File-to-file enhancement in bounded memory.
+//
+// The in-memory pipeline (`Clear.enhance(samples:)`) holds the signal, its
+// spectrogram, and the enhanced result at once - roughly 383 MB per 5 minutes
+// at 48 kHz, so a 33-minute recording peaks in the gigabytes and an hour is
+// simply not possible on a phone. This path keeps peak flat instead: it works
+// on 20-second windows and streams both ends.
+//
+// Two things make windowing safe:
+//
+//   * The model runs on independent 200-frame chunks, so cutting the signal
+//     into windows changes nothing about inference itself.
+//   * The ERB/DF front end carries a running mean (EMA, tau = 1 s). That state
+//     cannot be cut, so each window is fed 3 s of the previous window's audio
+//     as warmup and that prefix is discarded from the output. At tau = 1 s,
+//     3 s is ~95% convergence, so the seam is inaudible - but it does mean the
+//     output is not bit-identical to the whole-file path. Tests assert SNR, not
+//     equality.
+//
+// Mastering needs the integrated loudness of the *enhanced* signal, which is
+// only known once the last window is done. Rather than predict it from the
+// input (what the previous SDK did, via a calibrated attenuation constant) the
+// enhanced audio goes to a float32 scratch file while a streaming meter runs,
+// then a second, cheap pass applies the gain and encodes. No model work is
+// repeated.
+
+extension Clear {
+    /// Samples spanned by one model chunk: 200 frames at a 480-sample hop, so
+    /// exactly 2 s at 48 kHz.
+    ///
+    /// Both the window and the warmup must be whole multiples of this. The
+    /// model runs on a fixed 200-frame grid, and a window whose start is not on
+    /// that grid shifts every chunk boundary inside it, which moves the
+    /// per-chunk edge effects and audibly changes the output. Measured against
+    /// the in-memory path: a 4 s warmup (2 chunks) agrees at ~43 dB SNR, while
+    /// 3 s (1.5 chunks) collapses to ~12 dB. Length past the first couple of
+    /// chunks buys nothing - 4 s, 6 s and 10 s all land at ~43 dB - so this is
+    /// an alignment constraint, not a convergence one.
+    private static var chunkSamples: Int { 200 * ClearDSP.hopSize }
+
+    /// Window of new audio per iteration. 10 chunks.
+    private static var windowFrames: Int { 10 * chunkSamples }
+
+    /// Audio replayed from the previous window so the feature EMA (tau = 1 s)
+    /// reconverges before the samples we keep. 2 chunks = 4 s, which is both
+    /// grid-aligned and ~98% converged.
+    private static var warmupFrames: Int { 2 * chunkSamples }
+
+    func enhanceStreaming(path: String, to outputPath: String,
+                          options: Options,
+                          progress: ProgressHandler?) async throws -> Result {
+        if let progress {
+            progress(Progress(phase: .loadingModel, fraction: 0))
+            try await model.download { progress(Progress(phase: .loadingModel, fraction: $0)) }
+        }
+        let assets = try await model.value()
+        let start = ContinuousClock.now
+        let sampleRate = ClearDSP.sampleRate
+
+        let reader = try AudioIO.StreamingReader(path: path, sampleRate: sampleRate)
+        let enhancer = ClearEnhancer(sessions: assets.sessions)
+        let meter = Loudness.StreamingMeter(sampleRate: sampleRate)
+
+        // The front end is per window and quick; report it once so the phase
+        // sequence still reads analyzing -> enhancing for a caller's UI.
+        progress?(Progress(phase: .analyzing, fraction: 1))
+        progress?(Progress(phase: .enhancing, fraction: 0))
+
+        let scratch = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("clear-stream-\(UUID().uuidString).f32")
+        guard FileManager.default.createFile(atPath: scratch.path, contents: nil) else {
+            throw ClearError.inferenceFailed("cannot create a scratch file")
+        }
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let strength = Float(options.strength.value)
+        let blend = strength < 0.999
+        var totalFrames = 0
+
+        // Expected output length, for progress. The reader reports position at
+        // the source rate, so convert.
+        let expectedFrames = reader.sourceSampleRate > 0
+            ? Double(reader.totalSourceFrames) * (sampleRate / reader.sourceSampleRate)
+            : 0
+
+        do {
+            let scratchHandle = try FileHandle(forWritingTo: scratch)
+            defer { try? scratchHandle.close() }
+
+            var previousTail = [Float]()
+            while true {
+                try Task.checkCancellation()
+                guard let window = try reader.next(maxFrames: Self.windowFrames), !window.isEmpty else { break }
+
+                // Warmup prefix + this window. The prefix is real audio the
+                // model has already seen; it only exists to converge the EMA.
+                var input = previousTail
+                input.append(contentsOf: window)
+                let prefix = previousTail.count
+
+                let enhanced = try await enhancer.enhance(input)
+                guard enhanced.count >= prefix else {
+                    throw ClearError.inferenceFailed("window shorter than its warmup prefix")
+                }
+                var useful = Array(enhanced[prefix...])
+                if useful.count > window.count { useful.removeLast(useful.count - window.count) }
+
+                if blend {
+                    let n = min(useful.count, window.count)
+                    for i in 0..<n { useful[i] = strength * useful[i] + (1 - strength) * window[i] }
+                }
+
+                meter?.consume(useful)
+                totalFrames += useful.count
+                try useful.withUnsafeBufferPointer { bp in
+                    try scratchHandle.write(contentsOf: Data(bytes: bp.baseAddress!,
+                                                             count: bp.count * MemoryLayout<Float>.size))
+                }
+
+                previousTail = window.count > Self.warmupFrames
+                    ? Array(window[(window.count - Self.warmupFrames)...])
+                    : window
+
+                if let progress, expectedFrames > 0 {
+                    progress(Progress(phase: .enhancing,
+                                      fraction: min(1, Double(totalFrames) / expectedFrames)))
+                }
+            }
+        }
+
+        // Mastering: one gain for the whole file, from the enhanced signal's own
+        // loudness and peak, matching what the in-memory path computes.
+        var measured: Double? = nil
+        var gain: Float = 1
+        let mastering = options.mastering
+        if mastering.enabled, let meter, let lufs = meter.finalize() {
+            measured = lufs
+            var gainDB = mastering.integratedLUFS - lufs
+            if gainDB > mastering.maxLoudnessGainDB { gainDB = mastering.maxLoudnessGainDB }
+            gain = Float(pow(10, gainDB / 20))
+            let ceiling = Float(pow(10, mastering.truePeakDBTP / 20))
+            let peak = meter.peak
+            if peak * gain > ceiling, peak > 0 { gain = ceiling / peak }
+        }
+
+        // Second pass: scratch -> encoder, applying the gain. No model, no DSP.
+        let writer = try AudioIO.StreamingWriter(to: outputPath, sampleRate: Int(sampleRate), channels: 1)
+        defer { writer.finish() }
+        let readHandle = try FileHandle(forReadingFrom: scratch)
+        defer { try? readHandle.close() }
+        let blockBytes = (1 << 16) * MemoryLayout<Float>.size
+        let applyGain = mastering.enabled
+        while true {
+            try Task.checkCancellation()
+            let data = try readHandle.read(upToCount: blockBytes) ?? Data()
+            if data.isEmpty { break }
+            var block = data.withUnsafeBytes { raw -> [Float] in
+                Array(raw.bindMemory(to: Float.self))
+            }
+            if applyGain {
+                for i in 0..<block.count { block[i] = max(-1, min(1, block[i] * gain)) }
+            }
+            try writer.write(block)
+        }
+        writer.finish()
+
+        progress?(Progress(phase: .enhancing, fraction: 1))
+        return Result(samples: [], sampleRate: sampleRate,
+                      durationSec: Double(totalFrames) / sampleRate,
+                      processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
+                      modelVariant: assets.variant)
+    }
+}
+#endif

--- a/Tests/AudioDSPTests/AudioDSPTests.swift
+++ b/Tests/AudioDSPTests/AudioDSPTests.swift
@@ -96,6 +96,69 @@ final class AudioDSPTests: XCTestCase {
         XCTAssertTrue(y.allSatisfy { abs($0) <= 1 })       // never clips
     }
 
+    // MARK: streaming meter
+
+    /// The whole point of the streaming meter: chunked measurement has to agree
+    /// with whole-signal measurement, whatever the chunk sizes are. The filter
+    /// state and the 400 ms block grid both have to survive chunk boundaries.
+    func testStreamingMeterMatchesWholeSignal() {
+        let sr = 48_000.0
+        var rng = SystemRandomNumberGenerator()
+        for trial in 0..<4 {
+            let n = [48_000 * 3, 48_000 * 7 + 13, 96_000, 48_000 * 11 + 1][trial]
+            var x = [Float](repeating: 0, count: n)
+            for i in 0..<n {
+                x[i] = 0.4 * Float(sin(2 * .pi * 220 * Double(i) / sr))
+                    + Float.random(in: -0.05...0.05, using: &rng)
+            }
+            let reference = Loudness.integratedLUFS(x, sampleRate: sr)
+            XCTAssertNotNil(reference, "n=\(n)")
+
+            // Deliberately awkward chunk sizes: not multiples of the block or
+            // step, and one larger than a block.
+            for chunk in [1_000, 4_800, 19_200, 50_000, 7_777] {
+                guard let meter = Loudness.StreamingMeter(sampleRate: sr) else {
+                    XCTFail("meter init"); return
+                }
+                var i = 0
+                while i < n {
+                    let end = min(i + chunk, n)
+                    meter.consume(Array(x[i..<end]))
+                    i = end
+                }
+                let streamed = meter.finalize()
+                XCTAssertNotNil(streamed, "n=\(n) chunk=\(chunk)")
+                // Not bit-exact: vDSP_biquad rounds slightly differently
+                // depending on how long a span it is handed (vector tail
+                // handling), so an odd chunk size shifts the last bits. The
+                // observed spread is ~1e-5 dB, which is nothing against the
+                // 0.1 LU that matters for delivery targets.
+                XCTAssertEqual(reference!, streamed!, accuracy: 1e-4,
+                               "n=\(n) chunk=\(chunk)")
+            }
+        }
+    }
+
+    func testStreamingMeterTracksPeak() {
+        guard let meter = Loudness.StreamingMeter(sampleRate: 48_000) else {
+            XCTFail("meter init"); return
+        }
+        meter.consume([0.1, -0.7, 0.3])
+        meter.consume([0.2, -0.25])
+        XCTAssertEqual(meter.peak, 0.7, accuracy: 1e-6)
+    }
+
+    func testStreamingMeterMemoryIsBounded() {
+        guard let meter = Loudness.StreamingMeter(sampleRate: 48_000) else {
+            XCTFail("meter init"); return
+        }
+        // 10 minutes fed in 1 s pieces; the meter must not be accumulating the
+        // signal itself.
+        let second = [Float](repeating: 0.2, count: 48_000)
+        for _ in 0..<600 { meter.consume(second) }
+        XCTAssertNotNil(meter.finalize())
+    }
+
     func testLoudnessSilenceIsNil() {
         XCTAssertNil(Loudness.integratedLUFS([Float](repeating: 0, count: 48_000), sampleRate: 48_000))
     }

--- a/Tests/AudioIOTests/AudioIOTests.swift
+++ b/Tests/AudioIOTests/AudioIOTests.swift
@@ -52,6 +52,70 @@ final class AudioIOTests: XCTestCase {
     }
     #endif
 
+    // MARK: extension-driven encoding
+
+    func testFormatInferredFromExtension() {
+        XCTAssertEqual(AudioFileFormat.inferred(fromPathExtension: "wav"), .wav)
+        XCTAssertEqual(AudioFileFormat.inferred(fromPathExtension: "WAV"), .wav)
+        XCTAssertEqual(AudioFileFormat.inferred(fromPathExtension: "m4a"), .aac(bitRate: 128_000))
+        XCTAssertEqual(AudioFileFormat.inferred(fromPathExtension: "mp4"), .aac(bitRate: 128_000))
+        XCTAssertEqual(AudioFileFormat.inferred(fromPathExtension: "caf"), .pcm)
+        XCTAssertEqual(AudioFileFormat.inferred(fromPathExtension: "aiff"), .pcm)
+        XCTAssertNil(AudioFileFormat.inferred(fromPathExtension: "opus"))
+    }
+
+    #if !os(WASI)
+    /// `.wav` must still produce a RIFF file byte-for-byte compatible with the
+    /// portable encoder.
+    func testWriteWAVExtensionStaysRIFF() throws {
+        let x = tone(2000)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dal-fmt-\(UUID().uuidString).wav")
+        try AudioIO.write(x, sampleRate: 16000, to: url.path)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let head = try [UInt8](Data(contentsOf: url).prefix(12))
+        XCTAssertEqual(Array(head[0..<4]), Array("RIFF".utf8))
+        XCTAssertEqual(Array(head[8..<12]), Array("WAVE".utf8))
+    }
+
+    #if canImport(AVFoundation)
+    /// The regression this whole change is about: an `.m4a` destination used to
+    /// receive RIFF/WAVE bytes. It must now be a real MPEG-4 AAC file that
+    /// decodes back to the same audio, and be far smaller than the PCM.
+    func testM4AExtensionProducesAAC() async throws {
+        // 48 kHz mono is what Clear emits, and the rate the explicit AAC bit
+        // rate applies at.
+        let sr = 48_000
+        let x = tone(sr * 3, freq: 440, sr: Double(sr))
+        let dir = FileManager.default.temporaryDirectory
+        let m4a = dir.appendingPathComponent("dal-fmt-\(UUID().uuidString).m4a")
+        let wav = dir.appendingPathComponent("dal-fmt-\(UUID().uuidString).wav")
+        try AudioIO.write(x, sampleRate: sr, to: m4a.path)
+        try AudioIO.write(x, sampleRate: sr, to: wav.path)
+        defer {
+            try? FileManager.default.removeItem(at: m4a)
+            try? FileManager.default.removeItem(at: wav)
+        }
+
+        // Not a RIFF container: the old behaviour would have written one.
+        let head = try [UInt8](Data(contentsOf: m4a).prefix(12))
+        XCTAssertNotEqual(Array(head[0..<4]), Array("RIFF".utf8))
+        XCTAssertEqual(Array(head[4..<8]), Array("ftyp".utf8), "expected an MPEG-4 box")
+
+        // Lossy, so well under the 16-bit PCM. The requested bit rate is only a
+        // hint to AVAudioFile, so this checks the order of magnitude rather than
+        // an exact size.
+        let aacSize = try FileManager.default.attributesOfItem(atPath: m4a.path)[.size] as! Int
+        let wavSize = try FileManager.default.attributesOfItem(atPath: wav.path)[.size] as! Int
+        XCTAssertLessThan(aacSize, wavSize / 2)
+
+        // And it is real audio: decodes back to about the same duration.
+        let decoded = try await AudioIO.decode(path: m4a.path, sampleRate: Double(sr))
+        XCTAssertEqual(Double(decoded.count), Double(x.count), accuracy: 4096)
+    }
+    #endif
+    #endif
+
     func testStereoMixdown() throws {
         // Interleaved L/R: L = +0.5, R = -0.5 -> mono averages to 0.
         let interleaved = [Float](repeating: 0, count: 200).enumerated().map { i, _ in

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -227,9 +227,13 @@ struct ClearTests {
         #expect(result.sampleRate == 48_000)
         #expect(FileManager.default.fileExists(atPath: output.path))
 
-        // The written file decodes back to the enhanced signal.
+        // The written file decodes back to the enhanced signal. Length comes
+        // from `durationSec`, not `samples`: writing to a file takes the
+        // bounded-memory path, which never materializes the signal, so
+        // `samples` is empty by design.
         let decoded = try await AudioIO.decode(path: output.path, sampleRate: 48_000)
-        #expect(abs(decoded.count - result.samples.count) <= 480)
+        let expected = Int(result.durationSec * 48_000)
+        #expect(abs(decoded.count - expected) <= 480)
         #expect(decoded.contains { $0 != 0 })
     }
 

--- a/Tests/ClearTests/StreamingTests.swift
+++ b/Tests/ClearTests/StreamingTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Darwin
+import Testing
+import AudioIO
+import AudioDSP
+import TestSupport
+@testable import Clear
+
+/// The bounded-memory file path: it must agree with the in-memory pipeline, and
+/// its peak must not grow with the length of the file.
+/// Thread-safe max, because progress arrives from the worker pool.
+private final class PeakTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Double
+    init(start: Double) { value = start }
+    func observe(_ v: Double) { lock.lock(); value = max(value, v); lock.unlock() }
+    var peak: Double { lock.lock(); defer { lock.unlock() }; return value }
+}
+
+private enum TempFootprint {
+    static func current() -> Double {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size)
+        let kr = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        return kr == KERN_SUCCESS ? Double(info.phys_footprint) / 1024 / 1024 : -1
+    }
+}
+
+@Suite(.serialized)
+struct ClearStreamingTests {
+    private func enhancer() async throws -> Clear {
+        let files = try await ModelFixture.files(ClearModel.self)
+        return try Clear(modelPath: files.path(ClearModel.artifact))
+    }
+
+    private func footprintMB() -> Double {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size)
+        let kr = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        return kr == KERN_SUCCESS ? Double(info.phys_footprint) / 1024 / 1024 : -1
+    }
+
+    private func speechish(_ seconds: Double) -> [Float] {
+        // Something with structure the model will actually act on, plus noise,
+        // and an amplitude envelope so the loudness gate has quiet and loud
+        // stretches to work with.
+        let n = Int(seconds * 48_000)
+        var x = [Float](repeating: 0, count: n)
+        var seed: UInt64 = 0x5EED
+        func rnd() -> Float {
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            return Float(Int32(truncatingIfNeeded: seed >> 33)) / Float(Int32.max)
+        }
+        for i in 0..<n {
+            let t = Double(i) / 48_000
+            let env = 0.35 * (0.6 + 0.4 * sin(2 * .pi * 0.25 * t))
+            let voiced = sin(2 * .pi * 140 * t) + 0.5 * sin(2 * .pi * 280 * t) + 0.25 * sin(2 * .pi * 560 * t)
+            x[i] = Float(env) * (Float(voiced) / 1.75 + 0.08 * rnd())
+        }
+        return x
+    }
+
+    /// Windowed output is not bit-identical to whole-file output (the feature
+    /// EMA is reconverged per window rather than threaded across the seam), so
+    /// this asserts they agree to within a healthy SNR instead.
+    @Test(.modelBacked) func streamingMatchesInMemory() async throws {
+        let clear = try await enhancer()
+        let x = speechish(50)   // more than two 20 s windows, so seams are exercised
+
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("clear-stream-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let input = dir.appendingPathComponent("in.wav")
+        let output = dir.appendingPathComponent("out.wav")
+        try AudioIO.writeWAV(x, sampleRate: 48_000, to: input.path)
+
+        // Bounded-memory path (writes a file).
+        let streamed = try await clear.enhance(path: input.path, to: output.path,
+                                               options: .init(mastering: .bypass))
+        let streamedSamples = try await AudioIO.decode(path: output.path, sampleRate: 48_000)
+
+        // In-memory path over the same input.
+        let reference = try await clear.enhance(samples: x, sampleRate: 48_000,
+                                                options: .init(mastering: .bypass))
+
+        #expect(abs(streamedSamples.count - reference.samples.count) <= 480)
+        #expect(abs(streamed.durationSec - reference.durationSec) < 0.05)
+
+        // 16-bit WAV quantization alone caps this around 90 dB; the seams are
+        // what we are really measuring.
+        // ~43 dB in practice. The floor guards the grid alignment described in
+        // Streaming.swift: a window or warmup that is not a whole number of
+        // 200-frame model chunks drops this to ~12 dB.
+        let agreement = snr(reference.samples, streamedSamples)
+        #expect(agreement > 35, "streaming vs in-memory SNR was \(agreement) dB")
+    }
+
+    /// Mastering has to land on the same target as the in-memory path, which is
+    /// the part the scratch-file round trip exists to preserve.
+    @Test(.modelBacked) func streamingMasteringMatches() async throws {
+        let clear = try await enhancer()
+        let x = speechish(45)
+
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("clear-master-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let input = dir.appendingPathComponent("in.wav")
+        let output = dir.appendingPathComponent("out.wav")
+        try AudioIO.writeWAV(x, sampleRate: 48_000, to: input.path)
+
+        let streamed = try await clear.enhance(path: input.path, to: output.path,
+                                               options: .init(mastering: .applePodcasts))
+        let written = try await AudioIO.decode(path: output.path, sampleRate: 48_000)
+        let achieved = Loudness.integratedLUFS(written, sampleRate: 48_000)
+
+        #expect(streamed.measuredLUFS != nil)
+        if let achieved {
+            // Landed on the preset target (-19 LUFS), give or take the gain cap
+            // and quantization.
+            #expect(abs(achieved - (-19)) < 1.5, "mastered to \(achieved) LUFS")
+        }
+    }
+
+    /// The acceptance criterion for the whole exercise: doubling the input must
+    /// not double the peak.
+    @Test(.modelBacked) func peakDoesNotGrowWithDuration() async throws {
+        let clear = try await enhancer()
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("clear-peak-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var peaks: [Double] = []
+        for seconds in [60.0, 240.0] {
+            let input = dir.appendingPathComponent("in-\(Int(seconds)).wav")
+            let output = dir.appendingPathComponent("out-\(Int(seconds)).wav")
+            try AudioIO.writeWAV(speechish(seconds), sampleRate: 48_000, to: input.path)
+
+            let before = footprintMB()
+            let tracker = PeakTracker(start: before)
+            _ = try await clear.enhance(path: input.path, to: output.path,
+                                        options: .init(mastering: .applePodcasts)) { [tracker] _ in
+                tracker.observe(TempFootprint.current())
+            }
+            let peak = tracker.peak
+            peaks.append(peak - before)
+            try? FileManager.default.removeItem(at: input)
+            try? FileManager.default.removeItem(at: output)
+            print(String(format: ">>> %.0fs: peak +%.0f MB", seconds, peak - before))
+        }
+
+        // 4x the audio. Whole-file processing would be ~4x the memory; windowed
+        // processing should be roughly flat, so allow generous slack and still
+        // catch a regression to linear growth.
+        #expect(peaks[1] < peaks[0] + 150,
+                "peak grew from \(peaks[0]) MB to \(peaks[1]) MB with 4x the audio")
+    }
+}

--- a/Tests/ClearTests/StreamingTests.swift
+++ b/Tests/ClearTests/StreamingTests.swift
@@ -1,3 +1,8 @@
+// The bounded-memory file path is Apple-only (AVFoundation-backed streaming
+// reader/writer), and so is the footprint probe below, which reads
+// task_vm_info. Gate the whole file on the same condition as the feature so
+// the Linux and WASI test runs skip it rather than failing to import Darwin.
+#if canImport(AVFoundation)
 import Foundation
 import Darwin
 import Testing
@@ -166,3 +171,4 @@ struct ClearStreamingTests {
                 "peak grew from \(peaks[0]) MB to \(peaks[1]) MB with 4x the audio")
     }
 }
+#endif


### PR DESCRIPTION
### Problem

   `enhance(path:to:)` held the signal, its spectrogram and the result in memory at
   once — ~383 MB per 5 minutes at 48 kHz. A 33-minute recording peaked in the
   gigabytes and got jetsam-killed on device. The standalone SDK this pipeline
   replaced streamed the file and peaked ~500 MB; that property was lost in the
   migration.

### Change

   On Apple platforms, `enhance(path:to:)` now processes 20 s windows and streams
   both ends:

   - `AudioIO.StreamingReader` / `StreamingWriter` — chunked decode and incremental encode
   - `Loudness.StreamingMeter` — BS.1770-4 loudness over a signal delivered in pieces
   - Enhanced audio goes to a float32 scratch file while the meter runs; a second
     cheap pass applies one gain and encodes. No model work is repeated.

   Other platforms keep the whole-file path, which also lost its redundant
   full-length copies. Writing now picks its encoder from the output extension
   instead of always emitting WAV (an `.m4a` destination previously received RIFF
   bytes).