### PR TITLE
Build the Linux natives on glibc 2.34 for AWS Lambda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
 
   linux:
     name: Linux (Swift + LiteRT)
-    runs-on: ubuntu-22.04 # glibc 2.35, the floor the published natives target
+    runs-on: ubuntu-22.04 # glibc 2.35; the *published* natives build on 2.34 in release.yml
     steps:
       - uses: actions/checkout@v5
       - name: Build deps (static Foundation autolinks these)
@@ -172,7 +172,13 @@ jobs:
       # and that no package's dist is stale.
       - run: mise run check:types
 
+      # These natives only feed test:node and are never published; the real
+      # distribution floor (glibc 2.34, AWS Lambda's AL2023) is enforced by the
+      # release workflow, which builds inside a glibc-2.34 container. This host
+      # is newer, so state its own floor instead of tripping the guard.
       - run: mise run build:node-native
+        env:
+          DAL_GLIBC_CEILING: "2.35"
       - run: mise run test:node
 
       # The browser is the default entry of every model package, so it gets a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,10 @@ jobs:
 
   # The npm packages ship a prebuilt native core per server-side target. Cross-OS
   # builds are not possible, so each is built on its own runner and gathered by
-  # the publish job. Linux builds on 22.04 (glibc 2.35) so the published libs run
-  # on Ubuntu 22.04+/Debian 12+, not only on the build host.
+  # the publish job. Linux builds inside a rhel-ubi9 container (glibc 2.34) so
+  # the published libs run on AWS Lambda's managed Node runtimes (Amazon Linux
+  # 2023 = glibc 2.34) as well as Ubuntu 22.04+/Debian 12+, not only on the
+  # build host. The container also supplies the Swift toolchain.
   natives:
     name: native ${{ matrix.target }}
     needs: gate
@@ -124,8 +126,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { target: linux-x64, runner: ubuntu-22.04 }
-          - { target: linux-arm64, runner: ubuntu-22.04-arm }
+          # Container glibc must stay <= 2.34 (Lambda AL2023); anything older
+          # also works. Newer runner images are fine - the container pins libc.
+          - { target: linux-x64, runner: ubuntu-24.04, container: "swift:6.3.3-rhel-ubi9" }
+          - { target: linux-arm64, runner: ubuntu-24.04-arm, container: "swift:6.3.3-rhel-ubi9" }
           # CI's `darwin-native` job uses the same runner, so the toolchain that
           # ships is the one CI proves. The published native's compatibility floor
           # comes from the manifest's `platforms` (macOS 13), not from the runner;
@@ -133,14 +137,16 @@ jobs:
           # package's 6.2 requirement.
           - { target: darwin-arm64, runner: macos-26 }
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v5
+      # Before checkout: with git present, actions/checkout does a real clone
+      # instead of the REST-tarball fallback the bare ubi9 image would force.
       - name: Linux build deps (static Foundation autolinks these)
         if: startsWith(matrix.target, 'linux')
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
-            libcurl4-openssl-dev libxml2-dev zlib1g-dev binutils file
+          dnf install -y -q --setopt=install_weak_deps=False \
+            git tar gzip libcurl-devel libxml2-devel zlib-devel binutils file
+      - uses: actions/checkout@v5
       - uses: jdx/mise-action@v4
       - uses: astral-sh/setup-uv@v7
         with:

--- a/mise-tasks/build/node-native
+++ b/mise-tasks/build/node-native
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Build each model's native Node core into packages/<model>-node/native/<platform>-<arch>"
 #MISE dir="{{config_root}}"
-#MISE tools={swift={version="6.3.3", os=["linux"]}}
 #USAGE arg "<model>" help="Model to build, or 'all'" default="all"
 source "$MISE_PROJECT_ROOT/Tools/dal.sh"
 
@@ -15,8 +14,11 @@ source "$MISE_PROJECT_ROOT/Tools/dal.sh"
 # self-contained; macOS uses Core ML against the OS-provided runtime.
 #
 # Two Linux distribution rules, learned the hard way:
