### PR TITLE
Honour an explicit cacheRoot on Apple and Linux

### DIFF
--- a/Sources/ModelStore/FoundationBackend.swift
+++ b/Sources/ModelStore/FoundationBackend.swift
@@ -82,7 +82,13 @@ public struct FoundationTransport: ModelTransport {
 
 /// `FileManager`-backed filesystem.
 public struct FoundationFileSystem: FileSystem {
-    public init() {}
+    private let cacheRoot: String?
+
+    /// - Parameter cacheRoot: base for the managed cache layout. `nil` asks
+    ///   `FileManager` for the platform's caches directory.
+    public init(cacheRoot: String? = nil) {
+        self.cacheRoot = cacheRoot.flatMap { $0.isEmpty ? nil : $0 }
+    }
 
     public func exists(_ path: String) -> Bool { FileManager.default.fileExists(atPath: path) }
 
@@ -113,6 +119,7 @@ public struct FoundationFileSystem: FileSystem {
     public func remove(_ path: String) { try? FileManager.default.removeItem(atPath: path) }
 
     public func defaultCacheRoot() -> String {
+        if let cacheRoot { return cacheRoot }
         if let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
             return url.path
         }
@@ -130,13 +137,20 @@ public extension StoredModel {
 
 public extension ModelStore {
     /// Default Apple/Linux store: URLSession + FileManager.
-    init(endpoint: String = "https://huggingface.co") {
-        self.init(transport: FoundationTransport(), fileSystem: FoundationFileSystem(), endpoint: endpoint)
+    ///
+    /// - Parameter cacheRoot: base for the managed cache layout. `nil` uses the
+    ///   platform caches directory, which is the usual case on Apple and Linux.
+    init(cacheRoot: String? = nil, endpoint: String = "https://huggingface.co") {
+        self.init(transport: FoundationTransport(),
+                  fileSystem: FoundationFileSystem(cacheRoot: cacheRoot), endpoint: endpoint)
     }
 
-    /// `cacheRoot` is ignored: FileManager provides a per-app default base.
+    /// An explicit `cacheRoot` wins; `nil` falls back to FileManager's caches
+    /// directory. This used to discard `cacheRoot` outright, so a caller that
+    /// passed one wrote somewhere else without saying so - which matters wherever
+    /// the platform default is not writable.
     static func platformDefault(cacheRoot: String?) throws -> ModelStore {
-        ModelStore()
+        ModelStore(cacheRoot: cacheRoot)
     }
 }
 #endif

--- a/js/src/native-sdk.js
+++ b/js/src/native-sdk.js
@@ -64,8 +64,11 @@ export function createNativeSdk({ here, packageName, modelId, coreName }) {
     core,
     async open(options = {}) {
       const onProgress = typeof options.onProgress === "function" ? options.onProgress : undefined;
-      const cacheRoot = options.cacheRoot ?? native.defaultCacheRoot();
-      const handle = core.create(cacheRoot, options.directory ?? null);
+      // Only an explicit cacheRoot goes down. Apple and Linux resolve their own
+      // caches directory, so the default fabricated here was discarded by the
+      // core anyway; now that the core honours what it is given, sending one
+      // would relocate every existing cache.
+      const handle = core.create(options.cacheRoot ?? null, options.directory ?? null);
       return readyModel({ core, packageName, handle, onProgress });
     },
   };


### PR DESCRIPTION
`ModelStore.platformDefault` discarded `cacheRoot` outright on Apple and Linux, so a caller that passed one wrote somewhere else without saying so: zero files there, `load()` back in 47 ms, quietly using the platform caches directory. It matters wherever that default is not writable.

The Node side stops fabricating a default to pair with it. The platform supplies one, and now that the core honours what it is given, sending `~/.cache` would relocate every existing cache. Only an explicit `cacheRoot` goes down, which is what `LoadedModel` already documented.

Verified: explicit root downloads into it with the managed layout; default load still resolves in 35 ms against the existing cache.