### PR TITLE
State the real Apple floor: macOS 15 / iOS 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,15 @@ jobs:
           - { target: linux-x64, runner: ubuntu-24.04, container: "swift:6.3.3-rhel-ubi9" }
           - { target: linux-arm64, runner: ubuntu-24.04-arm, container: "swift:6.3.3-rhel-ubi9" }
           # CI's `darwin-native` job uses the same runner, so the toolchain that
-          # ships is the one CI proves. The published native's compatibility floor
-          # comes from the manifest's `platforms` (macOS 13), not from the runner;
-          # macos-14 is no longer usable because its Swift 5.10 predates the
-          # package's 6.2 requirement.
+          # ships is the one CI proves. macos-14 is no longer usable because its
+          # Swift 5.10 predates the package's 6.2 requirement.
+          #
+          # The runner does not set the Apple floor either way: that comes from the
+          # Core ML models, built for macOS 15 / iOS 18. macOS 14 refuses to load
+          # them ("compiler major version for compiled model is 9.0.0 and is more
+          # recent than this framework major version 8.0.0"), macOS 15 and 26 both
+          # accept them. There is no `platforms` clause in Package.swift, so
+          # nothing enforces this at resolve time; the README states it.
           - { target: darwin-arm64, runner: macos-26 }
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Face](https://huggingface.co/desert-ant-labs).
 
 ### Install
 
-Requirements: iOS 16+, macOS 13+, tvOS 16+, visionOS 1+, and Swift 6.2+ (Xcode 26).
+Requirements: iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, and Swift 6.2+ (Xcode 26).
+The floor is the Core ML models', not the code's: they are built for this
+deployment target, and an older OS refuses to load them.
 
 Add the package with Swift Package Manager:
 
@@ -281,7 +283,7 @@ verified before it is used.
 
 | Platform | Runtime | Requirements |
 |---|---|---|
-| iOS, macOS, tvOS, visionOS | Core ML | iOS 16+, macOS 13+, tvOS 16+, visionOS 1+, Swift 6.2+ |
+| iOS, macOS, tvOS, visionOS | Core ML | iOS 18+, macOS 15+, tvOS 18+, visionOS 2+, Swift 6.2+ |
 | Android | LiteRT | API 24+, arm64-v8a and x86_64 |
 | Browser | WebAssembly + LiteRT.js | any browser with WebAssembly; `@litertjs/core` |
 | Node | prebuilt native core | linux-x64, linux-arm64, darwin-arm64 |


### PR DESCRIPTION
The README promised **iOS 16+ / macOS 13+ / tvOS 16+ / visionOS 1+**. The Core ML models are built for iOS 18, so an older OS refuses to load them: the package resolves fine and then fails at runtime.

Measured on the published `redact` v0.4.0 artifact (`coremlc 3520.5.1`), loading it with `MLModel(contentsOf:)` on three runners:

| macOS | result |
|---|---|
| 14.8.7 | **REFUSED** — `compiler major version for compiled model is 9.0.0 and is more recent than this framework major version 8.0.0` |
| 15.7.7 | ACCEPTED |
| 26.5.2 | ACCEPTED |

The iOS, tvOS and visionOS numbers are the equivalents of that deployment target, not separate measurements — worth a simulator check before anyone leans on them.

This **documents** the floor rather than moving it. No functional change: prose and one comment, no `Package.swift` clause, no CI behaviour. Nothing enforces the floor at resolve time, which is a separate decision.

`release.yml`'s comment claimed the floor came from a manifest `platforms` clause of macOS 13. There is no such clause, and that was never the constraint.