### PR TITLE
Make arm64 inference work where /sys/devices/system/cpu is not mounted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,28 @@ jobs:
           DAL_GLIBC_CEILING: "2.35"
       - run: mise run test:node
 
+      # The sysfs shim, proved where it matters: a container with
+      # /sys/devices/system/cpu masked, which is the shape AWS Lambda presents.
+      # Reading the cpu range must fail without the preload and succeed with it.
+      # The interposition is arch-independent, so x86_64 gates it even though
+      # only arm64 needs it at run time.
+      - name: cpu-topology shim intercepts a masked sysfs
+        run: |
+          set -euo pipefail
+          shim=packages/redact-node/native/linux-x64/libdalcpushim.so
+          [ -f "$shim" ] || { echo "::error::build:node-native did not produce $shim"; exit 1; }
+          mask="--mount type=tmpfs,destination=/sys/devices/system/cpu,tmpfs-mode=0555"
+          read_cpu='require("node:fs").readFileSync("/sys/devices/system/cpu/possible","utf8")'
+          if docker run --rm $mask -v "$PWD/$shim:/shim.so" node:22-slim \
+               node -e "$read_cpu" 2>/dev/null; then
+            echo "::error::sysfs was readable without the shim; the test proves nothing"
+            exit 1
+          fi
+          got=$(docker run --rm $mask -v "$PWD/$shim:/shim.so" -e LD_PRELOAD=/shim.so \
+                  node:22-slim node -e "process.stdout.write($read_cpu.trim())")
+          echo "with shim, /sys/devices/system/cpu/possible = '$got'"
+          [[ "$got" =~ ^0(-[0-9]+)?$ ]] || { echo "::error::unexpected cpu range '$got'"; exit 1; }
+
       # The browser is the default entry of every model package, so it gets a
       # real engine and real weights, not just a bundle that compiles.
       - run: mise run test:browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,11 +208,9 @@ jobs:
           DAL_GLIBC_CEILING: "2.35"
       - run: mise run test:node
 
