### PR TITLE
Map platform onto the ingest enum, and make telemetry debuggable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,19 @@ jobs:
           # that it can never be invalidated.
           enable-cache: false
 
+      # Same reasoning as the Apple job: no model artifact is committed, so the
+      # model-backed suites download the pinned revision on a cold cache. Cache
+      # the store so that happens once per revision rather than once per push -
+      # anonymous Hub tree calls from every push 429 under parallel jobs - and
+      # the run stays independent of Hugging Face being reachable. On Linux the
+      # managed store lives under XDG's ~/.cache.
+      - name: Cache downloaded models
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/desert-ant-models
+          key: models-${{ runner.os }}-${{ hashFiles('Sources/*/Catalog.swift') }}
+          restore-keys: models-${{ runner.os }}-
+
       # An app that adds one SDK must pay for that SDK alone; this reads the
       # resolved SwiftPM graph, so it needs the toolchain this job already has.
       - run: mise run check:isolation
@@ -155,6 +168,20 @@ jobs:
             ~/.swiftpm/swift-sdks
             ~/.config/swiftpm/swift-sdks
           key: swift-wasm-sdk-6.3.3
+
+      # The node package suites download the pinned model revision too: into the
+      # suite-local .model-cache (an explicit `directory`), and the managed store
+      # for anything resolving by default. Cache both for the same reason as the
+      # Swift jobs. The browser suite fetches inside Chromium and is not covered
+      # by a file cache.
+      - name: Cache downloaded models
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/desert-ant-models
+            packages/*-node/test/.model-cache
+          key: models-js-${{ runner.os }}-${{ hashFiles('Sources/*/Catalog.swift') }}
+          restore-keys: models-js-${{ runner.os }}-
 
       # The JS-host backends (JSON.parse, RegExp, String.normalize, fetch) only
       # actually execute under wasm, so this is the browser correctness check.

--- a/Sources/NativeBindings/CExports.swift
+++ b/Sources/NativeBindings/CExports.swift
@@ -30,6 +30,11 @@ public func dal_destroy(_ handle: UnsafeMutableRawPointer?) {
     nativeDestroy(handle)
 }
 
