### PR TITLE
Raise the Swift floor to 6.2, migrate to the Swift 6 language mode, and check it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       # the js job runs the same task after build:wasm, where it also proves the
       # declared wasm ABI is the one Swift exports.
       - run: mise run check:types
+      # The README promises a minimum Swift; this builds on exactly that, because
+      # the claim silently drifted twice while nothing checked it.
+      - run: mise run check:swift-floor
       - run: mise run test:js
 
   apple:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
       # the js job runs the same task after build:wasm, where it also proves the
       # declared wasm ABI is the one Swift exports.
       - run: mise run check:types
+      # check:swift-floor links the dynamic products, so it vendors LiteRT, which
+      # is fetched with uv exactly as the linux and js jobs do.
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
       # The README promises a minimum Swift; this builds on exactly that, because
       # the claim silently drifted twice while nothing checked it.
       - run: mise run check:swift-floor
@@ -74,14 +79,20 @@ jobs:
 
   darwin-native:
     name: darwin native (npm)
-    # macos-14 on purpose: this is the runner release.yml publishes the
-    # darwin-arm64 native from, and it carries an older Swift than the `apple`
-    # job's macos-26. Building it anywhere else proves the wrong thing - a
-    # concurrency diagnostic that only the older compiler emits shipped a broken
-    # release exactly this way. Same reasoning as ubuntu-22.04 for the Linux
-    # floor. macOS also ships bash 3.2, so this is the task set's only cover for
-    # the empty-array expansion the Linux jobs accept.
-    runs-on: macos-14
+    # The runner release.yml publishes the darwin-arm64 native from, so the
+    # toolchain that ships is the one CI proves. It was macos-14 to keep the
+    # shipped native on the oldest compiler, but macos-14 carries Swift 5.10 and
+    # the package now requires 6.2, so it cannot build this at all.
+    #
+    # Nothing is lost by moving. The artifact's compatibility floor comes from the
+    # manifest's `platforms`, not the runner: built here it still reports
+    # `minos 13.0` (verified with otool), the same as before. And "does it build on
+    # the oldest compiler we promise" is now a job of its own, check:swift-floor,
+    # which is a stricter version of what the old runner pin was reaching for - a
+    # broken release once shipped through exactly that gap. macOS still ships bash
+    # 3.2, so this remains the task set's only cover for the empty-array expansion
+    # the Linux jobs accept.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v5
       - uses: jdx/mise-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,12 @@ jobs:
         include:
           - { target: linux-x64, runner: ubuntu-22.04 }
           - { target: linux-arm64, runner: ubuntu-22.04-arm }