-      # The sysfs shim, proved where it matters: a container with
-      # /sys/devices/system/cpu masked, which is the shape AWS Lambda presents.
-      # Reading the cpu range must fail without the preload and succeed with it.
-      # The interposition is arch-independent, so x86_64 gates it even though
-      # only arm64 needs it at run time.
+      # A container with /sys/devices/system/cpu masked, the shape Lambda
+      # presents: the read must fail without the preload and succeed with it.
+      # x86_64 gates it because the interposition is arch-independent.
       - name: cpu-topology shim intercepts a masked sysfs
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
   - [Usage](#usage-2)
 - [Model downloads and caching](#model-downloads-and-caching)
   - [Offline and airgapped](#offline-and-airgapped)
+  - [AWS Lambda on arm64](#aws-lambda-on-arm64)
 - [Platform support](#platform-support)
 - [Contributing](#contributing)
 - [License](#license)
@@ -308,6 +309,24 @@ and no network at run time. For a build that has to be reproducible, use the
 commit sha in place of the tag - the Hub accepts either, and `v0.4.0` is
 `1d65950bbf0459a4d7a94afb85095877f585d99c`. A revision is pinned per SDK version
 and moves only with a deliberate bump: every 1.0.x release ships `v0.4.0`.
+
+### AWS Lambda on arm64
+
+Lambda does not mount `/sys/devices/system/cpu`. On arm64 the CPU backend reads
+it to enumerate cores, so without it inference fails on every call even though
+the library loads. Preload the shim shipped alongside the native:
+
+```
+LD_PRELOAD=/var/task/node_modules/@desert-ant-labs/redact/native/linux-arm64/libdalcpushim.so
+```
+
+Set it as a function environment variable, and correct the path if the package
+lives in a layer (`/opt/nodejs/node_modules/...`). It answers those two sysfs
+reads and passes everything else through untouched. The dynamic linker has to
+insert it before libc, which is why the SDK cannot do this for you.
+
+x86_64 needs none of this: there the core count comes from a CPU instruction
+rather than sysfs.
 
 ## Platform support
 

--- a/Tools/cpushim/dal_cpu_shim.c
+++ b/Tools/cpushim/dal_cpu_shim.c
@@ -1,0 +1,101 @@
+// Supplies the two sysfs files XNNPACK's cpuinfo needs when the kernel's CPU
+// tree is not mounted. Preloaded with LD_PRELOAD; does nothing otherwise.
+//
+// Why this exists. LiteRT's CPU accelerator is XNNPACK, which asks cpuinfo to
+// enumerate cores before it builds its thread pool. On ARM there is no
+// instruction that answers that, so cpuinfo reads
+// /sys/devices/system/cpu/{possible,present}. AWS Lambda's sandbox does not
+// mount /sys/devices/system/cpu at all, cpuinfo fails, XNNPACK never
+// initializes, and LiteRtCreateCompiledModel fails - inference is dead while
+// the library itself loaded fine. x86_64 is unaffected: there cpuinfo uses the
+// CPUID instruction and never touches sysfs, which is the whole asymmetry.
+//
+// Only those two exact paths are answered; every other call goes straight to
+// libc. The reply is served from anonymous memory, so no writable filesystem is
+// needed and there is nothing to clean up.
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static const char kPossible[] = "/sys/devices/system/cpu/possible";
+static const char kPresent[] = "/sys/devices/system/cpu/present";
+
+static int wanted(const char *path) {
+  return path && (strcmp(path, kPossible) == 0 || strcmp(path, kPresent) == 0);
+}
+
+// A read-only fd holding the cpu range sysfs would have reported, e.g. "0-1".
+// -1 leaves the caller to the real file, so a host that does mount sysfs is
+// never second-guessed on the strength of a failed memfd.
+static int cpu_range_fd(void) {
+  long n = sysconf(_SC_NPROCESSORS_ONLN);
+  if (n < 1) n = 1;
+  char buf[32];
+  int len = (n == 1) ? snprintf(buf, sizeof buf, "0\n")
+                     : snprintf(buf, sizeof buf, "0-%ld\n", n - 1);
+  int fd = memfd_create("dal-cpu-range", MFD_CLOEXEC);
+  if (fd < 0) return -1;
+  if (write(fd, buf, len) != len || lseek(fd, 0, SEEK_SET) != 0) {
+    close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+// O_CREAT's mode is variadic; read it only when the flag is set, as libc does.
+static mode_t creat_mode(int flags, va_list ap) {
+  return (flags & O_CREAT) ? (mode_t)va_arg(ap, int) : 0;
+}
+
+int open(const char *path, int flags, ...) {
+  static int (*real)(const char *, int, ...);
+  if (!real) real = dlsym(RTLD_NEXT, "open");
+  if (wanted(path)) {
+    int fd = cpu_range_fd();
+    if (fd >= 0) return fd;
+  }
+  va_list ap;
+  va_start(ap, flags);
+  mode_t mode = creat_mode(flags, ap);
+  va_end(ap);
+  return real(path, flags, mode);
+}
+
+int open64(const char *path, int flags, ...) {
+  static int (*real)(const char *, int, ...);
+  if (!real) real = dlsym(RTLD_NEXT, "open64");
+  if (wanted(path)) {
+    int fd = cpu_range_fd();
+    if (fd >= 0) return fd;
+  }
+  va_list ap;
+  va_start(ap, flags);
+  mode_t mode = creat_mode(flags, ap);
+  va_end(ap);
+  return real(path, flags, mode);
+}
+
+FILE *fopen(const char *path, const char *mode) {
+  static FILE *(*real)(const char *, const char *);
+  if (!real) real = dlsym(RTLD_NEXT, "fopen");
+  if (wanted(path)) {
+    int fd = cpu_range_fd();
+    if (fd >= 0) return fdopen(fd, "r");
+  }
+  return real(path, mode);
+}
+
+FILE *fopen64(const char *path, const char *mode) {
+  static FILE *(*real)(const char *, const char *);
+  if (!real) real = dlsym(RTLD_NEXT, "fopen64");
+  if (wanted(path)) {
+    int fd = cpu_range_fd();
+    if (fd >= 0) return fdopen(fd, "r");
+  }
+  return real(path, mode);
+}

--- a/Tools/cpushim/dal_cpu_shim.c
+++ b/Tools/cpushim/dal_cpu_shim.c
@@ -1,18 +1,7 @@
-// Supplies the two sysfs files XNNPACK's cpuinfo needs when the kernel's CPU
-// tree is not mounted. Preloaded with LD_PRELOAD; does nothing otherwise.
-//
-// Why this exists. LiteRT's CPU accelerator is XNNPACK, which asks cpuinfo to
-// enumerate cores before it builds its thread pool. On ARM there is no
-// instruction that answers that, so cpuinfo reads
-// /sys/devices/system/cpu/{possible,present}. AWS Lambda's sandbox does not
-// mount /sys/devices/system/cpu at all, cpuinfo fails, XNNPACK never
-// initializes, and LiteRtCreateCompiledModel fails - inference is dead while
-// the library itself loaded fine. x86_64 is unaffected: there cpuinfo uses the
-// CPUID instruction and never touches sysfs, which is the whole asymmetry.
-//
-// Only those two exact paths are answered; every other call goes straight to
-// libc. The reply is served from anonymous memory, so no writable filesystem is
-// needed and there is nothing to clean up.
+// LD_PRELOAD shim answering the two sysfs files XNNPACK's cpuinfo reads to count
+// cores, for hosts that do not mount /sys/devices/system/cpu (AWS Lambda).
+// Without them inference fails on arm64; x86_64 uses CPUID and never reads them.
+// Every other call passes through to libc.
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <fcntl.h>
@@ -29,21 +18,11 @@ static int wanted(const char *path) {
   return path && (strcmp(path, kPossible) == 0 || strcmp(path, kPresent) == 0);
 }
 
-// A read-only fd holding the cpu range sysfs would have reported, e.g. "0-1".
-// -1 leaves the caller to the real file, so a host that does mount sysfs is
-// never second-guessed on the strength of a failed memfd.
+// The cpu range sysfs would report, e.g. "0-1", served from anonymous memory.
+// -1 falls back to the real file.
 //
-// The count is whatever the kernel reports, which is what a mounted sysfs would
-// have said. On Lambda that is the microVM's CPU count rather than the fractional
-// vCPU the function is entitled to - true on x86_64 too, where cpuinfo reads
-// CPUID and never comes near this file, so it is the platform's answer and not
-// this shim's invention.
-//
-// Two things keep this from recursing, and both are load-bearing: `online` is not
-// in `wanted`, and only open/fopen are interposed, not openat. sysconf reads
-// /sys/devices/system/cpu/online before falling back to /proc/stat, and it does so
-// with a direct openat that never reaches the PLT. Intercept openat *and* claim
-// `online`, and this calls itself forever.
+// Do not add "online" to `wanted` or interpose openat: sysconf reads that path,
+// so the shim would call itself forever.
 static int cpu_range_fd(void) {
   long n = sysconf(_SC_NPROCESSORS_ONLN);
   if (n < 1) n = 1;

--- a/Tools/cpushim/dal_cpu_shim.c
+++ b/Tools/cpushim/dal_cpu_shim.c
@@ -32,6 +32,18 @@ static int wanted(const char *path) {
 // A read-only fd holding the cpu range sysfs would have reported, e.g. "0-1".
 // -1 leaves the caller to the real file, so a host that does mount sysfs is
 // never second-guessed on the strength of a failed memfd.
+//
+// The count is whatever the kernel reports, which is what a mounted sysfs would
+// have said. On Lambda that is the microVM's CPU count rather than the fractional
+// vCPU the function is entitled to - true on x86_64 too, where cpuinfo reads
+// CPUID and never comes near this file, so it is the platform's answer and not
+// this shim's invention.
+//
+// Two things keep this from recursing, and both are load-bearing: `online` is not
+// in `wanted`, and only open/fopen are interposed, not openat. sysconf reads
+// /sys/devices/system/cpu/online before falling back to /proc/stat, and it does so
+// with a direct openat that never reaches the PLT. Intercept openat *and* claim
+// `online`, and this calls itself forever.
 static int cpu_range_fd(void) {
   long n = sysconf(_SC_NPROCESSORS_ONLN);
   if (n < 1) n = 1;

--- a/js/src/native.js
+++ b/js/src/native.js
@@ -84,12 +84,32 @@ export function loadNative({ here, packageName, coreName, modelId, symbols, targ
     return dir;
   }
 
+  // LiteRT's CPU accelerator is XNNPACK, which asks cpuinfo to enumerate cores
+  // first. On ARM that answer only exists in sysfs, and AWS Lambda does not
+  // mount /sys/devices/system/cpu, so XNNPACK never starts and every inference
+  // fails while the library itself loaded cleanly. Checked here so that reads as
+  // a fixable setup problem instead of surfacing later as "the model failed to
+  // run". x86_64 is unaffected: cpuinfo uses CPUID there and never opens sysfs.
+  function checkCpuTopology(dir) {
+    if (process.platform !== "linux" || process.arch !== "arm64") return;
+    if (fs.existsSync("/sys/devices/system/cpu/present")) return;
+    if ((process.env.LD_PRELOAD ?? "").includes("libdalcpushim")) return;
+    const shim = path.join(dir, "libdalcpushim.so");
+    throw new Error(
+      `${packageName}: this host does not mount /sys/devices/system/cpu, which the ` +
+        `CPU backend needs to enumerate cores on arm64 (AWS Lambda is one such host). ` +
+        `Set LD_PRELOAD=${shim} to preload the shim bundled with this package, ` +
+        `or run on x86_64, which does not need it.`,
+    );
+  }
+
   const CORE = coreFile(coreName);
   let lib;
   function loadLib() {
     if (lib) return lib;
     const koffi = koffiModule();
     const dir = nativeDir();
+    checkCpuTopology(dir);
     // Load the LiteRT runtime first so the core's DT_NEEDED resolves in-process.
     const runtime = RUNTIME[process.platform];
     if (runtime && fs.existsSync(path.join(dir, runtime))) koffi.load(path.join(dir, runtime));

--- a/js/src/native.js
+++ b/js/src/native.js
@@ -84,12 +84,9 @@ export function loadNative({ here, packageName, coreName, modelId, symbols, targ
     return dir;
   }
 
-  // LiteRT's CPU accelerator is XNNPACK, which asks cpuinfo to enumerate cores
-  // first. On ARM that answer only exists in sysfs, and AWS Lambda does not
-  // mount /sys/devices/system/cpu, so XNNPACK never starts and every inference
-  // fails while the library itself loaded cleanly. Checked here so that reads as
-  // a fixable setup problem instead of surfacing later as "the model failed to
-  // run". x86_64 is unaffected: cpuinfo uses CPUID there and never opens sysfs.
+  // Without /sys/devices/system/cpu the CPU backend cannot count cores on arm64
+  // and every inference fails, though the library loads fine. Caught here so it
+  // reads as a setup problem rather than "the model failed to run".
   function checkCpuTopology(dir) {
     if (process.platform !== "linux" || process.arch !== "arm64") return;
     if (fs.existsSync("/sys/devices/system/cpu/present")) return;

--- a/mise-tasks/build/node-native
+++ b/mise-tasks/build/node-native
@@ -67,6 +67,11 @@ for model in $(dal_select "${usage_model:-all}" node); do
         rm -rf "$stub"
         cp ".build-host/release/lib${product}Node.so" "$dest/"
         cp "$litert/libLiteRt.so" "$dest/"
+        # Ships next to the natives so a host with no /sys/devices/system/cpu
+        # (AWS Lambda) can LD_PRELOAD it and let XNNPACK start. Not loaded
+        # otherwise, and not linked into anything - see the source for why the
+        # dynamic linker has to be the one to insert it.
+        cc -shared -fPIC -O2 -o "$dest/libdalcpushim.so" Tools/cpushim/dal_cpu_shim.c -ldl
         # The npm package needs no .debug_info/.symtab; koffi resolves the
         # <model>_* C ABI through .dynsym, which stripping keeps.
         strip --strip-unneeded "$dest/lib${product}Node.so"

--- a/mise-tasks/build/node-native
+++ b/mise-tasks/build/node-native
@@ -67,10 +67,8 @@ for model in $(dal_select "${usage_model:-all}" node); do
         rm -rf "$stub"
         cp ".build-host/release/lib${product}Node.so" "$dest/"
         cp "$litert/libLiteRt.so" "$dest/"
-        # Ships next to the natives so a host with no /sys/devices/system/cpu
-        # (AWS Lambda) can LD_PRELOAD it and let XNNPACK start. Not loaded
-        # otherwise, and not linked into anything - see the source for why the
-        # dynamic linker has to be the one to insert it.
+        # Ships beside the natives for hosts with no /sys/devices/system/cpu to
+        # LD_PRELOAD; nothing links it.
         cc -shared -fPIC -O2 -o "$dest/libdalcpushim.so" Tools/cpushim/dal_cpu_shim.c -ldl
         # The npm package needs no .debug_info/.symtab; koffi resolves the
         # <model>_* C ABI through .dynsym, which stripping keeps.

--- a/mise-tasks/build/node-native
+++ b/mise-tasks/build/node-native
@@ -72,7 +72,7 @@ for model in $(dal_select "${usage_model:-all}" node); do
         cc -shared -fPIC -O2 -o "$dest/libdalcpushim.so" Tools/cpushim/dal_cpu_shim.c -ldl
         # The npm package needs no .debug_info/.symtab; koffi resolves the
         # <model>_* C ABI through .dynsym, which stripping keeps.
-        strip --strip-unneeded "$dest/lib${product}Node.so"
+        strip --strip-unneeded "$dest/lib${product}Node.so" "$dest/libdalcpushim.so"
         # Distribution floor guard: fail loudly if any shipped lib picked up a
         # glibc symbol newer than Amazon Linux 2023 (AWS Lambda) provides.
         # DAL_GLIBC_CEILING loosens it for builds that are never published


### PR DESCRIPTION
On arm64, Lambda does not mount `/sys/devices/system/cpu`, so LiteRT's CPU backend cannot count cores and every inference fails even though the library loads. x86_64 is fine because it reads CPUID instead.

This adds a small `LD_PRELOAD` shim that answers the only two files cpuinfo needs, shipped beside the natives. The SDK cannot load it itself — libc always wins symbol resolution — so the loader now detects the situation and prints the exact `LD_PRELOAD` to set instead of failing with "the model failed to run". README documents it; CI gates it in a container with the tree masked.

Verified in a linux/arm64 container: fails with sysfs masked, works with the shim, cpuinfo errors gone.