### PR TITLE
Bring uhm into the monorepo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,7 @@ let jsTestSupport: [Target.Dependency] = noJavaScriptKit ? [] : [
 struct ModelPackage {
     let name: String
     var dependencies: [Target.Dependency] = []
+    var resources: [Resource] = []
     var testDependencies: [Target.Dependency] = []
     var testResources: [Resource] = []
 }
@@ -57,6 +58,10 @@ let models: [ModelPackage] = [
         name: "Redact",
         dependencies: [.product(name: "RealModule", package: "swift-numerics")],
         testResources: [.copy("Resources/deterministic_corpus.json")]
+    ),
+    .init(
+        name: "Uhm",
+        dependencies: ["AudioIO", "AudioDSP"]
     ),
 ]
 let modelDependencies: [Target.Dependency] = models.map { .byName(name: $0.name) }
@@ -140,7 +145,8 @@ let modelTargets: [Target] = models.map { model in
         dependencies: [.byName(name: "DesertAnt"), .byName(name: "NativeBindings")]
             + model.dependencies,
         path: "Sources/\(model.name)",
-        exclude: ["Web"]
+        exclude: ["Web"],
+        resources: model.resources
     )
 } + modelWasmTargets
 

--- a/Sources/Uhm/Binding.swift
+++ b/Sources/Uhm/Binding.swift
@@ -1,0 +1,62 @@
+// Uhm's side of the cross-language binding: construction, plus the two payload
+// schemas that are genuinely model-specific (the options a run takes, and what a
+// result looks like). The generic handle lifecycle and the exported symbols live
+// in NativeBindings and UhmNative, so this file is only the model's adapter.
+
+import DesertAnt
+
+extension Uhm: BoundModel {
+    // `isDownloaded()` and `download(progress:)` are Uhm's own public API and
+    // witness the protocol as they stand.
+
+    /// Input payload: `f32Array samples` (mono), then `f64 sampleRate`.
+    ///
+    /// Options payload: `f64 minConfidence` (NaN means the balanced preset),
+    /// then `f64 minDurationSec` (NaN means the SDK default), then
+    /// `u32 includeTypes` (0/1). An empty payload means the SDK defaults.
+    /// The bias presets themselves are Swift-side numbers, so no preset id
+    /// crosses the boundary and adding one breaks no host.
+    ///
+    /// Result payload: `f64 audioDuration`, then `u32 count`, then per
+    /// detection `f64 start`, `f64 end`, `f64 confidence`, and a
+    /// length-prefixed UTF-8 type string (empty when no type was assigned).
+    public func run(input: FFIReader, options: FFIReader) async -> [UInt8]? {
+        var input = input
+        var options = options
+        let samples = input.f32Array()
+        let sampleRate = input.f64()
+        guard !samples.isEmpty, sampleRate > 0 else { return nil }
+        var opts = Options.default
+        if !options.isEmpty {
+            let minConfidence = options.f64()
+            if !minConfidence.isNaN { opts.minConfidence = minConfidence }
+            let minDuration = options.f64()
+            if !minDuration.isNaN { opts.minDurationSec = minDuration }
+            opts.includeTypes = options.u32() != 0
+        }
+        guard let result = try? await analyze(samples: samples,
+                                              sampleRate: Int(sampleRate.rounded()),
+                                              options: opts) else {
+            return nil
+        }
+        var w = FFIWriter()
+        w.f64(result.audioDuration)
+        w.u32(result.fillers.count)
+        for f in result.fillers {
+            w.f64(f.start)
+            w.f64(f.end)
+            w.f64(f.confidence)
+            w.string(f.type?.rawValue ?? "")
+        }
+        return w.bytes
+    }
+}
+
+/// How the generic bindings construct Uhm.
+public enum UhmBinding: ModelBinding {
+    public static let id = UhmModel.id
+
+    public static func make(cacheRoot: String?, directory: String?) -> any BoundModel {
+        Uhm(directory: directory, cacheRoot: cacheRoot)
+    }
+}

--- a/Sources/Uhm/Catalog.swift
+++ b/Sources/Uhm/Catalog.swift
@@ -1,0 +1,50 @@
+// This model's catalog declaration: coordinates, file names, and which of them
+// each platform ships. The shared behaviour (distribution, resolve, availability)
+// comes from `ModelDeclaration` in the catalog's shared half.
+
+import DesertAnt
+
+/// The uhm model: on-device filler-word detection ("uh", "um", "hmm", ...)
+/// with one prediction every 20 ms. One published tier (``Uhm/Quality``; the
+/// standalone SDK's second, HuBERT-base tier is disabled until republished):
+/// the small, fast DistilHuBERT `uhm`, hosted on the Hub as a precompiled,
+/// unzipped `.mlmodelc/`, which is exactly the store's expected layout.
+public enum UhmModel: ModelDeclaration {
+    public static let id = "uhm"
+    public static let product = "Uhm"
+    // The Hub repo has no `v`-tag yet (the standalone uhm-swift SDK tracked its
+    // default branch), so pin the exact commit this SDK is built against;
+    // becomes a `v`-tag once one is published.
+    public static let revision = "612592c10ad7b2a51f3237725448a1aad212480b"
+    /// The standalone uhm-swift release this port matches. No published
+    /// npm/Maven package yet, so nothing cross-checks this the way
+    /// ModelCatalogTests checks emo and redact; keep it in step with
+    /// packages/uhm-* when they land.
+    public static let sdkVersion = "1.1.0"
+    public static let summary = "On-device filler-word detection: frame-precise \"uh\"/\"um\"/\"hmm\" spans."
+
+    /// The tier this declaration describes: the SDK default's resolution.
+    /// A caller-selected tier (`Uhm(quality:)`) downloads through
+    /// ``Uhm/Quality`` rather than through this manifest - the catalog entry
+    /// stays one model's default artifact, which is what tooling and the
+    /// shared test fixture expect.
+    public static let quality = Uhm.Quality.default.resolved
+
+    /// Core ML export (a directory on the Hub): Apple. No LiteRT export has
+    /// been published, so Apple is currently the only platform in `files`.
+    public static let coreML = quality.coreML
+
+    /// The ~13 KB per-filler type-labeler head (SoundAnalysis, Apple-only),
+    /// downloaded alongside the detector. Tier-independent: both qualities'
+    /// file lists include it.
+    public static let labeler = "UhmLabel.mlmodel"
+
+    /// The detector's constants (window length, frame hop, thresholds) live in
+    /// `Detector.swift`, so there are no config sidecars: Apple ships the
+    /// detector plus the tiny type-labeler head.
+    public static let files: [ModelPlatform: [String]] = quality.files
+
+    public static func artifact(for platform: ModelPlatform) -> String {
+        quality.artifact(for: platform)
+    }
+}