-#   * build on an old glibc (CI uses ubuntu-22.04 = glibc 2.35) so the published
-#     libs run on Ubuntu 22.04+/Debian 12+, not only on the build host;
+#   * build against glibc <= 2.34: AWS Lambda's managed Node runtimes (Amazon
+#     Linux 2023) ship glibc 2.34, and glibc is only forward-compatible. CI runs
+#     this inside a swift:*-rhel-ubi9 container (glibc 2.34, which also supplies
+#     the Swift toolchain - hence no mise swift pin above); ubuntu-22.04 is
+#     already too new (2.35). Guarded by the ceiling check below;
 #   * link `-z nodelete` so the process does not dlclose the static Swift
 #     runtime at shutdown, which segfaults on natural exit on some glibc builds.
 dal_vendor_litert
@@ -42,6 +44,9 @@ for model in $(dal_select "${usage_model:-all}" node); do
         swift build --scratch-path .build-host -c release --product "${product}Node" ${traits[@]+"${traits[@]}"} \
             -Xlinker -rpath -Xlinker @loader_path
         cp ".build-host/release/lib${product}Node.dylib" "$dest/"
+        # -x drops local symbols; the exported <model>_* C ABI koffi binds
+        # lives in the export table, which strip never touches.
+        strip -x "$dest/lib${product}Node.dylib"
     else
         dest="packages/$model-node/native/linux-$arch"
         rm -rf "$dest" && mkdir -p "$dest"
@@ -62,6 +67,22 @@ for model in $(dal_select "${usage_model:-all}" node); do
         rm -rf "$stub"
         cp ".build-host/release/lib${product}Node.so" "$dest/"
         cp "$litert/libLiteRt.so" "$dest/"
+        # The npm package needs no .debug_info/.symtab; koffi resolves the
+        # <model>_* C ABI through .dynsym, which stripping keeps.
+        strip --strip-unneeded "$dest/lib${product}Node.so"
+        # Distribution floor guard: fail loudly if any shipped lib picked up a
+        # glibc symbol newer than Amazon Linux 2023 (AWS Lambda) provides.
+        # DAL_GLIBC_CEILING loosens it for builds that are never published
+        # (ci.yml's test-only natives build on newer hosts); the release
+        # workflow builds in a glibc-2.34 container and keeps the default.
+        ceiling=${DAL_GLIBC_CEILING:-2.34}
+        for lib in "$dest"/*.so; do
+            max=$(objdump -T "$lib" | grep -o 'GLIBC_[0-9.]*' | sed 's/GLIBC_//' | sort -uV | tail -1)
+            if [ -n "$max" ] && [ "$(printf '%s\n' "$max" "$ceiling" | sort -V | tail -1)" != "$ceiling" ]; then
+                echo "error: $(basename "$lib") requires GLIBC_$max > $ceiling; build on an older glibc" >&2
+                exit 1
+            fi
+        done
     fi
     ls -la "$dest"
 done


### PR DESCRIPTION
ubuntu-22.04 links glibc 2.35 symbols, but Lambda's managed Node runtimes run Amazon Linux 2023 with glibc 2.34, so the published .so failed to dlopen there. Build inside swift:6.3.3-rhel-ubi9 (glibc 2.34, which also supplies the toolchain - the mise swift pin goes away), and guard every shipped lib with an objdump GLIBC_<=2.34 ceiling check.

glibc is backwards compatible so 2.35+ is still supported

   <details>
   <summary>Reproduce before</summary>

   ```bash
   $ docker run --rm redact-glibc-repro; echo "repro-exit=$?"
   glibc: glibc 2.34
   arch:  arm64 | node: v22.23.2
   natives: libLiteRt.so, libRedactNode.so

   Reproduced:
   Failed to load shared library: /lib64/libm.so.6: version `GLIBC_2.35' not found (required by
 /repro/node_modules/@desert-ant-labs/redact/native/linux-arm64/libRedactNode.so)
   repro-exit=0
   ```

   </details>

   <details>
   <summary>After patch</summary>

   ```bash
   $ docker run --rm redact-glibc-fix; echo "exit=$?"
   glibc: glibc 2.34
   arch:  arm64 | node: v22.23.2

   OK: freshly built natives load cleanly on the Lambda runtime
   exit=0
   ```

   </details>

cc @l-r 