+@_cdecl("dal_flush_telemetry")
+public func dal_flush_telemetry() {
+    nativeFlushTelemetry()
+}
+
 @_cdecl("dal_buffer_free")
 public func dal_buffer_free(_ pointer: UnsafeMutablePointer<CChar>?) {
     nativeBufferFree(pointer)

--- a/Sources/NativeBindings/NativeRuntime.swift
+++ b/Sources/NativeBindings/NativeRuntime.swift
@@ -68,6 +68,14 @@ public func nativeRun(
     return payload.flatMap(ffiEmit)
 }
 
+/// Debug-only: force every tracked session to emit usage now (bypassing the
+/// debounce and the re-emit window) and block until the sends complete. Only
+/// does anything when `DAL_HTTP_DEBUG` is set (otherwise no hooks are installed
+/// and this returns immediately).
+public func nativeFlushTelemetry() {
+    blockingValue { await TelemetryDebug.shared.flushAndWait() }
+}
+
 public func nativeDestroy(_ handle: UnsafeMutableRawPointer?) {
     guard let handle else { return }
     Unmanaged<NativeHandle>.fromOpaque(handle).release()

--- a/Sources/Usage/Transport.swift
+++ b/Sources/Usage/Transport.swift
@@ -23,6 +23,8 @@ public func makeSend(endpoint: String) -> @Sendable (IngestBody, SendOptions) ->
         // (the transport is fire-and-forget). These types always encode.
         guard let json = try? buildBody(body) else { return }
         let payload = Array(json.utf8)
+        let debug = telemetryDebugEnabled()
+        if debug { print("[usage] POST \(endpoint)\n[usage] body: \(json)") }
         #if os(WASI)
         // On the browser, an unload flush must use navigator.sendBeacon (a normal
         // fetch is cancelled as the page goes away). text/plain keeps it a CORS
@@ -30,7 +32,15 @@ public func makeSend(endpoint: String) -> @Sendable (IngestBody, SendOptions) ->
         if opts.beacon, jsSendBeacon(endpoint, payload) { return }
         #endif
         let task = Task.detached {
-            _ = try? await httpPOST(endpoint, body: payload, contentType: "application/json")
+            do {
+                let response = try await httpPOST(endpoint, body: payload, contentType: "application/json")
+                if debug {
+                    let text = String(decoding: response.body, as: UTF8.self)
+                    print("[usage] response: \(response.status) \(text)")
+                }
+            } catch {
+                if debug { print("[usage] send failed: \(error)") }
+            }
         }
         // When enabled, let a caller await this otherwise fire-and-forget send.
         if telemetryDebugEnabled() {

--- a/Sources/Usage/Wire.swift
+++ b/Sources/Usage/Wire.swift
@@ -10,6 +10,9 @@
 // Android/wasm), so no JSON is hand-written here.
 
 import JSON
+#if os(WASI)
+import JavaScriptKit
+#endif
 
 /// SDK identity attached to every body's `sdk` field.
 public let defaultSDKName = "desert-ant-core"
@@ -17,24 +20,29 @@ public let defaultSDKVersion = "0.1.0" // keep in sync with the package/product 
 
 /// The platform tag put on the wire's `platform` field, derived from the build
 /// target. `IngestBody` defaults to this, so callers never pass it by hand.
+///
+/// The ingest API accepts exactly `ios | android | web | server`, so the build
+/// targets are mapped onto those: Apple device platforms (iPhone, TV, watch,
+/// Vision) report `ios`, and everything that runs on a desktop or a server
+/// (macOS, Linux, Node-native hosts) reports `server`. The wasm build serves
+/// two hosts from one binary — a browser page and Node (e.g. an SSR pass) — so
+/// on WASI the tag is detected at runtime: a browser is `web`, Node is `server`.
 #if os(Android)
 public let defaultPlatform = "android"
-#elseif os(iOS)
+#elseif os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
 public let defaultPlatform = "ios"
-#elseif os(macOS)
-public let defaultPlatform = "macos"
-#elseif os(tvOS)
-public let defaultPlatform = "tvos"
-#elseif os(visionOS)
-public let defaultPlatform = "visionos"
-#elseif os(watchOS)
-public let defaultPlatform = "watchos"
-#elseif os(Linux)
-public let defaultPlatform = "linux"
 #elseif os(WASI)
-public let defaultPlatform = "web"
+public var defaultPlatform: String {
+    // Node exposes `process.versions.node`; no browser global does. Checked
+    // rather than `location` so an SSR framework that shims `location` (or a
+    // browser extension page without one) still classifies correctly.
+    if JSObject.global.process.object?.versions.object?.node.string != nil {
+        return "server"
+    }
+    return "web"
+}
 #else
-public let defaultPlatform = "unknown"
+public let defaultPlatform = "server"
 #endif
 
 /// SDK identity block. Optional fields on the wire are omitted when `nil`

--- a/Tests/UsageTests/UsageClientTests.swift
+++ b/Tests/UsageTests/UsageClientTests.swift
@@ -185,7 +185,9 @@ struct WireTests {
         #elseif os(Android)
         #expect(body.platform == "android")
         #elseif os(WASI)
-        #expect(body.platform == "web")
+        // One wasm binary serves two hosts, detected at runtime: a browser is
+        // "web", Node (where this suite runs on CI) is "server".
+        #expect(body.platform == "web" || body.platform == "server")
         #endif
         #expect(["ios", "android", "web", "server"].contains(body.platform))
         #expect(body.platform == defaultPlatform)

--- a/Tests/UsageTests/UsageClientTests.swift
+++ b/Tests/UsageTests/UsageClientTests.swift
@@ -177,19 +177,17 @@ struct WireTests {
     @Test func platformDefaultsToBuildTarget() throws {
         // No platform passed: IngestBody fills it from the build target.
         let body = IngestBody(sentAt: "t", events: [IngestEvent(deviceId: "d")])
-        #if os(macOS)
-        #expect(body.platform == "macos")
-        #elseif os(iOS)
+        // The ingest API accepts exactly these values; build targets map onto them.
+        #if os(macOS) || os(Linux)
+        #expect(body.platform == "server")
+        #elseif os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         #expect(body.platform == "ios")
-        #elseif os(Linux)
-        #expect(body.platform == "linux")
         #elseif os(Android)
         #expect(body.platform == "android")
         #elseif os(WASI)
         #expect(body.platform == "web")
-        #else
-        #expect(!body.platform.isEmpty)
         #endif
+        #expect(["ios", "android", "web", "server"].contains(body.platform))
         #expect(body.platform == defaultPlatform)
     }
 

--- a/examples/redact/RedactWasmExample/telemetry-test.mjs
+++ b/examples/redact/RedactWasmExample/telemetry-test.mjs
@@ -1,0 +1,25 @@
+// Telemetry smoke test against the real ingest API, server-side (native Node).
+//
+// Runs a redaction through the local packages/redact-node native build, then
+// forces the debounced usage POST out and awaits it. With DAL_HTTP_DEBUG set,
+// the Swift core logs the exact body posted and the response status + body.
+//
+// Run from the repo root:
+//   mise run build:node-native redact   # once, to build the native core
+//   node examples/redact/RedactWasmExample/telemetry-test.mjs
+
+// Must be set before the model loads: the Swift core reads it at session
+// creation to install the flush hooks, and the transport reads it to log.
+process.env.DAL_HTTP_DEBUG = "1";
+
+const { Redact } = await import("../../../packages/redact-node/node.js");
+
+const redact = await Redact.load({});
+const r = await redact.redaction("Hi, I'm Anna Kowalska, reach me at anna.k@example.com.");
+console.log("redacted: " + r.redactedText);
+
+// Force the usage turnstile to emit now (bypassing the debounce and the
+// re-emit window) and wait for the HTTP send to finish before exiting.
+console.log("flushing telemetry...");
+await globalThis.__dalFlushTelemetry();
+console.log("done");

--- a/js/src/native-sdk.js
+++ b/js/src/native-sdk.js
@@ -57,8 +57,16 @@ export function createNativeSdk({ here, packageName, modelId, coreName }) {
       }
     },
     destroy: (handle) => lib.destroy(handle),
+    flushTelemetry: () => callAsync(lib.flushTelemetry),
     withCallGroup,
   };
+
+  // Debug-only hook for forcing the usage POST out and awaiting it, mirroring
+  // the wasm entry (`createWasmSdk`). Gated on the same flag the Swift core
+  // reads natively, so it exists exactly when the flush hooks are installed.
+  if (process.env.DAL_HTTP_DEBUG) {
+    globalThis.__dalFlushTelemetry = () => core.flushTelemetry();
+  }
 
   return {
     core,

--- a/js/src/native.js
+++ b/js/src/native.js
@@ -43,6 +43,9 @@ export const dalSymbols = (modelId) => ({
   // options and the result. A video model needs no new symbol here.
   run: "void* dal_run(void*, const uint8_t*, int, const uint8_t*, int, const char*, const char*)",
   destroy: "void dal_destroy(void*)",
+  // Debug-only (DAL_HTTP_DEBUG): force pending usage telemetry out and block
+  // until the sends finish.
+  flushTelemetry: "void dal_flush_telemetry()",
   bufferFree: "void dal_buffer_free(void*)",
 });
 


### PR DESCRIPTION
The ingest API accepts exactly ios | android | web | server, but native builds sent the raw build target (macos, linux), so every native send was silently 400'd. Desktop and server hosts now report "server"; on WASI, where one wasm binary serves both a browser page and Node, the tag is detected at runtime (process.versions.node => server, else web).

Under DAL_HTTP_DEBUG the transport logs the posted body and the response status + body, and a new dal_flush_telemetry export gives the Node native path the same force-flush-and-await hook the wasm entry already had (globalThis.__dalFlushTelemetry). telemetry-test.mjs exercises the whole path against the live API; verified with a 202.