-          # macos-14 sets the compatibility floor for the published darwin
-          # native. CI's `darwin-native` job uses the same runner, so the
-          # toolchain that ships is the one CI proves.
-          - { target: darwin-arm64, runner: macos-14 }
+          # CI's `darwin-native` job uses the same runner, so the toolchain that
+          # ships is the one CI proves. The published native's compatibility floor
+          # comes from the manifest's `platforms` (macOS 13), not from the runner;
+          # macos-14 is no longer usable because its Swift 5.10 predates the
+          # package's 6.2 requirement.
+          - { target: darwin-arm64, runner: macos-26 }
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.2
 import PackageDescription
 import Foundation
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Face](https://huggingface.co/desert-ant-labs).
 
 ### Install
 
-Requirements: iOS 16+, macOS 13+, tvOS 16+, visionOS 1+, and Swift 5.9+.
+Requirements: iOS 16+, macOS 13+, tvOS 16+, visionOS 1+, and Swift 6.2+ (Xcode 26).
 
 Add the package with Swift Package Manager:
 
@@ -281,7 +281,7 @@ verified before it is used.
 
 | Platform | Runtime | Requirements |
 |---|---|---|
-| iOS, macOS, tvOS, visionOS | Core ML | iOS 16+, macOS 13+, tvOS 16+, visionOS 1+, Swift 5.9+ |
+| iOS, macOS, tvOS, visionOS | Core ML | iOS 16+, macOS 13+, tvOS 16+, visionOS 1+, Swift 6.2+ |
 | Android | LiteRT | API 24+, arm64-v8a and x86_64 |
 | Browser | WebAssembly + LiteRT.js | any browser with WebAssembly; `@litertjs/core` |
 | Node | prebuilt native core | linux-x64, linux-arm64, darwin-arm64 |

--- a/Sources/AudioIO/AppleAudioIO.swift
+++ b/Sources/AudioIO/AppleAudioIO.swift
@@ -1,5 +1,10 @@
 #if canImport(AVFoundation)
-import AVFoundation
+// `@preconcurrency`: AVAudioConverter's input block is documented to run
+// synchronously, before `convert(to:error:)` returns, but AVFAudio predates
+// concurrency annotations and the block is typed `@Sendable`. Without this the
+// Swift 6 language mode flags the buffer it hands back and the "already fed" flag
+// it flips, neither of which ever leaves this call.
+@preconcurrency import AVFoundation
 import Foundation
 
 // Apple decode backend: AVFoundation reads any supported container/codec, and
@@ -40,7 +45,10 @@ extension AudioIO {
             guard let outBuffer = AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: capacity) else {
                 throw AudioIOError.decodeFailed("cannot build output buffer")
             }
-            var fed = false
+            // `nonisolated(unsafe)` for the same reason as `@preconcurrency` above:
+            // the block that flips this runs synchronously inside `convert`, on this
+            // thread, so there is no concurrency for the flag to be unsafe across.
+            nonisolated(unsafe) var fed = false
             var error: NSError?
             converter.convert(to: outBuffer, error: &error) { _, status in
                 if fed { status.pointee = .endOfStream; return nil }

--- a/Sources/FFIBuffer/FFIBuffer.swift
+++ b/Sources/FFIBuffer/FFIBuffer.swift
@@ -23,7 +23,10 @@ import WASILibc
 
 /// Accumulates a typed payload, then emits it as a length-prefixed C buffer the
 /// host reads and frees with `ffiFree`.
-public struct FFIWriter {
+// `Sendable` because both are plain value types over `[UInt8]` (a public struct
+// gets no implicit conformance across module boundaries, so it has to be said).
+// That is what lets a payload cross into the task an FFI entry point blocks on.
+public struct FFIWriter: Sendable {
     /// The payload built so far (without the outer length prefix).
     public private(set) var bytes: [UInt8] = []
 
@@ -115,7 +118,7 @@ public func ffiFree(_ ptr: UnsafeMutablePointer<CChar>?) { free(ptr) }
 /// This is what lets one generic C ABI serve every model: a model's options are
 /// a payload it decodes itself, instead of a per-model argument list that would
 /// need its own exported symbol.
-public struct FFIReader {
+public struct FFIReader: Sendable {
     private let bytes: [UInt8]
     private var offset = 0
 

--- a/Sources/Inference/UsageTracking.swift
+++ b/Sources/Inference/UsageTracking.swift
@@ -31,7 +31,15 @@ actor TrackedSession: InferenceSession {
     private let debounceNanos: UInt64
     private let maxDevices = 512
 
-    private var clients: [String: UsageClient] = [:]
+    // `nonisolated(unsafe)` so the `deinit` below can flush these. A deinit is
+    // nonisolated and `UsageClient` is deliberately not Sendable (unsynchronized
+    // counters only this actor touches), which the Swift 6 language mode rejects.
+    // `isolated deinit` (SE-0371) is the feature for this but needs macOS 15.4 /
+    // iOS 18.4, far above this package's floor. The unchecked access is sound
+    // rather than asserted: a deinit runs only once the last reference is gone,
+    // and a task executing on an actor holds one, so no actor work can be in
+    // flight to race with it.
+    private nonisolated(unsafe) var clients: [String: UsageClient] = [:]
     private var deviceOrder: [String] = []       // FIFO for eviction
     private var cachedDefaultDevice: String?
     private var pendingFlush: Task<Void, Never>?

--- a/Sources/NativeBindings/NativeRuntime.swift
+++ b/Sources/NativeBindings/NativeRuntime.swift
@@ -32,7 +32,7 @@ public func nativeIsDownloaded(_ handle: UnsafeMutableRawPointer?) -> Int32 {
 
 public func nativeDownload(_ handle: UnsafeMutableRawPointer?) -> Int32 {
     guard let model = model(handle) else { return -1 }
-    let ok: Bool = blockingValue {
+    let ok: Bool = blockingValue(with: model) { model in
         do {
             try await model.download(progress: { _ in })
             return true
@@ -58,7 +58,7 @@ public func nativeRun(
     let optionsReader = FFIReader(options, optionsLen)
     let group = string(groupId)
     let device = string(deviceId)
-    let payload: [UInt8]? = blockingValue {
+    let payload: [UInt8]? = blockingValue(with: model) { model in
         await InferenceContext.$deviceId.withValue(device) {
             await InferenceContext.withCallGroup(id: group) {
                 await model.run(input: inputReader, options: optionsReader)

--- a/Sources/PlatformSupport/Blocking.swift
+++ b/Sources/PlatformSupport/Blocking.swift
@@ -5,6 +5,30 @@ private final class BlockingBox<Value: Sendable>: @unchecked Sendable {
     var value: Value?
 }
 
+/// Hands one non-Sendable value to the operation `blockingValue` runs.
+///
+/// The unchecked claim is true because of what `blockingValue` does: the calling
+/// thread blocks until the operation finishes, so the value is touched by exactly
+/// one thread at a time. A model is not Sendable (a LiteRT interpreter is not
+/// thread-safe, which is why Clear pools sessions), and two host threads calling
+/// one handle concurrently is the host's contract to avoid - as it was before the
+/// language could say so. Keeping the assertion here means no FFI entry point has
+/// to make it.
+private struct Transferred<Value>: @unchecked Sendable {
+    let value: Value
+}
+
+/// Run an async operation to completion while blocking the current host worker
+/// thread, handing it `input`. Use this only at synchronous FFI boundaries, never
+/// on an app's main thread.
+public func blockingValue<Value: Sendable, Input>(
+    with input: Input,
+    _ operation: @escaping @Sendable (Input) async -> Value
+) -> Value {
+    let transferred = Transferred(value: input)
+    return blockingValue { await operation(transferred.value) }
+}
+
 /// Run an async operation to completion while blocking the current host worker
 /// thread. Use this only at synchronous FFI boundaries, never on an app's main
 /// thread.

--- a/Sources/Redact/Deterministic.swift
+++ b/Sources/Redact/Deterministic.swift
@@ -169,7 +169,7 @@ enum Deterministic {
     private static let fiHetuShapeRE = rx(#"^(\d{6})[-+A-F](\d{3})([0-9A-Y])$"#)
     private static func fiHetuOk(_ v: String) -> Bool { let s = stripSpaces(v).uppercased(); guard let m = fiHetuShapeRE.first(s) else { return false }; let n = Int(m.group(1)! + m.group(2)!)!; return String(Array("0123456789ABCDEFHJKLMNPRSTUVWXY")[n % 31]) == m.group(3)! }
 
-    private static let natValidators: [Int: [(String) -> Bool]] = [
+    private static let natValidators: [Int: [@Sendable (String) -> Bool]] = [
         9: [nlBsnOk, ptNifOk],
         10: [bgEgnOk, czRcOk, huAdoazOk, plNipOk, atSvnrOk],
         11: [plPeselOk, hrOibOk, grAmkaOk, eeIsikukoodOk, lvPkOk, beRrnOk, itPivaOk],
@@ -179,9 +179,9 @@ enum Deterministic {
 
     // VAT: per-country checksum
     private static let vatFmtOnly: Set<String> = ["ES", "LV", "NL"]
-    private static let vat: [String: (String) -> Bool] = {
-        func re(_ p: String) -> Pattern { rx("^" + p + "$") }
-        var m: [String: (String) -> Bool] = [
+    private static let vat: [String: @Sendable (String) -> Bool] = {
+        @Sendable func re(_ p: String) -> Pattern { rx("^" + p + "$") }
+        var m: [String: @Sendable (String) -> Bool] = [
             "AT": { n in guard re(#"U\d{8}"#).test(n) else { return false }; let d = dl(n); var s = 4; for i in 0..<7 { var x = d[i] * (i % 2 == 1 ? 2 : 1); if x > 9 { x -= 9 }; s += x }; return (10 - s % 10) % 10 == d[7] },
             "BE": { n in re(#"0\d{9}"#).test(n) && (97 - Int(n.prefix(8))! % 97) == Int(n.suffix(2))! },
             "BG": { n in if re(#"\d{9}"#).test(n) { let d = dl(n); var s = 0; for i in 0..<8 { s += d[i]*(i+1) }; s %= 11; if s == 10 { s = 0; for i in 0..<8 { s += d[i]*(i+3) }; s %= 11; if s == 10 { s = 0 } }; return s == d[8] }; return re(#"\d{10}"#).test(n) && bgEgnOk(n) },

--- a/Sources/Regex/Regex.swift
+++ b/Sources/Regex/Regex.swift
@@ -22,6 +22,19 @@
 /// regex literals and generic `RegexComponent` contexts still won't accept it.
 /// Patterns are the common ICU/JS/Java subset (no inline `(?i)` flags or
 /// possessive quantifiers; `\p{...}` is fine).
+// `@unchecked Sendable` because a pattern is shared as a `static let` by every
+// deterministic recognizer, and the Swift 6 language mode needs that to be safe.
+// The claim holds per engine, for a different reason each time:
+//
+//   - Apple and Linux hold an `NSRegularExpression`, which Foundation documents as
+//     immutable and thread-safe for matching.
+//   - Android holds only the pattern string and its case flag, a value type; each
+//     match crosses to the host's java.util.regex on its own.
+//   - wasm holds a JS `RegExp` and does reset `lastIndex` while iterating, so the
+//     claim there rests on that runtime being single-threaded - the same basis as
+//     every other wasm-only unchecked conformance in this package.
+extension Pattern: @unchecked Sendable {}
+
 public struct Pattern {
     private let pattern: String
     private let caseInsensitive: Bool

--- a/Sources/TextNormalization/JSNormalization.swift
+++ b/Sources/TextNormalization/JSNormalization.swift
@@ -3,7 +3,10 @@
 #if os(WASI)
 import JavaScriptKit
 
-private let jsNormalize: JSObject =
+// `nonisolated(unsafe)` because `JSObject` is not Sendable: a JS reference belongs
+// to the context that made it, and this module only ever runs on wasm, which is
+// single-threaded. Same basis as every other wasm-only unchecked global here.
+private nonisolated(unsafe) let jsNormalize: JSObject =
     JSObject.global.Function.function!.new("s", "return s.normalize('NFKC')")
 
 func nfkcNormalize(_ s: String) -> String { jsNormalize(s).string ?? s }

--- a/docs/development.md
+++ b/docs/development.md
@@ -137,6 +137,12 @@ Plus two invariants, in the `checks` job:
   audio stack unless it imports one. An app that adds one SDK pays for that SDK
   alone, and this reads the resolved SwiftPM graph, so it cannot be fooled by an
   incremental build.
+- `check:swift-floor` - the package builds on the oldest Swift the README
+  promises (6.2). Nothing checked this before, so the claim drifted twice: it said
+  5.9 while `nonisolated(unsafe)` (5.10) and later typed throws (6.0) were already
+  in code every consumer parses. Parsing covers the Apple-only and Android-only
+  branches too, since Swift parses inactive `#if` blocks; type-checking those needs
+  the `apple` job.
 - `check:types` - the `.d.ts` files that ship to npm compile, and the two
   contracts core restates are identical to the ones BridgeJS generates from
   Swift: `WasmCore` against the exports a core provides

--- a/mise-tasks/check/swift-floor
+++ b/mise-tasks/check/swift-floor
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#MISE description="Build the package with the oldest Swift the README promises"
+#MISE dir="{{config_root}}"
+#MISE tools={swift={version="6.2.1", os=["linux"]}}
+source "$MISE_PROJECT_ROOT/Tools/dal.sh"
+
+# The README promises a minimum Swift, and nothing used to check it, so the claim
+# drifted twice without anyone noticing: it said 5.9 while `nonisolated(unsafe)`
+# (5.10) and later typed throws (6.0) were already in code every consumer parses.
+# Both would have failed a consumer's build on the toolchain we advertised.
+#
+# This is the same idea as pinning the Linux jobs to ubuntu-22.04 for glibc and
+# the darwin native to macos-14: build where you promise, not where it is easy.
+#
+# What it covers: every file in the package is parsed here, including the
+# `#if canImport(CoreML)` and `#if os(Android)` branches, because Swift parses
+# inactive conditional blocks. That is the class of breakage that actually
+# happened. What it does not cover: type-checking the Apple-only branches, which
+# needs a Mac; the `apple` job builds those, on a newer Xcode.
+floor=$(grep -oE 'version="[0-9.]+"' "$MISE_PROJECT_ROOT/mise-tasks/check/swift-floor" | head -1 | grep -oE '[0-9.]+')
+claimed=$(grep -oE 'Swift [0-9]+\.[0-9]+\+' "$MISE_PROJECT_ROOT/README.md" | head -1 | grep -oE '[0-9]+\.[0-9]+')
+
+# The task's pinned toolchain and the README have to agree, or this proves the
+# wrong thing quietly.
+case "$floor" in
+    "$claimed"*) ;;
+    *)
+        echo "error: this task builds with Swift $floor but README.md promises $claimed" >&2
+        exit 1
+        ;;
+esac
+
+# The dynamic products link LiteRT, so vendor it exactly as build:swift does -
+# a check that skipped linking would miss anything the linker only sees.
+dal_vendor_litert
+litert=$(dal_litert_dir)
+
+echo "== building with Swift $(swift --version | head -1 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1), the floor README.md promises =="
+swift build --scratch-path .build-floor ${litert:+-Xlinker "-L$litert"}
+echo "ok: the package builds on its advertised minimum Swift"

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,7 @@
 #   mise run test:browser        each model's browser path in headless Chromium
 #   mise run test:bundles        every npm package through the real bundlers
 #   mise run check:types         the shipped .d.ts files, and the declared wasm ABI
+#   mise run check:swift-floor   the package builds on the Swift the README promises
 #
 #   mise run build:swift [model] Swift targets, one model at a time
 #   mise run build:wasm  [model] the browser core -> packages/<model>-node/dist
@@ -48,6 +49,7 @@ depends = [
     "check:version",
     "check:isolation",
     "check:types",
+    "check:swift-floor",
     "test:swift",
     "test:wasi",
     "test:js",


### PR DESCRIPTION
The README promised Swift 5.9+ and nothing verified it, so the claim drifted twice: `nonisolated(unsafe)` (5.10) had been in code every consumer parses for a while, and the BridgeJS work added typed throws (6.0), which the tool requires for exported entry points. Swift 5.10.1 cannot even parse two of our files.

Nothing was lost by being wrong, because the App Store has required Xcode 26 (Swift 6.2) since April 28, 2026 - anyone who can ship an app is already past the old floor. So the floor is now 6.2, `swift-tools-version` is 6.2, and the package builds in the Swift 6 language mode.

## The migration

Turning on the language mode produced 132 errors that collapsed into six root causes. Each is fixed by making a claim that is true rather than by silencing the checker, and each says why in a comment:

- **`FFIReader` / `FFIWriter` are `Sendable`.** Plain value types over `[UInt8]`; a public struct simply gets no implicit conformance across module boundaries.
- **`blockingValue(with:)` transfers one non-Sendable value** into the task it blocks on. The unchecked box lives in that function, once, because its contract - the caller blocks until the operation finishes - is what makes it true. The FFI entry points need no annotations of their own.
- **`Pattern` is `@unchecked Sendable`** (this was 128 of the errors, one per static recognizer in Redact). The reason differs per engine: `NSRegularExpression` is documented thread-safe, Android holds only a pattern string and its flag, and the wasm engine resets `lastIndex` while iterating, which is safe only because that runtime is single-threaded.
- **Redact's validator tables are `@Sendable` closures.** They are pure checksums.
- **`TrackedSession.clients` is `nonisolated(unsafe)`** for its `deinit`. `isolated deinit` (SE-0371) is the right feature but requires macOS 15.4, far above this package's floor; the unchecked access is sound because a deinit runs only after the last reference is gone, and a task executing on an actor holds one.
- **`@preconcurrency import AVFoundation`** in AppleAudioIO: `AVAudioConverter`'s input block runs synchronously inside `convert`, but AVFAudio predates the annotations.

## The check

`check:swift-floor` builds the package with the exact Swift the README promises and fails if the two disagree (verified by pointing the README at 6.4 and watching it complain). It vendors LiteRT like `build:swift` so linking is covered, and because Swift parses inactive `#if` branches it also parses the Apple-only and Android-only code - which is the class of breakage that actually happened. Wired into `mise run test` and the `checks` job.

## Verification

At the floor toolchain where it matters, and on every platform:

- **Linux, Swift 6.2.1** (mise-provisioned, what CI uses): full build clean.
- **macOS, Swift 6.2.4**: build clean, `--build-tests` clean, 104 of 106 tests pass - the two failures are the HTTP tests wanting the echo server that `test:swift` starts.
- **wasm, 6.3.3**: builds, after one more `nonisolated(unsafe)` for a JS global.
- **Android, aarch64**: zero errors. The Linux build only *parses* `#if os(Android)` code, so this was cross-compiled separately to type-check it.