--- a/Sources/Uhm/Detector.swift
+++ b/Sources/Uhm/Detector.swift
@@ -1,0 +1,220 @@
+// The frame-level detector: sliding 30 s windows over 16 kHz mono samples,
+// one softmax per 20 ms frame from the model, then threshold + run-merging
+// into (start, end) spans. Platform-neutral: the model runs behind DesertAnt's
+// `InferenceSession` (Core ML on Apple today), and audio decode happens in
+// `Uhm.swift` via AudioIO, so nothing here touches a file or a framework.
+
+import DesertAnt
+
+/// Frame-level filler detector. Wraps an inference session that emits a
+/// per-frame softmax (20 ms frames) over filler classes; this type thresholds
+/// and merges consecutive positive frames into `Filler` spans. Pair with
+/// `FillerTypeClassifier` (Apple) to assign a `Uhm.FillerType`.
+struct FillerDetector: Sendable {
+
+    // MARK: - Configuration
+
+    struct Config: Sendable {
+        var sampleRate: Double
+        var maxWindowSec: Double      // model's fixed input length
+        var hopSec: Double            // sliding window hop between successive model calls
+        var frameHopSamples: Int      // conv stem hop (320 = 20ms @ 16kHz)
+        var minFrameProb: Double      // per-frame threshold for "is filler"
+        var minDurationSec: Double    // discard runs shorter than this
+        var mergeGapSec: Double       // merge adjacent runs within this gap
+
+        static let `default` = Config(
+            sampleRate: 16_000,
+            maxWindowSec: 30.0,
+            hopSec: 25.0,                // 5s overlap between windows
+            frameHopSamples: 320,
+            minFrameProb: 0.5,
+            minDurationSec: 0.10,
+            mergeGapSec: 0.10
+        )
+    }
+
+    /// Bucketed wall-time captured during a single `detect()` call. Exposed via
+    /// the `timingsHandler` for diagnostic / bench callers that want to see
+    /// where inference time is going.
+    struct Timings: Sendable {
+        /// Total session-run wall time across every window. Everything
+        /// accelerator-side lives here.
+        var inferenceSec: Double
+        /// Per-window normalize + input build.
+        var prepSec: Double
+        /// Frame-prob threshold + run merging.
+        var groupSec: Double
+
+        init(inferenceSec: Double = 0, prepSec: Double = 0, groupSec: Double = 0) {
+            self.inferenceSec = inferenceSec
+            self.prepSec = prepSec
+            self.groupSec = groupSec
+        }
+    }
+
+    // The export's tensor names (`models/convert_to_onnx.py` /
+    // `convert_to_coreml.py` in the model repo fix both).
+    private static let inputName = "audio"
+    private static let outputName = "probs"
+
+    let config: Config
+    private let session: any InferenceSession
+    private let maxSamples: Int
+
+    init(session: any InferenceSession, config: Config = .default) {
+        var c = config
+        if let s = environmentVariable("UHM_FRAME_MIN_PROB"), let v = Double(s) {
+            c.minFrameProb = v
+        }
+        self.session = session
+        self.maxSamples = Int(c.maxWindowSec * c.sampleRate)
+        self.config = c
+    }
+
+    // MARK: - Detection
+
+    /// Detect filler spans in mono `samples` (at `config.sampleRate`). Runs
+    /// sliding windows of `maxWindowSec` with `hopSec` hop and averages
+    /// overlapping frame probs. Honours `Task.cancel()` between windows.
+    ///
+    /// Passing an optional `timingsHandler` opts into a per-phase wall-time
+    /// breakdown; the timer overhead is negligible and the handler runs
+    /// synchronously before returning.
+    func detect(
+        samples: [Float],
+        progressHandler: (@Sendable (Double) -> Void)? = nil,
+        timingsHandler: ((Timings) -> Void)? = nil
+    ) async throws -> [Filler] {
+        var t = Timings()
+        // Early bail if the caller already cancelled before we started.
+        try Task.checkCancellation()
+        guard !samples.isEmpty else {
+            timingsHandler?(t)
+            return []
+        }
+
+        let stepSamples = Int(config.hopSec * config.sampleRate)
+        let totalFrames = (samples.count + config.frameHopSamples - 1) / config.frameHopSamples
+        var sumProbs = [Float](repeating: 0, count: totalFrames)
+        var counts = [Float](repeating: 0, count: totalFrames)
+
+        var winOffsets: [(start: Int, end: Int)] = []
+        var winStart = 0
+        while winStart < samples.count {
+            let end = min(samples.count, winStart + maxSamples)
+            winOffsets.append((winStart, end))
+            if end == samples.count { break }
+            winStart += stepSamples
+        }
+
+        progressHandler?(0)
+        for (index, range) in winOffsets.enumerated() {
+            try Task.checkCancellation()
+            let prepStart = ContinuousClock.now
+            let input = normalizedWindow(samples, start: range.start, end: range.end)
+            let tensor = Tensor(float32: input, shape: [1, maxSamples])
+            t.prepSec += Self.elapsed(since: prepStart)
+            let inferenceStart = ContinuousClock.now
+            let outputs = try await session.run(
+                inputs: [Self.inputName: tensor], outputs: [Self.outputName])
+            t.inferenceSec += Self.elapsed(since: inferenceStart)
+            let probs = Self.fillerProbs(outputs.first)
+            let frameOffset = range.start / config.frameHopSamples
+            let usableFrames = (range.end - range.start + config.frameHopSamples - 1)
+                / config.frameHopSamples
+            for k in 0..<min(usableFrames, probs.count) {
+                let g = frameOffset + k
+                if g < totalFrames {
+                    sumProbs[g] += probs[k]
+                    counts[g] += 1
+                }
+            }
+            progressHandler?(min(1.0, Double(index + 1) / Double(winOffsets.count)))
+        }
+
+        // Average overlapping windows.
+        var probs = [Float](repeating: 0, count: totalFrames)
+        for i in 0..<totalFrames {
+            probs[i] = counts[i] > 0 ? sumProbs[i] / counts[i] : 0
+        }
+        let groupStart = ContinuousClock.now
+        let fillers = Self.group(probs: probs, config: config)
+        t.groupSec = Self.elapsed(since: groupStart)
+        timingsHandler?(t)
+        return fillers
+    }
+
+    // MARK: - Helpers
+
+    /// Per-window mean/std normalize, matching the feature extractor used in
+    /// training, zero-padded to the model's fixed window.
+    private func normalizedWindow(_ samples: [Float], start: Int, end: Int) -> [Float] {
+        var mean: Float = 0
+        for i in start..<end { mean += samples[i] }
+        mean /= Float(end - start)
+        var sumSq: Float = 0
+        for i in start..<end { sumSq += (samples[i] - mean) * (samples[i] - mean) }
+        let std = (sumSq / Float(max(1, end - start - 1))).squareRoot() + 1e-7
+        let invStd = 1 / std
+
+        var window = [Float](repeating: 0, count: maxSamples)
+        for k in 0..<(end - start) { window[k] = (samples[start + k] - mean) * invStd }
+        return window
+    }
+
+    /// Per-frame filler probability from the model's `(1, T, C)` softmax:
+    /// `1 - p_not_filler` (class 0). The session backends already deliver
+    /// dense float32, so no stride/precision handling is needed here.
+    private static func fillerProbs(_ tensor: Tensor?) -> [Float] {
+        guard let tensor, let values = tensor.float32Values else { return [] }
+        let shape = tensor.shape
+        guard shape.count >= 3 else { return values }
+        let t = shape[shape.count - 2]
+        let c = shape[shape.count - 1]
+        var result = [Float]()
+        result.reserveCapacity(t)
+        for frame in 0..<t {
+            result.append(1.0 - values[frame * c])
+        }
+        return result
+    }
+
+    /// Threshold frame probs and merge adjacent runs into spans.
+    static func group(probs: [Float], config: Config) -> [Filler] {
+        let threshold = Float(config.minFrameProb)
+        let frameSec = Double(config.frameHopSamples) / config.sampleRate
+        var fillers: [Filler] = []
+        var i = 0
+        while i < probs.count {
+            if probs[i] < threshold { i += 1; continue }
+            var j = i
+            var sum: Float = 0
+            while j < probs.count && probs[j] >= threshold {
+                sum += probs[j]
+                j += 1
+            }
+            let startSec = Double(i) * frameSec
+            let endSec = Double(j) * frameSec
+            let avgConf = Double(sum / Float(j - i))
+            if let last = fillers.last, startSec - last.end <= config.mergeGapSec {
+                fillers[fillers.count - 1] = Filler(
+                    label: "filler",
+                    start: last.start, end: endSec,
+                    confidence: max(last.confidence, avgConf))
+            } else if endSec - startSec >= config.minDurationSec {
+                fillers.append(Filler(
+                    label: "filler",
+                    start: startSec, end: endSec,
+                    confidence: avgConf))
+            }
+            i = j
+        }
+        return fillers
+    }
+
+    private static func elapsed(since start: ContinuousClock.Instant) -> Double {
+        let components = start.duration(to: .now).components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+}

--- a/Sources/Uhm/Filler.swift
+++ b/Sources/Uhm/Filler.swift
@@ -1,0 +1,14 @@
+import DesertAnt
+
+/// A filler span produced by the internal pipeline (frame detector or type
+/// classifier). Mapped to the public `Uhm.Detection` in `Uhm.analyze`.
+struct Filler: Sendable, Equatable {
+    /// Producing-stage label: `"filler"` from the frame detector, or a type
+    /// such as `"uh"`/`"um"` from the type classifier.
+    let label: String
+    let start: Double
+    let end: Double
+    let confidence: Double
+
+    var duration: Double { end - start }
+}

--- a/Sources/Uhm/Labeler.swift
+++ b/Sources/Uhm/Labeler.swift
@@ -1,0 +1,140 @@
+// The per-filler type labeler. A small sound classifier (`uh` / `um` / `hmm` /
+// `other`) trained with CreateML's MLSoundClassifier, so inference runs
+// through Apple's SoundAnalysis framework using the built-in audio feature
+// extractor - the model is just the classifier head (~13 KB), downloaded
+// alongside the detector (`UhmModel.labeler`).
+//
+// SoundAnalysis exists only on Apple platforms, so everywhere else
+// `Detection.type` is nil and `Options.includeTypes` is a no-op. That is the
+// honest shape until a cross-platform labeler export lands.
+
+#if canImport(SoundAnalysis) && canImport(CoreML)
+import Foundation
+import CoreML
+import SoundAnalysis
+
+/// Per-filler type labeler. Used by `Uhm` to attach a `FillerType` to each
+/// detection emitted by the frame-level `FillerDetector`.
+final class FillerTypeClassifier: NSObject, @unchecked Sendable {
+    struct Config: Sendable {
+        var minConfidence: Double
+        var mergeGap: Double           // merge adjacent filler windows within this gap (s)
+        var minDuration: Double        // discard merged events shorter than this
+        var overlapFactor: Double      // SNClassifySoundRequest window overlap
+        var fillerLabel: String
+
+        static let `default` = Config(
+            minConfidence: 0.6,
+            mergeGap: 0.20,
+            minDuration: 0.18,
+            overlapFactor: 0.5,
+            fillerLabel: "filler"
+        )
+    }
+
+    let config: Config
+    private let model: MLModel
+
+    init(modelURL: URL, config: Config = .default) throws {
+        self.config = config
+        let url = modelURL
+        let compiled: URL
+        if url.pathExtension == "mlmodelc" {
+            compiled = url
+        } else {
+            compiled = try MLModel.compileModel(at: url)
+        }
+        self.model = try MLModel(contentsOf: compiled)
+    }
+
+    func detect(audioPath: String) throws -> [Filler] {
+        let url = URL(fileURLWithPath: audioPath)
+        let analyzer = try SNAudioFileAnalyzer(url: url)
+        let request = try SNClassifySoundRequest(mlModel: model)
+        request.overlapFactor = config.overlapFactor
+
+        let observer = ResultsObserver(fillerLabel: config.fillerLabel,
+                                       minConfidence: config.minConfidence)
+        try analyzer.add(request, withObserver: observer)
+        analyzer.analyze()
+
+        return mergeAdjacent(observer.hits)
+    }
+
+    // MARK: - Post-processing
+
+    private struct Hit {
+        let start: Double
+        let end: Double
+        let confidence: Double
+        let label: String
+    }
+
+    private func mergeAdjacent(_ hits: [Hit]) -> [Filler] {
+        guard !hits.isEmpty else { return [] }
+        let sorted = hits.sorted { $0.start < $1.start }
+        var merged: [(start: Double, end: Double, conf: Double, n: Int, label: String)] = []
+        for h in sorted {
+            // Merge only when adjacent AND same label, so per-type stays distinct.
+            if var last = merged.last, h.start - last.end <= config.mergeGap, last.label == h.label {
+                last.end = max(last.end, h.end)
+                last.conf += h.confidence
+                last.n += 1
+                merged[merged.count - 1] = last
+            } else {
+                merged.append((h.start, h.end, h.confidence, 1, h.label))
+            }
+        }
+        return merged.compactMap { run in
+            let dur = run.end - run.start
+            guard dur >= config.minDuration else { return nil }
+            // Strip "filler_" prefix for output: "filler_uh" -> "uh"
+            let displayLabel = run.label.hasPrefix("filler_")
+                ? String(run.label.dropFirst("filler_".count))
+                : run.label
+            return Filler(
+                label: displayLabel,
+                start: run.start,
+                end: run.end,
+                confidence: run.conf / Double(run.n))
+        }
+    }
+
+    // MARK: - SoundAnalysis observer
+
+    private final class ResultsObserver: NSObject, SNResultsObserving {
+        let fillerLabel: String
+        let minConfidence: Double
+        var hits: [Hit] = []
+
+        init(fillerLabel: String, minConfidence: Double) {
+            self.fillerLabel = fillerLabel
+            self.minConfidence = minConfidence
+        }
+
+        func request(_ request: SNRequest, didProduce result: SNResult) {
+            guard let r = result as? SNClassificationResult else { return }
+            guard let top = r.classifications.first else { return }
+            // Accept:
+            //   - "filler" (binary detector)
+            //   - "filler_*" (per-type detector with prefix)
+            //   - "uh"/"um"/"hmm"/"other" (Uhm-Label: forced filler-only model)
+            let label = top.identifier
+            let knownFillerWords: Set<String> = ["uh", "um", "hmm", "other", "ah", "eh", "er", "mm"]
+            let isFiller = label == fillerLabel
+                        || label.hasPrefix("filler_")
+                        || knownFillerWords.contains(label)
+            guard isFiller, Double(top.confidence) >= minConfidence else { return }
+            hits.append(Hit(
+                start: r.timeRange.start.seconds,
+                end: (r.timeRange.start + r.timeRange.duration).seconds,
+                confidence: Double(top.confidence),
+                label: label
+            ))
+        }
+
+        func request(_ request: SNRequest, didFailWithError error: Error) {}
+        func requestDidComplete(_ request: SNRequest) {}
+    }
+}
+#endif

--- a/Sources/Uhm/ModelLoading.swift
+++ b/Sources/Uhm/ModelLoading.swift
@@ -1,0 +1,71 @@
+// How Uhm obtains and shapes its model: the download/adopt sources and the
+// `ModelAssets` the pipeline consumes. (Running the model is `Detector.swift`.)
+// All platform variation is data (which artifact ships where, declared in
+// `Catalog.swift`); building the platform's session is DesertAnt's
+// `inferenceSession` factory - Core ML on Apple, LiteRT on Android/Linux, the
+// JS host on the web.
+import DesertAnt
+
+// The SDK's usage identity (`UhmModel.sdkInfo`) is derived from the catalog
+// declaration's `product` + `sdkVersion`, so it cannot drift from the published
+// package version or be forgotten on a session.
+
+/// A ready inference session for the frame-level detector.
+///
+/// Also the entry point for the cross-language bindings and custom deployments
+/// (not part of the Swift SDK's public API, which loads the model for you).
+@_spi(UhmBindings)
+public struct ModelAssets: Sendable {
+    let session: any InferenceSession
+    /// Path of the downloaded type-labeler model (Apple-only; `nil` when the
+    /// assets were built without a resolved model directory, e.g. from the
+    /// bindings, or when the file is absent).
+    let labelerModelPath: String?
+
+    /// Bindings entry point: build from an already-constructed session (e.g.
+    /// the wasm host's `JSInferenceSession`).
+    @_spi(UhmBindings)
+    public init(session: any InferenceSession) {
+        self.session = session
+        self.labelerModelPath = nil
+    }
+
+    init(session: any InferenceSession, labelerModelPath: String?) {
+        self.session = session
+        self.labelerModelPath = labelerModelPath
+    }
+
+    /// A session over an artifact already on disk (a `.mlmodelc` on Apple).
+    init(modelPath: String, computeUnits: ComputeUnits = .all) throws {
+        self.init(session: try inferenceSession(
+            modelPath: modelPath, computeUnits: computeUnits, sdk: UhmModel.sdkInfo),
+            labelerModelPath: nil)
+    }
+
+    /// Build from a resolved model directory: this platform's session over the
+    /// selected tier's artifact, plus the type-labeler file when present.
+    static func uhm(files: StoredModel, quality: Uhm.Quality,
+                    computeUnits: ComputeUnits) async throws -> ModelAssets {
+        ModelAssets(
+            session: try await files.inferenceSession(
+                model: quality.artifact(for: .current), computeUnits: computeUnits,
+                sdk: UhmModel.sdkInfo),
+            labelerModelPath: files.exists(UhmModel.labeler) ? files.path(UhmModel.labeler) : nil)
+    }
+}
+
+public extension Uhm {
+    /// The published model repository.
+    static var modelRepo: String { UhmModel.repo }
+    /// The model revision this SDK is built against (pinned; not configurable).
+    static var modelRevision: String { UhmModel.revision }
+}
+
+// MARK: shipping the model with your app
+
+// This package bundles no artifacts and has no resource bundle to load one
+// from. The detector model and the tiny type-labeler head (Apple-only) are
+// downloaded on demand: to a managed cache location by default, or to the
+// `directory` you pass. Shipping the model with your app is therefore just
+// pointing `directory` at a folder that already holds this platform's
+// artifacts - they are then used offline, with no download.

--- a/Sources/Uhm/Native.swift
+++ b/Sources/Uhm/Native.swift
@@ -1,0 +1,61 @@
+// Uhm's exported entry points. Everything behind them is model-agnostic and
+// lives in NativeBindings; this file only names the symbols, because symbol
+// names are the one thing that cannot be shared: `@_cdecl` takes a string
+// literal and JNI derives its name from the Kotlin class.
+//
+// The names are model-scoped (`uhm_create`, `Java_ai_desertant_uhm_...`) rather
+// than generic, so two models can be linked into one binary - which is what lets
+// a model be a single target instead of a separate native one.
+
+#if !os(WASI)
+import DesertAnt
+import NativeBindings
+#if os(Android)
+import Android
+#endif
+
+#if !os(Android)
+@_cdecl("uhm_create")
+public func uhm_create(_ modelId: UnsafePointer<CChar>?, _ cacheRoot: UnsafePointer<CChar>?,
+                       _ directory: UnsafePointer<CChar>?) -> UnsafeMutableRawPointer? {
+    nativeCreate(binding: UhmBinding.self, modelId: modelId,
+                 cacheRoot: cacheRoot, directory: directory)
+}
+#endif
+
+#if os(Android)
+@_cdecl("Java_ai_desertant_uhm_UhmNative_create")
+public func androidCreateUhm(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                             _ modelId: jbyteArray?, _ cacheRoot: jbyteArray?,
+                             _ directory: jbyteArray?) -> jlong {
+    androidCreate(UhmBinding.self, env: env, cls: cls, modelId: modelId,
+                  cacheRoot: cacheRoot, directory: directory)
+}
+
+@_cdecl("Java_ai_desertant_uhm_UhmNative_destroy")
+public func androidDestroyUhm(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                              _ handle: jlong) {
+    nativeDestroy(androidPointer(handle))
+}
+
+@_cdecl("Java_ai_desertant_uhm_UhmNative_isDownloaded")
+public func androidIsDownloadedUhm(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                                   _ handle: jlong) -> jint {
+    androidIsDownloaded(env, cls, handle)
+}
+
+@_cdecl("Java_ai_desertant_uhm_UhmNative_download")
+public func androidDownloadUhm(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                               _ handle: jlong) -> jint {
+    androidDownload(env, cls, handle)
+}
+
+@_cdecl("Java_ai_desertant_uhm_UhmNative_run")
+public func androidRunUhm(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                          _ handle: jlong, _ input: jbyteArray?,
+                          _ options: jbyteArray?) -> jbyteArray? {
+    androidRun(env, cls, handle, input, options)
+}
+
+#endif
+#endif

--- a/Sources/Uhm/Quality.swift
+++ b/Sources/Uhm/Quality.swift
@@ -1,0 +1,67 @@
+// Which published tier of the model to run.
+//
+// The standalone uhm-swift SDK shipped two trained models and selected between
+// them with `Uhm(quality:)`; this port keeps that API. Like clear's
+// `ModelVariant`, a quality is a real choice, not a label: it selects the
+// files that get downloaded and loaded, as its own slice of the model repo, so
+// choosing one tier never downloads the other.
+
+import DesertAnt
+
+extension Uhm {
+    /// Model tier, mirroring the standalone uhm-swift SDK's `Uhm.Quality`.
+    ///
+    /// uhm-swift also had `.standard` (the HuBERT-base `uhm-base`, its free
+    /// default). That tier is disabled here for now: its Core ML export has
+    /// not been republished to the monorepo's Hub repo, so declaring the case
+    /// would only offer a download that fails. Reinstate it (case, `stem`,
+    /// `inferred`) once `uhm-base.mlmodelc` is uploaded and the revision pin
+    /// is bumped.
+    public enum Quality: Sendable, Equatable, Hashable, CaseIterable {
+        /// The distilled DistilHuBERT model (smaller, faster, more precise;
+        /// uhm-swift's Pro tier, published here as `uhm`).
+        case high
+        /// Resolves to ``high``. (The standalone SDK resolved `auto` to
+        /// `.standard`; with that tier disabled, `auto` keeps this port's
+        /// shipping behaviour — everyone gets the distilled model.)
+        case auto
+
+        /// The tier a `Uhm` uses unless told otherwise.
+        public static let `default` = Quality.auto
+
+        /// The concrete tier `self` selects (`auto` resolves; the others are
+        /// themselves).
+        public var resolved: Quality { self == .auto ? .high : self }
+
+        /// The artifact stem on the Hub for the resolved tier.
+        var stem: String { "uhm" }
+
+        /// Core ML export (a directory on the Hub): Apple — currently the only
+        /// platform with a published export (see `UhmModel.files`).
+        public var coreML: String { "\(stem).mlmodelc" }
+
+        /// The runnable artifact for `platform`. Only Apple ships today, so
+        /// every platform answers the Core ML name.
+        public func artifact(for platform: ModelPlatform) -> String { coreML }
+
+        /// Repo-relative entries each platform needs for this tier: the
+        /// detector plus the tier-independent type-labeler head.
+        public var files: [ModelPlatform: [String]] {
+            [.apple: [coreML + "/", UhmModel.labeler]]
+        }
+
+        /// This tier's slice of the model repo: the same repo and pinned
+        /// revision as the catalog entry, but only this tier's files.
+        public var distribution: ModelDistribution {
+            ModelDistribution(repo: UhmModel.repo, revision: UhmModel.revision, files: files)
+        }
+
+        /// The tier an artifact path belongs to, by its file name
+        /// (`.../uhm.mlmodelc` -> `.high`), or nil if the name is not a
+        /// published tier - a custom or renamed export.
+        public static func inferred(fromPath path: String) -> Quality? {
+            let name = path.split(separator: "/").last.map(String.init) ?? path
+            return name.hasPrefix("uhm.") ? .high : nil
+        }
+    }
+}

--- a/Sources/Uhm/Uhm.swift
+++ b/Sources/Uhm/Uhm.swift
@@ -1,0 +1,475 @@
+#if canImport(Foundation) && !os(Android) && !os(WASI)
+import Foundation
+#endif
+import DesertAnt
+import AudioDSP
+import AudioIO
+
+/// `Uhm` — public API for filler-word detection: frame-precise "uh", "um",
+/// "hmm" and other filler sounds, one prediction every 20 ms. DistilHuBERT
+/// under the hood, running through desert-ant-core's inference seam (Core ML
+/// on Apple today).
+///
+/// The model is downloaded on demand from `desert-ant-labs/uhm` and cached
+/// locally. Construction is cheap and does no I/O; the model downloads (if
+/// needed) and loads on the first `analyze(...)`. Call `download(progress:)`
+/// to prewarm.
+///
+/// Usage:
+/// ```
+/// let uhm = Uhm()
+/// let result = try await uhm.analyze(audioPath: "in.wav")
+/// for f in result.fillers { print(f.start, f.end, f.type ?? "") }
+/// ```
+///
+/// Trained on English; transfers acoustically to Spanish, French, German, and
+/// Dutch without retraining.
+public final class Uhm: @unchecked Sendable {
+
+    // MARK: - Types
+
+    /// Precision / recall trade-off knob. `balanced` is the default — empirically
+    /// the cleanest cutoff between real fillers and borderline false positives
+    /// across en/es/fr/de/nl. Step up to `.precision` for stricter auto-cut, or
+    /// down to `.recall` when you'd rather review-and-confirm than miss.
+    public enum Bias: Sendable {
+        // Thresholds are stable across model versions: shipped models are
+        // pre-calibrated so a given `Options.minConfidence` means the same thing
+        // against any release.
+        /// Strictest gate (min confidence 0.75) — fewest false alarms; safest for automatic cuts.
+        case precision
+        /// Default gate (min confidence 0.65) — clean cuts on the labeled corpus.
+        case balanced
+        /// Loosest gate (min confidence 0.50) — catches more, at the cost of more false positives.
+        case recall
+
+        /// The confidence threshold this preset maps to. Public so host apps can
+        /// reuse a preset's value directly (e.g. gate an edit action at
+        /// `Bias.precision.minConfidence`) instead of hardcoding the number.
+        public var minConfidence: Double {
+            switch self {
+            case .precision: return 0.75
+            case .balanced: return 0.65
+            case .recall: return 0.50
+            }
+        }
+    }
+
+    /// Tuning for a single `analyze(...)` call.
+    public struct Options: Sendable {
+        /// Precision/recall preset that sets the confidence threshold. Default `.balanced`.
+        public var bias: Bias
+        /// Whether to run the type labeler to fill in `Detection.type`
+        /// (`uh`/`um`/`hmm`/…). Set `false` to skip it when you only need
+        /// filler-vs-not spans. Default `true`. Apple platforms only
+        /// (SoundAnalysis); elsewhere `type` stays nil.
+        public var includeTypes: Bool
+        /// Override the bias preset's confidence threshold. `nil` = use `bias`.
+        public var minConfidence: Double?
+        /// Discard detections shorter than this, in seconds. Default `0.12`.
+        public var minDurationSec: Double
+
+        /// Creates analysis options.
+        /// - Parameters:
+        ///   - bias: Precision/recall preset. Default `.balanced`.
+        ///   - includeTypes: Run the type labeler. Default `true`.
+        ///   - minConfidence: Explicit threshold that overrides `bias`. Default `nil`.
+        ///   - minDurationSec: Minimum detection duration to keep. Default `0.12`.
+        public init(bias: Bias = .balanced,
+                    includeTypes: Bool = true,
+                    minConfidence: Double? = nil,
+                    minDurationSec: Double = 0.12) {
+            self.bias = bias
+            self.includeTypes = includeTypes
+            self.minConfidence = minConfidence
+            self.minDurationSec = minDurationSec
+        }
+
+        /// The default options (`.balanced`, types on, 0.12 s minimum).
+        public static let `default` = Options()
+    }
+
+    /// Output of the per-filler type labeler.
+    /// `and` is a mid-sentence "and"-as-filler subtype — useful when you want
+    /// to keep or treat connectors differently from `uh`/`um`. `other` is the
+    /// "labeler isn't confident which kind" bucket — surface it as something
+    /// neutral ("filler") in user-facing UI; useful as-is for analytics.
+    public enum FillerType: String, Sendable, Codable, CaseIterable {
+        case uh, um, hmm, and, other
+    }
+
+    /// A single detected filler span.
+    public struct Detection: Sendable, Equatable {
+        /// Start time in seconds from the beginning of the audio.
+        public let start: Double
+        /// End time in seconds from the beginning of the audio.
+        public let end: Double
+        /// Model confidence for this span, in `0...1`.
+        public let confidence: Double
+        /// The filler subtype, or `nil` when `includeTypes` is false or the type labeler couldn't load.
+        public let type: FillerType?
+        /// Span length in seconds (`end - start`).
+        public var duration: Double { end - start }
+
+        /// Creates a detection. Normally you receive these from `analyze(...)`
+        /// rather than constructing them, but the initializer is public for
+        /// tests and for feeding `reconcileWords(_:fillers:)`.
+        public init(start: Double, end: Double, confidence: Double, type: FillerType?) {
+            self.start = start
+            self.end = end
+            self.confidence = confidence
+            self.type = type
+        }
+    }
+
+    /// Per-phase wall-time captured during `analyze()`. `inferenceSec` is
+    /// the sum of every model call (the bit the accelerator touches); the
+    /// rest is Swift glue. Use it to tell whether you're CPU-bound on
+    /// decode/labeling or actually waiting on the model.
+    public struct PhaseTimings: Sendable {
+        /// Audio file → 16 kHz mono Float32. One pass over the audio.
+        public var decodeSec: Double
+        /// Cumulative model-inference time inside the frame detector. This is
+        /// the number that moves when you pin compute units.
+        public var inferenceSec: Double
+        /// Per-window normalize + input build.
+        public var prepSec: Double
+        /// Threshold + run merging on frame probs.
+        public var groupSec: Double
+        /// Type-labeler classifier across all detections (small
+        /// model, mostly CPU; usually a few ms total).
+        public var labelingSec: Double
+
+        /// Creates a phase-timing record. Populated by `analyze(...)`; the
+        /// initializer is public mainly for constructing `Result` values in tests.
+        public init(decodeSec: Double = 0,
+                    inferenceSec: Double = 0,
+                    prepSec: Double = 0,
+                    groupSec: Double = 0,
+                    labelingSec: Double = 0) {
+            self.decodeSec = decodeSec
+            self.inferenceSec = inferenceSec
+            self.prepSec = prepSec
+            self.groupSec = groupSec
+            self.labelingSec = labelingSec
+        }
+    }
+
+    /// The result of an `analyze(...)` call.
+    public struct Result: Sendable {
+        /// Detected fillers, in time order.
+        public let fillers: [Detection]
+        /// Total decoded audio length, in seconds.
+        public let audioDuration: Double
+        /// Per-phase breakdown of the `analyze(...)` call this `Result` came from.
+        public let phaseTimings: PhaseTimings
+
+        /// Creates a result. You normally receive this from `analyze(...)`.
+        public init(fillers: [Detection], audioDuration: Double, phaseTimings: PhaseTimings = PhaseTimings()) {
+            self.fillers = fillers
+            self.audioDuration = audioDuration
+            self.phaseTimings = phaseTimings
+        }
+    }
+
+    // MARK: - State
+
+    /// Model input rate: 16 kHz mono, one frame every 20 ms.
+    static let sampleRate = 16_000
+
+    // Resolving, downloading, single-flighting, and offline availability are
+    // `LoadedModel`; Uhm adds only how a resolved directory becomes its session.
+    let model: LoadedModel<ModelAssets>
+
+    /// The concrete model tier this instance loads (`auto` already resolved),
+    /// or nil when it was built from explicit assets or a model path whose
+    /// tier could not be inferred - only the caller knows what that file is.
+    public let resolvedQuality: Quality?
+
+    // MARK: - Init
+
+    /// Creates an analyzer.
+    ///
+    /// Construction does **no** network or model I/O. The model is downloaded
+    /// (if not already cached) and loaded lazily on the first `analyze(...)`.
+    /// To fetch it ahead of time — e.g. at app launch — call
+    /// `download(progress:)`.
+    ///
+    /// Nothing is bundled with this package. To ship the model with your app,
+    /// point `directory` at a folder you populated with the model files: it is
+    /// used as-is, offline, and nothing is downloaded.
+    ///
+    /// - Parameters:
+    ///   - directory: An explicit model home (adopt files there, else download
+    ///     into it), or `nil` for the managed cache.
+    ///   - quality: Which model tier to load. Default `.auto` (see ``Quality``).
+    ///   - computeUnits: Core ML compute-unit policy. Default `.all`.
+    public convenience init(directory: String? = nil, quality: Quality = .auto,
+                            computeUnits: ComputeUnits = .all) {
+        self.init(directory: directory, cacheRoot: nil, quality: quality,
+                  computeUnits: computeUnits)
+    }
+
+    /// Binding entry point that also supplies the platform base cache root under
+    /// which the managed layout lives. On Apple/Linux FileManager provides it,
+    /// so the public `init(directory:...)` passes `nil`.
+    @_spi(UhmBindings)
+    public init(directory: String?, cacheRoot: String?, quality: Quality = .auto,
+                computeUnits: ComputeUnits = .all) {
+        // A tier is its own slice of the model repo, so the loader resolves
+        // that distribution rather than the catalog entry's default one.
+        let resolved = quality.resolved
+        resolvedQuality = resolved
+        model = LoadedModel(resolved.distribution,
+                            directory: directory, cacheRoot: cacheRoot) { files in
+            try await .uhm(files: files, quality: resolved, computeUnits: computeUnits)
+        }
+    }
+
+    /// Creates a detector from explicitly provided assets (the bindings and
+    /// custom-deployment paths).
+    @_spi(UhmBindings)
+    public init(assets: ModelAssets) {
+        resolvedQuality = nil
+        model = LoadedModel { assets }
+    }
+
+    /// Bench / power-user initializer — load a local model artifact directly
+    /// (a `.mlmodelc` on Apple), skipping the store entirely. Lets a host app
+    /// ship its own variant. For tests and custom deployments; apps point
+    /// `directory` at their files instead. The tier is read off the file name
+    /// when it matches a published one (`uhm.*`).
+    public init(modelPath: String, computeUnits: ComputeUnits = .all) throws {
+        let assets = try ModelAssets(modelPath: modelPath, computeUnits: computeUnits)
+        resolvedQuality = Quality.inferred(fromPath: modelPath)
+        model = LoadedModel { assets }
+    }
+
+    /// Whether a given tier is already downloaded and intact (usable offline),
+    /// without constructing an analyzer. `directory` mirrors the initializer's
+    /// parameter (nil = the managed cache).
+    public static func isDownloaded(quality: Quality = .auto,
+                                    directory: String? = nil,
+                                    cacheRoot: String? = nil) -> Bool {
+        quality.resolved.distribution
+            .isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot)
+    }
+
+    // MARK: - Model management
+
+    /// Whether the model is already downloaded and available with no network:
+    /// cached (for the managed location) or already present in `directory`.
+    /// Checked on disk, so it's safe to read on launch to decide whether to
+    /// show a download UI before calling `download(progress:)`.
+    public func isDownloaded() -> Bool { model.isDownloaded() }
+
+    /// Download and cache the model without running anything.
+    ///
+    /// Call this at app launch (or behind a Wi-Fi/"prepare" gate) to prewarm
+    /// the on-device model so the first real `analyze(...)` is instant. Safe to
+    /// call repeatedly: once cached it's a cheap no-op. Concurrent calls, and
+    /// an implicit load from a first use, share one download.
+    ///
+    /// - Parameter progress: Download progress in `0...1`.
+    public func download(progress: @escaping @Sendable (Double) -> Void = { _ in }) async throws {
+        try await model.download(progress: progress)
+    }
+
+    /// Await model readiness. The bindings use this to surface load errors
+    /// eagerly; apps can just call `analyze`.
+    @_spi(UhmBindings)
+    public func waitUntilLoaded() async throws {
+        _ = try await model.value()
+    }
+
+    // MARK: - Analyze
+
+    /// Detects filler words in raw PCM samples.
+    ///
+    /// - Parameters:
+    ///   - samples: Mono PCM samples. Resampled to 16 kHz internally if needed.
+    ///   - sampleRate: Sample rate of `samples`, in Hz.
+    ///   - options: Bias, type labeling, and duration thresholds. Default `.default`.
+    ///   - progressHandler: Optional inference progress in `0...1`.
+    /// - Returns: The detected fillers plus timing metadata.
+    /// - Throws: A model error, or `CancellationError` if the enclosing task is cancelled.
+    public func analyze(
+        samples: [Float],
+        sampleRate: Int,
+        options: Options = .default,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> Result {
+        try await analyze(samples: samples, sampleRate: sampleRate, options: options,
+                          progressHandler: progressHandler, timings: PhaseTimings())
+    }
+
+    private func analyze(
+        samples: [Float],
+        sampleRate: Int,
+        options: Options,
+        progressHandler: (@Sendable (Double) -> Void)?,
+        timings: PhaseTimings
+    ) async throws -> Result {
+        var timings = timings
+        // Bail early if the caller already cancelled.
+        try Task.checkCancellation()
+        // Download (first call only) + load the model. No-op once cached/loaded.
+        let assets = try await model.value()
+
+        let input = sampleRate == Self.sampleRate
+            ? samples
+            : Resample.linear(samples, from: Double(sampleRate), to: Double(Self.sampleRate))
+        let audioDuration = Double(input.count) / Double(Self.sampleRate)
+        let minConf = options.minConfidence ?? options.bias.minConfidence
+
+        let detector = FillerDetector(session: assets.session)
+        var detTimings = FillerDetector.Timings()
+        var detections = try await detector.detect(
+            samples: input,
+            progressHandler: progressHandler,
+            timingsHandler: { detTimings = $0 }
+        )
+        .filter { $0.confidence >= minConf && $0.duration >= options.minDurationSec }
+        .map { Detection(start: $0.start, end: $0.end, confidence: $0.confidence, type: nil) }
+        timings.inferenceSec = detTimings.inferenceSec
+        timings.prepSec = detTimings.prepSec
+        timings.groupSec = detTimings.groupSec
+
+        if options.includeTypes {
+            let labelStart = ContinuousClock.now
+            detections = try await labelDetections(detections, samples: input, assets: assets)
+            timings.labelingSec = elapsedSeconds(since: labelStart)
+        }
+
+        return Result(fillers: detections, audioDuration: audioDuration, phaseTimings: timings)
+    }
+
+    /// Detects filler words in in-memory audio-file `bytes` (WAV and the
+    /// platform's decodable formats).
+    public func analyze(
+        bytes: [UInt8],
+        options: Options = .default,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> Result {
+        let decodeStart = ContinuousClock.now
+        let samples = try await AudioIO.decode(bytes: bytes, sampleRate: Double(Self.sampleRate))
+        return try await analyze(samples: samples, sampleRate: Self.sampleRate, options: options,
+                                 progressHandler: progressHandler,
+                                 timings: PhaseTimings(decodeSec: elapsedSeconds(since: decodeStart)))
+    }
+
+    #if canImport(Foundation) && !os(Android) && !os(WASI)
+    /// Detects filler words in an audio file at the given path.
+    ///
+    /// Any format the platform decoder can read is accepted; audio is decoded
+    /// to 16 kHz mono internally. Filesystem platforms (Apple/Linux); on
+    /// Android/web use `analyze(bytes:)`.
+    ///
+    /// - Parameters:
+    ///   - audioPath: Filesystem path to the audio file.
+    ///   - options: Bias, type labeling, and duration thresholds. Default `.default`.
+    ///   - progressHandler: Optional inference progress in `0...1`.
+    /// - Returns: The detected fillers plus timing metadata.
+    /// - Throws: A decode/model error, or `CancellationError` if the enclosing task is cancelled.
+    public func analyze(
+        audioPath: String,
+        options: Options = .default,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> Result {
+        let decodeStart = ContinuousClock.now
+        let samples = try await AudioIO.decode(path: audioPath, sampleRate: Double(Self.sampleRate))
+        return try await analyze(samples: samples, sampleRate: Self.sampleRate, options: options,
+                                 progressHandler: progressHandler,
+                                 timings: PhaseTimings(decodeSec: elapsedSeconds(since: decodeStart)))
+    }
+
+    /// Detects filler words in the audio at the given file URL.
+    ///
+    /// - Parameters:
+    ///   - audioURL: File URL of the audio. Any decodable format.
+    ///   - options: Bias, type labeling, and duration thresholds. Default `.default`.
+    ///   - progressHandler: Optional inference progress in `0...1`.
+    /// - Returns: The detected fillers plus timing metadata.
+    public func analyze(
+        audioURL: URL,
+        options: Options = .default,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> Result {
+        try await analyze(audioPath: audioURL.path, options: options, progressHandler: progressHandler)
+    }
+    #endif
+
+    func elapsedSeconds(since start: ContinuousClock.Instant) -> Double {
+        let components = start.duration(to: .now).components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+
+    // MARK: - Type labeling (Apple only)
+
+    #if canImport(SoundAnalysis) && canImport(CoreML)
+    private func labelDetections(_ detections: [Detection], samples: [Float], assets: ModelAssets) async throws -> [Detection] {
+        guard !detections.isEmpty,
+              let labelerPath = assets.labelerModelPath,
+              let labeler = try? FillerTypeClassifier(modelURL: URL(fileURLWithPath: labelerPath))
+        else { return detections }
+        let window = Self.sampleRate  // 1 s clip centered on each detection
+        var out: [Detection] = []
+        for d in detections {
+            // Bail between detections so cancellation lands promptly when the
+            // caller flips away (e.g. a setting change invalidates these fillers).
+            try Task.checkCancellation()
+            let center = Int((d.start + d.end) / 2 * Double(Self.sampleRate))
+            let start = max(0, center - window / 2)
+            let end = min(samples.count, start + window)
+            var clip = Array(samples[start..<end])
+            if clip.count < window {
+                clip.append(contentsOf: [Float](repeating: 0, count: window - clip.count))
+            }
+            // SNAudioFileAnalyzer wants a file, so the 1 s clip round-trips
+            // through a temp WAV.
+            let tmpURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("uhm-label-\(UUID().uuidString).wav")
+            try Data(AudioIO.encodeWAV(clip, sampleRate: Self.sampleRate)).write(to: tmpURL)
+            defer { try? FileManager.default.removeItem(at: tmpURL) }
+            let labels = try labeler.detect(audioPath: tmpURL.path)
+            let bestLabel = labels.max(by: { $0.confidence < $1.confidence })
+            let type: FillerType? = bestLabel.flatMap { FillerType(rawValue: $0.label) }
+            out.append(Detection(start: d.start, end: d.end, confidence: d.confidence, type: type))
+        }
+        return out
+    }
+    #else
+    private func labelDetections(_ detections: [Detection], samples: [Float], assets: ModelAssets) async throws -> [Detection] {
+        detections   // no labeler on this platform; `type` stays nil
+    }
+    #endif
+}
+
+/// Errors thrown while loading or running the model. (`MessageError` is
+/// `LocalizedError` wherever Foundation exists, so `localizedDescription`
+/// shows `message`.)
+public enum UhmError: MessageError, Sendable {
+    /// On-device detection failed or returned an unexpected output.
+    case inferenceFailed(String)
+    /// A model resource could not be found.
+    case modelMissing(String)
+
+    public var message: String {
+        switch self {
+        case .inferenceFailed(let detail): "On-device filler detection failed: \(detail)."
+        case .modelMissing(let name): "A Uhm model resource was not found: \(name)."
+        }
+    }
+}
+
+#if os(WASI)
+public extension Uhm {
+    /// Build from a JS host inference session (the wasm entry point). The host
+    /// (supplied to the module at instantiation) must have compiled the model
+    /// first.
+    @_spi(UhmBindings)
+    convenience init() throws {
+        self.init(assets: ModelAssets(session: try inferenceSession(sdk: UhmModel.sdkInfo)))
+    }
+}
+#endif

--- a/Sources/Uhm/Web/main.swift
+++ b/Sources/Uhm/Web/main.swift
@@ -1,0 +1,22 @@
+#if os(WASI)
+import DesertAnt
+import WasmBindings
+@_spi(UhmBindings) import Uhm
+
+// Uhm's WebAssembly entry point.
+//
+// The exported surface is the shared, model-agnostic one in `WasmBindings`
+// (`Exports.swift`, generated into typed JS by BridgeJS), the wasm twin of the
+// `dal_*` C ABI: options and results cross as the FFI payloads
+// `Uhm/Binding.swift` already encodes, so nothing model-specific is repeated
+// here. Uhm has no sidecars, and audio in and out crosses as the model's own
+// payload through the shared `run` entry like any other model's input.
+//
+// Uhm ships no npm package (and no published web artifact) yet, so this is a
+// compile check today; the surface it exposes is the same one every model's
+// package consumes.
+installWasmModel(
+    WasmModel(UhmModel.self, binding: UhmBinding.self) { _, session in
+        Uhm(assets: ModelAssets(session: session))
+    })
+#endif

--- a/Sources/Uhm/WordReconciliation.swift
+++ b/Sources/Uhm/WordReconciliation.swift
@@ -1,0 +1,202 @@
+// Pure geometry over ASR word ranges and detected fillers; no platform
+// dependencies, so it runs everywhere the module builds.
+
+/// A timestamped word from an ASR transcript.
+///
+/// Field names match WhisperKit's `WordTiming` (`word`, `start`, `end`) so the
+/// mapping is trivial:
+///
+/// ```swift
+/// let words = segment.words?.map {
+///     WordRange(start: Double($0.start), end: Double($0.end), word: $0.word)
+/// } ?? []
+/// ```
+///
+/// Float → Double conversion stays the caller's job — keeps this type free
+/// of a hard WhisperKit dependency and lets non-Whisper ASR sources (Apple
+/// `SFSpeechRecognizer`, Deepgram, AssemblyAI, etc.) map in equally easily.
+public struct WordRange: Sendable, Equatable {
+    /// Word start time, in seconds.
+    public var start: Double
+    /// Word end time, in seconds.
+    public var end:   Double
+    /// The transcribed word text.
+    public var word:  String
+
+    /// Creates a timestamped word.
+    public init(start: Double, end: Double, word: String) {
+        self.start = start
+        self.end = end
+        self.word = word
+    }
+
+    /// Word length in seconds (`end - start`).
+    public var duration: Double { end - start }
+}
+
+/// Knobs for `Uhm.reconcileWords`. The defaults match DuoKit's production use:
+/// only adjust words with substantial filler overlap, and emit one timestamp
+/// per word rather than fragments.
+public struct ReconcileOptions: Sendable {
+    /// Minimum overlap fraction — overlap_seconds / piece_duration — before a
+    /// (piece, filler) pair triggers an adjustment. Below this the pair is
+    /// ignored. Default 0.5.
+    ///
+    /// Lower it (e.g. 0.2) to be more aggressive about trimming, at the cost
+    /// of being sensitive to ASR boundary jitter. Raise it to 0.7+ to only
+    /// touch obvious cases.
+    public var minOverlapFraction: Double = 0.5
+
+    /// When a word strictly contains a filler, emit *both* the pre- and
+    /// post-filler halves if true; emit only the longer half if false.
+    /// Default false — most consumers want one timestamp per word.
+    public var splitContainedWords: Bool = false
+
+    /// Creates reconciliation options.
+    /// - Parameters:
+    ///   - minOverlapFraction: Minimum overlap fraction before a (word, filler)
+    ///     pair is adjusted. Default `0.5`.
+    ///   - splitContainedWords: Emit both halves when a word contains a filler.
+    ///     Default `false`.
+    public init(minOverlapFraction: Double = 0.5,
+                splitContainedWords: Bool = false) {
+        self.minOverlapFraction = minOverlapFraction
+        self.splitContainedWords = splitContainedWords
+    }
+}
+
+public extension Uhm {
+    /// Reconcile ASR word ranges with detected filler ranges so cuts can be
+    /// applied without clipping word audio.
+    ///
+    /// Whisper (and most ASR) emits a single word range whose boundaries can
+    /// straddle, contain, or live inside a filler. Naïvely dropping any word
+    /// that overlaps a filler loses ~30 % of detections (the INSIDE-class
+    /// case where Whisper transcribes the filler as a word); naïvely cutting
+    /// at filler boundaries clips real audio. This function applies five
+    /// geometric rules per (word, overlapping filler) pair:
+    ///
+    /// - **Word fully inside filler** → drop the word. Whisper transcribed
+    ///   the filler as a real word.
+    /// - **Word leaks into filler from before** → trim the word's end to
+    ///   `filler.start`.
+    /// - **Word leaks out of filler to after** → push the word's start to
+    ///   `filler.end`.
+    /// - **Word strictly contains the filler** → split into pre- and
+    ///   post-filler ranges; emit the longer half (or both, per
+    ///   `options.splitContainedWords`).
+    /// - **No overlap** → word passes through unchanged.
+    ///
+    /// Multiple fillers overlapping a single word are applied sequentially,
+    /// so a word can split into many pieces if it spans multiple fillers
+    /// (with `splitContainedWords = true`).
+    ///
+    /// The `minOverlapFraction` option gates each rule: an overlap below
+    /// the threshold (vs the current word piece's duration) is ignored,
+    /// so small ASR-vs-Uhm boundary jitter doesn't trim real words.
+    ///
+    /// Output is sorted by `start` and filtered of zero/negative durations.
+    ///
+    /// - Parameters:
+    ///   - words:   ASR word ranges. Need not be sorted.
+    ///   - fillers: Filler detections — typically `result.fillers` from
+    ///              `Uhm.analyze(...)`. Need not be sorted.
+    ///   - options: See `ReconcileOptions`.
+    /// - Returns: Reconciled word ranges, sorted by `start`.
+    static func reconcileWords(
+        _ words: [WordRange],
+        fillers: [Detection],
+        options: ReconcileOptions = .init()
+    ) -> [WordRange] {
+        if fillers.isEmpty {
+            return words
+                .filter { $0.end > $0.start }
+                .sorted { $0.start < $1.start }
+        }
+
+        // Sort once; the per-word loop assumes nothing about input order but
+        // benefits from sequential filler order for the "skip non-overlapping"
+        // micro-optimisation below.
+        let sortedFillers = fillers.sorted { $0.start < $1.start }
+        var output: [WordRange] = []
+        output.reserveCapacity(words.count)
+
+        for word in words {
+            // Start with the original word as a single piece. Each filler may
+            // shrink, drop, or split the current pieces; later fillers see
+            // the already-modified set.
+            var pieces: [WordRange] = [word]
+
+            for filler in sortedFillers {
+                // Fillers are start-ascending: once one starts past the
+                // rightmost piece, no later filler can overlap this word.
+                if let lastEnd = pieces.last?.end, filler.start >= lastEnd {
+                    break
+                }
+                // Cheap reject: filler ended before the leftmost piece.
+                if let firstStart = pieces.first?.start, filler.end <= firstStart {
+                    continue
+                }
+
+                var next: [WordRange] = []
+                next.reserveCapacity(pieces.count)
+
+                for piece in pieces {
+                    let dur = piece.duration
+                    if dur <= 0 { continue }
+
+                    let overlapStart = Swift.max(piece.start, filler.start)
+                    let overlapEnd   = Swift.min(piece.end,   filler.end)
+                    let overlap = overlapEnd - overlapStart
+
+                    if overlap <= 0 {
+                        next.append(piece); continue
+                    }
+
+                    let pieceInsideFiller = filler.start <= piece.start && filler.end >= piece.end
+                    let pieceContainsFiller = piece.start < filler.start && piece.end > filler.end
+                    let leaksFromBefore = piece.start < filler.start && piece.end <= filler.end
+                    let leaksToAfter    = piece.start >= filler.start && piece.end > filler.end
+
+                    // The fraction gate absorbs ASR-vs-filler boundary jitter on partial
+                    // (leak) overlaps only. Full containment is unambiguous — a stretched
+                    // word enclosing a filler has a small overlap *because* it is
+                    // over-extended, the case we most want to split.
+                    if (leaksFromBefore || leaksToAfter), overlap / dur < options.minOverlapFraction {
+                        next.append(piece); continue
+                    }
+
+                    if pieceInsideFiller {
+                        // Drop: Whisper-as-word-of-filler. Don't append.
+                    } else if pieceContainsFiller {
+                        let pre  = WordRange(start: piece.start, end: filler.start, word: piece.word)
+                        let post = WordRange(start: filler.end,  end: piece.end,    word: piece.word)
+                        if options.splitContainedWords {
+                            if pre.duration  > 0 { next.append(pre)  }
+                            if post.duration > 0 { next.append(post) }
+                        } else {
+                            let longer = pre.duration >= post.duration ? pre : post
+                            if longer.duration > 0 { next.append(longer) }
+                        }
+                    } else if leaksFromBefore {
+                        next.append(WordRange(start: piece.start, end: filler.start, word: piece.word))
+                    } else if leaksToAfter {
+                        next.append(WordRange(start: filler.end, end: piece.end, word: piece.word))
+                    } else {
+                        // Shouldn't be reachable given the four exhaustive cases
+                        // when overlap > 0. Pass through defensively.
+                        next.append(piece)
+                    }
+                }
+                pieces = next
+                if pieces.isEmpty { break }
+            }
+
+            output.append(contentsOf: pieces)
+        }
+
+        return output
+            .filter { $0.end > $0.start }
+            .sorted { $0.start < $1.start }
+    }
+}

--- a/Tests/ModelCatalogTests/ModelCatalogTests.swift
+++ b/Tests/ModelCatalogTests/ModelCatalogTests.swift
@@ -4,6 +4,7 @@ import DesertAnt
 @testable import Emo
 @testable import Redact
 @testable import Clear
+@testable import Uhm
 
 /// Every model in the monorepo. The list lives here rather than beside the
 /// `ModelDeclaration` protocol because each model's module depends on the
@@ -13,6 +14,7 @@ let catalog: [any ModelDeclaration.Type] = [
     EmoModel.self,
     RedactModel.self,
     ClearModel.self,
+    UhmModel.self,
 ]
 
 /// Invariants every catalog entry must hold, so a malformed declaration fails

--- a/Tests/UhmTests/UhmTests.swift
+++ b/Tests/UhmTests/UhmTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Uhm
+
+final class UhmTests: XCTestCase {
+
+    func testBiasThresholds() {
+        XCTAssertEqual(Uhm.Bias.precision.minConfidence, 0.75)
+        XCTAssertEqual(Uhm.Bias.balanced.minConfidence, 0.65)
+        XCTAssertEqual(Uhm.Bias.recall.minConfidence, 0.50)
+    }
+
+    func testDefaultOptions() {
+        let options = Uhm.Options.default
+        XCTAssertEqual(options.bias.minConfidence, 0.65)
+        XCTAssertTrue(options.includeTypes)
+        XCTAssertNil(options.minConfidence)
+        XCTAssertEqual(options.minDurationSec, 0.12)
+    }
+}

--- a/Tests/UhmTests/WordReconciliationTests.swift
+++ b/Tests/UhmTests/WordReconciliationTests.swift
@@ -1,0 +1,215 @@
+import Testing
+@testable import Uhm
+
+@Suite struct WordReconciliationTests {
+    // MARK: - Helpers
+
+    private func w(_ start: Double, _ end: Double, _ word: String = "x") -> WordRange {
+        WordRange(start: start, end: end, word: word)
+    }
+
+    private func f(_ start: Double, _ end: Double, type: Uhm.FillerType? = .um) -> Uhm.Detection {
+        Uhm.Detection(start: start, end: end, confidence: 0.9, type: type)
+    }
+
+    // MARK: - Geometry rules (one filler, one word)
+
+    @Test func noFillersReturnsInputUnchanged() {
+        let words = [w(0, 1, "hi"), w(2, 3, "there")]
+        let out = Uhm.reconcileWords(words, fillers: [])
+        #expect(out == words)
+    }
+
+    @Test func noOverlapPassesThrough() {
+        let out = Uhm.reconcileWords([w(0, 1, "hi")], fillers: [f(2, 3)])
+        #expect(out == [w(0, 1, "hi")])
+    }
+
+    @Test func wordFullyInsideFillerIsDropped() {
+        // Whisper transcribed the filler as a word — drop it.
+        let out = Uhm.reconcileWords([w(2.1, 2.7, "uh")], fillers: [f(2.0, 3.0)])
+        #expect(out == [])
+    }
+
+    @Test func wordLeaksIntoFillerFromBefore() {
+        // Word [1, 3], filler [2, 4] — trim word end to 2.
+        let out = Uhm.reconcileWords([w(1, 3, "actually")], fillers: [f(2, 4)])
+        #expect(out == [w(1, 2, "actually")])
+    }
+
+    @Test func wordLeaksOutOfFillerToAfter() {
+        // Word [3, 5], filler [2, 4] — push word start to 4.
+        let out = Uhm.reconcileWords([w(3, 5, "thinking")], fillers: [f(2, 4)])
+        #expect(out == [w(4, 5, "thinking")])
+    }
+
+    @Test func wordContainsFillerEmitsLongerHalfByDefault() {
+        // Word [1, 10] dur 9, filler [2, 7] dur 5 — overlap 5/9 ≈ 56% ≥ 0.5.
+        // Pre=[1,2] dur 1, Post=[7,10] dur 3. Default: emit longer (post).
+        let out = Uhm.reconcileWords([w(1, 10, "and-then-um-anyway")],
+                                     fillers: [f(2, 7)])
+        #expect(out == [w(7, 10, "and-then-um-anyway")])
+    }
+
+    @Test func wordContainsFillerSplitWhenOptedIn() {
+        var opts = ReconcileOptions(); opts.splitContainedWords = true
+        let out = Uhm.reconcileWords([w(1, 10, "and-um-anyway")],
+                                     fillers: [f(2, 7)],
+                                     options: opts)
+        #expect(out == [
+            w(1, 2, "and-um-anyway"),
+            w(7, 10, "and-um-anyway"),
+        ])
+    }
+
+    @Test func wordContainingSmallFillerSplitsRegardlessOfFraction() {
+        // Word [1, 10] dur 9 fully contains filler [2, 3] dur 1 — overlap 11% < 0.5.
+        // Containment is unambiguous (the word is over-extended), so it splits below
+        // the fraction gate; emit the longer post half.
+        let out = Uhm.reconcileWords([w(1, 10, "long")], fillers: [f(2, 3)])
+        #expect(out == [w(3, 10, "long")])
+    }
+
+    @Test func shortFillerDeepInsideLongWordSplits() {
+        // Production case from a transcript: 'but' [6.94, 8.70] encloses a 0.16s
+        // [uh] [7.92, 8.08] — overlap only ~9%, which the fraction gate skipped,
+        // leaving the filler buried in the word. Containment splits to the longer
+        // pre half so the word no longer encloses the filler.
+        let out = Uhm.reconcileWords([w(6.94, 8.70, "but")], fillers: [f(7.92, 8.08)])
+        #expect(out == [w(6.94, 7.92, "but")])
+    }
+
+    // MARK: - minOverlapFraction gating
+
+    @Test func tinyOverlapIgnoredAtDefaultThreshold() {
+        // Word [1, 3] (dur 2), filler [2.95, 5] — overlap = 0.05s, fraction 2.5%.
+        // Below 0.5 default → ignored, word passes through.
+        let out = Uhm.reconcileWords([w(1, 3, "good")], fillers: [f(2.95, 5)])
+        #expect(out == [w(1, 3, "good")])
+    }
+
+    @Test func tinyOverlapHonouredAtLowerThreshold() {
+        var opts = ReconcileOptions(); opts.minOverlapFraction = 0.01
+        let out = Uhm.reconcileWords([w(1, 3, "good")], fillers: [f(2.95, 5)], options: opts)
+        // Now trims at 2.95.
+        #expect(out == [w(1, 2.95, "good")])
+    }
+
+    @Test func fractionThresholdIsAgainstCurrentPieceNotOriginal() {
+        // Word [0, 10] dur 10. Filler1 [2, 7] dur 5 — overlap 50%, at threshold
+        // (strict <, so NOT ignored). Contains rule: pre=[0,2] dur 2,
+        // post=[7,10] dur 3. Longer = post = [7, 10].
+        //
+        // Then filler2 [8, 10]. Piece [7, 10] dur 3. Overlap = 2.
+        //   - piece-relative fraction = 2/3 ≈ 67% → ≥ 0.5, triggers.
+        //   - original-word-relative fraction = 2/10 = 20% → would be ignored
+        //     if (incorrectly) checked against the original word's duration.
+        // So a passing result here confirms threshold is piece-relative.
+        // Piece [7, 10] leaks-from-before filler [8, 10] → trim end to 8.
+        let out = Uhm.reconcileWords([w(0, 10, "long")],
+                                     fillers: [f(2, 7), f(8, 10)])
+        #expect(out == [w(7, 8, "long")])
+    }
+
+    // MARK: - Multiple fillers per word
+
+    @Test func multipleFillersInSingleWordWithSplit() {
+        var opts = ReconcileOptions()
+        opts.splitContainedWords = true
+        opts.minOverlapFraction = 0.05   // small fillers, accept tiny overlaps
+        // Word [0, 10], fillers at [2, 3] and [6, 7].
+        // After first filler: [0,2] + [3,10] (split, both halves emitted).
+        // Second filler ([6, 7]) is inside the [3, 10] piece (dur 7, overlap
+        // 1, fraction ~14% ≥ 5%) → split that piece into [3,6] + [7,10].
+        let out = Uhm.reconcileWords([w(0, 10, "x")],
+                                     fillers: [f(2, 3), f(6, 7)],
+                                     options: opts)
+        #expect(out == [w(0, 2, "x"), w(3, 6, "x"), w(7, 10, "x")])
+    }
+
+    @Test func multipleFillersOnSingleWordSequentialTrim() {
+        // Word [0, 6] dur 6, filler1 [0, 4] dur 4 → overlap 4/6 ≈ 67%.
+        // Word starts at filler.start and ends after filler.end → leaks-to-after
+        // → push start to 4. Piece = [4, 6] dur 2.
+        //
+        // Then filler2 [5, 7] dur 2. Piece [4, 6] vs filler [5, 7]:
+        //   - overlap = 1, piece dur = 2, fraction = 50% (≥ threshold).
+        //   - piece starts before filler, ends inside filler → leaks-from-before
+        //     → trim end to 5. Final piece = [4, 5].
+        let out = Uhm.reconcileWords([w(0, 6, "x")],
+                                     fillers: [f(0, 4), f(5, 7)])
+        #expect(out == [w(4, 5, "x")])
+    }
+
+    @Test func fillerSpansMultipleWords() {
+        // Filler [2, 5], words [1, 3], [3, 4], [4, 6].
+        //  - [1, 3] leaks-from-before → [1, 2]
+        //  - [3, 4] inside filler → dropped
+        //  - [4, 6] leaks-to-after → [5, 6]
+        let out = Uhm.reconcileWords([
+            w(1, 3, "i"),
+            w(3, 4, "uhh"),
+            w(4, 6, "think"),
+        ], fillers: [f(2, 5)])
+        #expect(out == [w(1, 2, "i"), w(5, 6, "think")])
+    }
+
+    // MARK: - Output ordering + degenerate cases
+
+    @Test func outputIsSortedByStart() {
+        // Input deliberately out of order; expect sorted output.
+        let out = Uhm.reconcileWords([
+            w(5, 6, "c"),
+            w(1, 2, "a"),
+            w(3, 4, "b"),
+        ], fillers: [])
+        #expect(out.map { $0.word } == ["a", "b", "c"])
+    }
+
+    @Test func zeroDurationWordsFilteredOut() {
+        let out = Uhm.reconcileWords([w(2, 2, "void"), w(1, 3, "real")],
+                                     fillers: [])
+        #expect(out == [w(1, 3, "real")])
+    }
+
+    @Test func wordEqualToFillerIsDropped() {
+        // Exact same bounds — treated as "fully inside".
+        let out = Uhm.reconcileWords([w(2, 3, "uh")], fillers: [f(2, 3)])
+        #expect(out == [])
+    }
+
+    // MARK: - Realistic INSIDE-class scenario from the brief
+
+    @Test func insideClassThirtyPercentScenario() {
+        // Simulates the actual production case: a transcript where some
+        // words straddle, some live inside, some leak.
+        let words = [
+            w(0.10, 0.42, "I"),
+            w(0.42, 0.81, "think"),
+            w(0.81, 1.05, "um"),       // INSIDE: dropped
+            w(1.05, 1.42, "that"),
+            w(1.42, 1.78, "we"),
+            w(1.78, 2.30, "should"),
+            w(2.30, 2.65, "uh"),       // INSIDE: dropped
+            w(2.65, 3.10, "definitely"),
+            w(3.10, 3.55, "go"),
+        ]
+        let fillers = [
+            f(0.78, 1.10),   // covers "um"
+            f(2.28, 2.70),   // covers "uh"
+        ]
+        let out = Uhm.reconcileWords(words, fillers: fillers)
+        #expect(out.map { $0.word } ==
+                ["I", "think", "that", "we", "should", "definitely", "go"])
+        // No surviving word should overlap a filler more than minOverlapFraction.
+        for word in out {
+            for filler in fillers {
+                let lo = Swift.max(word.start, filler.start)
+                let hi = Swift.min(word.end, filler.end)
+                let overlap = Swift.max(0, hi - lo)
+                #expect(overlap / word.duration < 0.5,
+                        "word \"\(word.word)\" still overlaps filler")
+            }
+        }
+    }
+}

--- a/examples/uhm/UhmSwiftExample/Info.plist
+++ b/examples/uhm/UhmSwiftExample/Info.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Uhm</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>ISGraphicIconConfiguration</key>
+		<dict>
+			<key>ISEnclosureColor</key>
+			<string>indigo</string>
+			<key>ISSymbolColor</key>
+			<string>white</string>
+			<key>ISSymbolName</key>
+			<string>waveform</string>
+		</dict>
+	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/uhm/UhmSwiftExample/README.md
+++ b/examples/uhm/UhmSwiftExample/README.md
@@ -1,0 +1,9 @@
+# Uhm Swift Example
+
+A tiny SwiftUI app for trying Uhm on Apple platforms: pick an audio file and it lists every detected filler ("uh", "um", "hmm") with timestamps and confidence.
+
+## Run
+
+Open `UhmExample.xcodeproj` in Xcode, choose a simulator or device, and press Run.
+
+The first analysis downloads the Core ML model (~45 MB) to the app cache. Later runs use the cached model offline.

--- a/examples/uhm/UhmSwiftExample/UhmExample.xcodeproj/project.pbxproj
+++ b/examples/uhm/UhmSwiftExample/UhmExample.xcodeproj/project.pbxproj
@@ -1,0 +1,277 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 71;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A00000000000000000000012 /* Uhm in Frameworks */ = {isa = PBXBuildFile; productRef = A00000000000000000000011 /* Uhm */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A00000000000000000000004 /* UhmExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UhmExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A00000000000000000000005 /* UhmExample */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = UhmExample; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A00000000000000000000008 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A00000000000000000000012 /* Uhm in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A00000000000000000000002 = {
+			isa = PBXGroup;
+			children = (
+				A00000000000000000000005 /* UhmExample */,
+				A00000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A00000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A00000000000000000000004 /* UhmExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A00000000000000000000006 /* UhmExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A0000000000000000000000B /* Build configuration list for PBXNativeTarget "UhmExample" */;
+			buildPhases = (
+				A00000000000000000000007 /* Sources */,
+				A00000000000000000000008 /* Frameworks */,
+				A00000000000000000000009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A00000000000000000000005 /* UhmExample */,
+			);
+			name = UhmExample;
+			packageProductDependencies = (
+				A00000000000000000000011 /* Uhm */,
+			);
+			productName = UhmExample;
+			productReference = A00000000000000000000004 /* UhmExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A00000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2700;
+				LastUpgradeCheck = 2700;
+				TargetAttributes = {
+					A00000000000000000000006 = {
+						CreatedOnToolsVersion = 27.0;
+					};
+				};
+			};
+			buildConfigurationList = A0000000000000000000000A /* Build configuration list for PBXProject "UhmExample" */;
+			compatibilityVersion = "Xcode 16.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A00000000000000000000002;
+			packageReferences = (
+				A00000000000000000000010 /* XCRemoteSwiftPackageReference "uhm" */,
+			);
+			productRefGroup = A00000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A00000000000000000000006 /* UhmExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A00000000000000000000009 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A00000000000000000000007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A0000000000000000000000C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A0000000000000000000000D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A0000000000000000000000E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = D6V26V7TM4;
+				COREML_CODEGEN_LANGUAGE = None;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.desertant.UhmExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A0000000000000000000000F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = D6V26V7TM4;
+				COREML_CODEGEN_LANGUAGE = None;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.desertant.UhmExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A0000000000000000000000A /* Build configuration list for PBXProject "UhmExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A0000000000000000000000C /* Debug */,
+				A0000000000000000000000D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A0000000000000000000000B /* Build configuration list for PBXNativeTarget "UhmExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A0000000000000000000000E /* Debug */,
+				A0000000000000000000000F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A00000000000000000000010 /* XCRemoteSwiftPackageReference "uhm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Desert-Ant-Labs/uhm-swift.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A00000000000000000000011 /* Uhm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A00000000000000000000010 /* XCRemoteSwiftPackageReference "uhm" */;
+			productName = Uhm;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A00000000000000000000001 /* Project object */;
+}

--- a/examples/uhm/UhmSwiftExample/UhmExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/uhm/UhmSwiftExample/UhmExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/uhm/UhmSwiftExample/UhmExample.xcodeproj/xcshareddata/xcschemes/UhmExample.xcscheme
+++ b/examples/uhm/UhmSwiftExample/UhmExample.xcodeproj/xcshareddata/xcschemes/UhmExample.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A00000000000000000000006"
+               BuildableName = "UhmExample.app"
+               BlueprintName = "UhmExample"
+               ReferencedContainer = "container:UhmExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A00000000000000000000006"
+            BuildableName = "UhmExample.app"
+            BlueprintName = "UhmExample"
+            ReferencedContainer = "container:UhmExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A00000000000000000000006"
+            BuildableName = "UhmExample.app"
+            BlueprintName = "UhmExample"
+            ReferencedContainer = "container:UhmExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/uhm/UhmSwiftExample/UhmExample/ContentView.swift
+++ b/examples/uhm/UhmSwiftExample/UhmExample/ContentView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import Uhm
+
+// A tiny on-device filler-word demo: pick an audio file and Uhm lists every
+// "uh", "um", "hmm" it finds, with timestamps and confidence. Nothing leaves
+// the device. Everything below is UI. The whole SDK surface used here is
+// `Uhm()` and `analyze(audioURL:)` - the first run downloads the model once
+// and caches it; later runs are offline.
+
+struct ContentView: View {
+    private enum Phase: Equatable {
+        case idle, analyzing(Double), results, failed(String)
+    }
+
+    @State private var phase: Phase = .idle
+    @State private var picking = false
+    @State private var fillers: [Uhm.Detection] = []
+    @State private var audioDuration: Double = 0
+    @State private var fileName = ""
+    @State private var analyzeTask: Task<Void, Never>?
+
+    private let uhm = Uhm()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch phase {
+                case .idle: idleView
+                case .analyzing(let fraction): busyView(fraction)
+                case .results: resultsView
+                case .failed(let message): failedView(message)
+                }
+            }
+            .navigationTitle("Uhm")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Pick audio", systemImage: "waveform") { picking = true }
+                        .disabled(isBusy)
+                }
+            }
+            .fileImporter(isPresented: $picking,
+                          allowedContentTypes: [.audio],
+                          allowsMultipleSelection: false) { result in
+                if case let .success(urls) = result, let url = urls.first {
+                    analyze(url)
+                }
+            }
+        }
+    }
+
+    private var isBusy: Bool {
+        if case .analyzing = phase { return true }
+        return false
+    }
+
+    // MARK: Sections
+
+    private var idleView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "waveform")
+                .font(.system(size: 56))
+                .foregroundStyle(.tint)
+                .opacity(0.5)
+            Text("Pick an audio file to find filler words")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.secondary)
+            Text("\"uh\", \"um\", \"hmm\" - found on device, one prediction every 20 ms. The first run downloads the model (~45 MB) and caches it.")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .padding()
+    }
+
+    private func busyView(_ fraction: Double) -> some View {
+        VStack(spacing: 16) {
+            if fraction > 0 {
+                ProgressView(value: fraction)
+                    .frame(maxWidth: 220)
+                Text("Analyzing… \(Int(fraction * 100))%")
+                    .foregroundStyle(.secondary)
+            } else {
+                ProgressView()
+                Text("Loading model…")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+    }
+
+    private func failedView(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 44))
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+
+    private var resultsView: some View {
+        List {
+            Section {
+                if fillers.isEmpty {
+                    Text("No fillers detected.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(fillers.enumerated()), id: \.offset) { _, f in
+                        HStack {
+                            Text(f.type.map { "\($0)" } ?? "filler")
+                                .font(.system(.body, design: .rounded).weight(.medium))
+                            Spacer()
+                            Text("\(Int(f.confidence * 100))%")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                            Text(timecode(f.start))
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } header: {
+                Text("\(fileName) · \(fillers.count) filler\(fillers.count == 1 ? "" : "s") · \(timecode(audioDuration)) of audio")
+            }
+        }
+    }
+
+    // MARK: Analysis
+
+    private func analyze(_ url: URL) {
+        analyzeTask?.cancel()
+        phase = .analyzing(0)
+        fileName = url.lastPathComponent
+        let scoped = url.startAccessingSecurityScopedResource()
+        analyzeTask = Task {
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            do {
+                let result = try await uhm.analyze(audioURL: url) { fraction in
+                    Task { @MainActor in
+                        if case .analyzing = phase { phase = .analyzing(fraction) }
+                    }
+                }
+                fillers = result.fillers
+                audioDuration = result.audioDuration
+                phase = .results
+            } catch is CancellationError {
+                phase = .idle
+            } catch {
+                phase = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    private func timecode(_ seconds: Double) -> String {
+        let m = Int(seconds) / 60
+        let s = seconds - Double(m * 60)
+        return String(format: "%d:%05.2f", m, s)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/examples/uhm/UhmSwiftExample/UhmExample/UhmExampleApp.swift
+++ b/examples/uhm/UhmSwiftExample/UhmExample/UhmExampleApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct UhmExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
Port of Desert-Ant-Labs/uhm-swift (0.1.0) onto the shared seams: its ModelStore snapshot becomes the catalog declaration + LoadedModel, its direct CoreML detector runs behind InferenceSession, and its AVFoundation decode becomes AudioIO/AudioDSP. The SoundAnalysis type labeler stays Apple-only, bundled as the first model target resource (ModelPackage gains a resources field).

Public API matches uhm-swift: single DistilHuBERT model (no tiers), PhaseTimings, analyze(audioPath:/audioURL:/samples:sampleRate:). The Hub repo already ships uhm.mlmodelc/ in the store's expected layout, so only Apple is in files until a LiteRT export lands - like clear, no npm/Maven package yet, so wasm is a compile check.