### PR TITLE
Clear: pin the model, fix mastering, ship the packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 |---|---|---|---|---|---|
 | **Emo** | Multilingual emoji suggestion from short text, 23 languages | `Emo` | `ai.desertant:emo` | `@desert-ant-labs/emo` | [Hugging Face](https://huggingface.co/desert-ant-labs/emo) |
 | **Redact** | PII detection and reversible redaction, 27 languages | `Redact` | `ai.desertant:redact` | `@desert-ant-labs/redact` | [Hugging Face](https://huggingface.co/desert-ant-labs/redact) |
-| **Clear** | Speech enhancement: denoise, dereverb, podcast-ready 48 kHz | `Clear` | soon | soon | [Hugging Face](https://huggingface.co/desert-ant-labs/clear) |
+| **Clear** | Speech enhancement: denoise, dereverb, podcast-ready 48 kHz | `Clear` | `ai.desertant:clear` | `@desert-ant-labs/clear` | [Hugging Face](https://huggingface.co/desert-ant-labs/clear) |
 
 Each model behaves the same on every platform, so you can build a feature once
 and ship it everywhere. New models are added regularly; the current set is always
@@ -166,6 +166,7 @@ dependencyResolutionManagement {
 dependencies {
     implementation("ai.desertant:emo:1.0.5")
     implementation("ai.desertant:redact:1.0.5")
+    implementation("ai.desertant:clear:1.0.5")
 }
 ```
 
@@ -173,8 +174,8 @@ One dependency per model, using the coordinates from the table above.
 
 ### Usage
 
-`suggestions`, `redaction`, and `download` are suspending functions. A model owns
-native resources, so close it when you are done, or let `use { }` do it.
+`suggestions`, `redaction`, `enhance`, and `download` are suspending functions. A
+model owns native resources, so close it when you are done, or let `use { }` do it.
 
 ```kotlin
 import ai.desertant.emo.Emo
@@ -193,6 +194,21 @@ Redact(context).use { redact ->
     val result = redact.redaction("Email Anna Kovács at anna@example.hu.")
     println(result.redactedText)                 // Email [GIVEN_NAME_1] [SURNAME_1] at [EMAIL_1].
     val restored = result.restore(llmReply)
+}
+```
+
+```kotlin
+import ai.desertant.clear.Clear
+import ai.desertant.clear.LoudnessPreset
+import ai.desertant.clear.Mastering
+import ai.desertant.clear.Options
+
+Clear(context).use { clear ->
+    val result = clear.enhance(samples, 48_000.0)            // 48 kHz mono out
+    result.measuredTruePeakDbfs                              // what the master actually peaks at
+
+    val forSpotify = Options(mastering = Mastering.of(LoudnessPreset.SPOTIFY))
+    val louder = clear.enhance(samples, 48_000.0, forSpotify)
 }
 ```
 
@@ -244,6 +260,16 @@ const result = await redact.redaction("Email Anna Kovács at anna@example.hu.");
 console.log(result.redactedText);   // Email [GIVEN_NAME_1] [SURNAME_1] at [EMAIL_1].
 const restored = result.restore(llmReply);
 redact.dispose();
+```
+
+```ts
+import { Clear } from "@desert-ant-labs/clear";
+
+const clear = await Clear.load();
+const result = await clear.enhance(samples, 48_000);   // Float32Array in, 48 kHz mono out
+result.measuredTruePeakDBFS;                           // what the master actually peaks at
+await clear.enhance(samples, 48_000, { targetLUFS: "spotify" });
+clear.dispose();
 ```
 
 Self-host the model files or track download progress:

--- a/Sources/AudioDSP/Limiter.swift
+++ b/Sources/AudioDSP/Limiter.swift
@@ -66,6 +66,30 @@ public enum Limiter {
         channels = out
     }
 
+    /// ``Limiter/truePeakDBFS(_:)`` over a signal delivered in pieces, for the
+    /// file path, which never holds the whole master. Carrying the last sample
+    /// across calls is what keeps the interpolated peaks at a chunk boundary
+    /// from being missed.
+    public final class TruePeakMeter {
+        private var maxAbs: Float = 0
+        private var prev: Float = 0
+
+        public init() {}
+
+        public func consume(_ samples: [Float]) {
+            for cur in samples {
+                maxAbs = max(maxAbs, abs(cur))
+                maxAbs = max(maxAbs, abs(0.75 * prev + 0.25 * cur))
+                maxAbs = max(maxAbs, abs(0.50 * prev + 0.50 * cur))
+                maxAbs = max(maxAbs, abs(0.25 * prev + 0.75 * cur))
+                prev = cur
+            }
+        }
+
+        /// dBFS, or `-infinity` if nothing but silence was fed.
+        public var dBFS: Double { maxAbs > 0 ? 20 * log10(Double(maxAbs)) : -.infinity }
+    }
+
     /// Per-position magnitude across channels: what the envelope reacts to.
     static func jointMagnitude(_ channels: [[Float]], count n: Int) -> [Float] {
         var absX = [Float](repeating: 0, count: n)

--- a/Sources/AudioDSP/Limiter.swift
+++ b/Sources/AudioDSP/Limiter.swift
@@ -1,0 +1,174 @@
+// Look-ahead peak limiting and true-peak measurement: the half of mastering
+// that rides transients instead of turning the whole file down.
+//
+// A single static gain cannot hold a loudness target and a peak ceiling at the
+// same time: one transient above the ceiling forces the gain down for the
+// entire signal, landing the master below the LUFS it was asked for. The
+// limiter pulls gain down only around the peaks that need it, so a delivery
+// spec like -16 LUFS at -1.5 dBTP is met rather than approximated.
+//
+// Attack is instantaneous - the look-ahead window is what buys the time to
+// reach the required gain before the peak arrives - and release is exponential.
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Android)
+import Android
+#elseif canImport(WASILibc)
+import WASILibc
+#endif
+
+public enum Limiter {
+    /// How far ahead the limiter sees. The gain is already at its target when
+    /// the peak arrives, so the attack costs no distortion.
+    public static let lookaheadSeconds = 0.005
+    /// Exponential release back to unity gain once a peak has passed.
+    public static let releaseSeconds = 0.050
+
+    /// True peak in dBFS across every channel, by 4x linear interpolation, or
+    /// `-infinity` for digital silence.
+    ///
+    /// Inter-sample peaks live between samples, so the largest sample is not
+    /// the largest value a DAC will reconstruct. Four phases is the BS.1770
+    /// oversampling factor; linear interpolation is the approximation the
+    /// platform SDKs shipped, and it errs low by a fraction of a dB rather
+    /// than reporting a peak that is not there.
+    public static func truePeakDBFS(_ channels: [[Float]]) -> Double {
+        var maxAbs: Float = 0
+        for channel in channels {
+            var prev: Float = 0
+            for cur in channel {
+                maxAbs = max(maxAbs, abs(cur))
+                maxAbs = max(maxAbs, abs(0.75 * prev + 0.25 * cur))
+                maxAbs = max(maxAbs, abs(0.50 * prev + 0.50 * cur))
+                maxAbs = max(maxAbs, abs(0.25 * prev + 0.75 * cur))
+                prev = cur
+            }
+        }
+        guard maxAbs > 0 else { return -.infinity }
+        return 20 * log10(Double(maxAbs))
+    }
+
+    /// Limit `channels` in place so nothing exceeds `ceilingDBTP`.
+    ///
+    /// Implemented as one pass of ``Limiter/Streaming`` over the whole signal
+    /// rather than as its own loop, so the in-memory and file-streaming paths
+    /// cannot drift apart.
+    public static func apply(_ channels: inout [[Float]], ceilingDBTP: Double, sampleRate: Double) {
+        guard !channels.isEmpty, (channels.first?.count ?? 0) > 0 else { return }
+        let limiter = Streaming(ceilingDBTP: ceilingDBTP, sampleRate: sampleRate,
+                                channels: channels.count)
+        var out = limiter.process(channels)
+        let tail = limiter.flush()
+        for c in 0..<out.count { out[c].append(contentsOf: tail[c]) }
+        channels = out
+    }
+
+    /// Per-position magnitude across channels: what the envelope reacts to.
+    static func jointMagnitude(_ channels: [[Float]], count n: Int) -> [Float] {
+        var absX = [Float](repeating: 0, count: n)
+        for channel in channels {
+            channel.withUnsafeBufferPointer { src in
+                guard let p = src.baseAddress else { return }
+                for i in 0..<n {
+                    let a = abs(p[i])
+                    if a > absX[i] { absX[i] = a }
+                }
+            }
+        }
+        return absX
+    }
+
+    /// A limiter over a signal delivered in pieces.
+    ///
+    /// `process` can only emit samples whose look-ahead window it has actually
+    /// seen, so it holds the last `lookahead` samples of every chunk back and
+    /// returns them from a later `process` or from `flush`. Feeding the whole
+    /// signal in one call and then flushing gives the same samples as feeding
+    /// it in pieces: the envelope and the held-back tail both carry across.
+    ///
+    /// Not thread safe; feed it from one place.
+    public final class Streaming {
+        private let ceiling: Float
+        private let lookahead: Int
+        private let release: Float
+        /// The gain envelope, carried across calls. This is the state that
+        /// makes chunked limiting identical to whole-signal limiting.
+        private var env: Float = 1
+        private var pending: [[Float]]
+
+        public init(ceilingDBTP: Double, sampleRate: Double, channels: Int) {
+            ceiling = Float(pow(10, ceilingDBTP / 20))
+            lookahead = max(0, Int(Limiter.lookaheadSeconds * sampleRate))
+            release = Float(exp(-1.0 / (sampleRate * Limiter.releaseSeconds)))
+            pending = Array(repeating: [], count: max(0, channels))
+        }
+
+        /// Limit what can be finished, and hold the rest for the next call.
+        public func process(_ chunk: [[Float]]) -> [[Float]] {
+            let nCh = pending.count
+            guard chunk.count == nCh, nCh > 0 else { return chunk }
+            var joined = [[Float]]()
+            joined.reserveCapacity(nCh)
+            for c in 0..<nCh { joined.append(pending[c] + chunk[c]) }
+
+            let total = joined[0].count
+            guard total > 0 else { return Array(repeating: [], count: nCh) }
+            let finishable = max(0, total - lookahead)
+            let out = run(joined, count: finishable, horizon: total)
+            for c in 0..<nCh { pending[c] = Array(joined[c][finishable...]) }
+            return out
+        }
+
+        /// Emit the held-back tail. Past the end of the signal there is nothing
+        /// left to look ahead at, so the window simply shrinks.
+        public func flush() -> [[Float]] {
+            let nCh = pending.count
+            let n = pending.first?.count ?? 0
+            guard n > 0 else { return Array(repeating: [], count: nCh) }
+            let out = run(pending, count: n, horizon: n)
+            for c in 0..<nCh { pending[c] = [] }
+            return out
+        }
+
+        /// Apply the envelope to the first `count` samples, reacting to peaks
+        /// up to `horizon`.
+        ///
+        /// The window maximum comes from a monotonic-decreasing deque, which is
+        /// O(n) overall rather than O(n * lookahead). Its ring buffer holds
+        /// `lookahead + 2` slots because that is all that can be live at once -
+        /// sizing it to the signal cost ~115 MB on a five-minute stereo file.
+        private func run(_ buf: [[Float]], count: Int, horizon: Int) -> [[Float]] {
+            let nCh = buf.count
+            let absX = Limiter.jointMagnitude(buf, count: horizon)
+            let capacity = max(2, lookahead + 2)
+            var dq = [Int](repeating: 0, count: capacity)
+            var head = 0, tail = 0
+
+            func push(_ index: Int) {
+                let v = absX[index]
+                while tail > head, absX[dq[(tail - 1) % capacity]] <= v { tail -= 1 }
+                dq[tail % capacity] = index
+                tail += 1
+            }
+            for j in 0..<min(lookahead, horizon) { push(j) }
+
+            var out = (0..<nCh).map { _ in [Float](repeating: 0, count: count) }
+            for i in 0..<count {
+                let end = i + lookahead
+                if end >= lookahead, end < horizon { push(end) }
+                while tail > head, dq[head % capacity] < i { head += 1 }
+                let ahead = tail > head ? absX[dq[head % capacity]] : 0
+                if ahead > ceiling {
+                    let required = ceiling / ahead
+                    if required < env { env = required }
+                }
+                for c in 0..<nCh { out[c][i] = buf[c][i] * env }
+                env = 1 - (1 - env) * release
+            }
+            return out
+        }
+    }
+}

--- a/Sources/AudioDSP/Loudness.swift
+++ b/Sources/AudioDSP/Loudness.swift
@@ -194,16 +194,21 @@ public enum Loudness {
                                         peakCeilingDBFS: Double) -> Double?
     {
         guard let lufs = integratedLUFS(samples, sampleRate: sampleRate) else { return nil }
+        // Only upward gain is capped: amplifying a quiet input past the cap
+        // would lift the model's noise floor with it, while attenuating a loud
+        // one is always safe.
         var gainDB = targetLUFS - lufs
         if gainDB > maxGainDB { gainDB = maxGainDB }
-        var gain = Float(pow(10, gainDB / 20))
+        let gain = Float(pow(10, gainDB / 20))
+        for i in 0..<samples.count { samples[i] *= gain }
 
-        var peak: Float = 0
-        for v in samples { peak = max(peak, abs(v)) }
-        let ceiling = Float(pow(10, peakCeilingDBFS / 20))
-        if peak * gain > ceiling, peak > 0 { gain = ceiling / peak }
-
-        for i in 0..<samples.count { samples[i] = max(-1, min(1, samples[i] * gain)) }
+        // The limiter, not a static backoff, is what holds the ceiling. Backing
+        // the whole signal off by `ceiling / peak` would meet the ceiling and
+        // miss the loudness target by however far the loudest transient
+        // overshot.
+        var channels = [samples]
+        Limiter.apply(&channels, ceilingDBTP: peakCeilingDBFS, sampleRate: sampleRate)
+        samples = channels[0]
         return lufs
     }
 }

--- a/Sources/Clear/Binding.swift
+++ b/Sources/Clear/Binding.swift
@@ -19,8 +19,10 @@ extension Clear: BoundModel {
     /// crosses the boundary and adding one breaks no host.
     ///
     /// Result payload: `f32Array samples` (48 kHz mono), then `f64 sampleRate`,
-    /// `f64 durationSec`, `f64 processingSec`, and `f64 measuredLUFS` (NaN when
-    /// mastering was disabled).
+    /// `f64 durationSec`, `f64 processingSec`, `f64 measuredLUFS` (NaN when
+    /// mastering was disabled), and `f64 measuredTruePeakDBFS` (likewise NaN).
+    /// Fields are only ever appended, so a host built against an earlier schema
+    /// keeps reading the prefix it knows.
     public func run(input: FFIReader, options: FFIReader) async -> [UInt8]? {
         var input = input
         var options = options
@@ -45,6 +47,7 @@ extension Clear: BoundModel {
         w.f64(result.durationSec)
         w.f64(result.processingSec)
         w.f64(result.measuredLUFS ?? .nan)
+        w.f64(result.measuredTruePeakDBFS ?? .nan)
         return w.bytes
     }
 }

--- a/Sources/Clear/Catalog.swift
+++ b/Sources/Clear/Catalog.swift
@@ -8,7 +8,12 @@ import DesertAnt
 public enum ClearModel: ModelDeclaration {
     public static let id = "clear"
     public static let product = "Clear"
-    public static let revision = "v0.2.0"
+    // Not the v0.2.0 tag: that tag's Core ML export predates the ANE-shaped
+    // batch-4 layout the enhancer now feeds (Enhancer.batchSize), so Apple
+    // would fail with a shape mismatch on every run. This commit of `main`
+    // carries the re-shaped .mlmodelc alongside the LiteRT exports; becomes
+    // the next `v`-tag once one is cut with it.
+    public static let revision = "1d8810fa86077c319952ffc2080b31bab86a2ad7"
     /// Matches packages/clear-node/package.json and packages/clear-kotlin/build.gradle.kts
     /// (ModelCatalogTests enforces it).
     public static let sdkVersion = "1.0.5"

--- a/Sources/Clear/Catalog.swift
+++ b/Sources/Clear/Catalog.swift
@@ -9,9 +9,8 @@ public enum ClearModel: ModelDeclaration {
     public static let id = "clear"
     public static let product = "Clear"
     public static let revision = "v0.2.0"
-    /// No published npm/Maven package yet, so nothing cross-checks this the way
-    /// ModelCatalogTests checks emo and redact; keep it in step with
-    /// packages/clear-* when they land.
+    /// Matches packages/clear-node/package.json and packages/clear-kotlin/build.gradle.kts
+    /// (ModelCatalogTests enforces it).
     public static let sdkVersion = "1.0.5"
     public static let summary = "On-device speech enhancement: denoise, dereverb, and loudness-normalize."
 

--- a/Sources/Clear/Catalog.swift
+++ b/Sources/Clear/Catalog.swift
@@ -8,10 +8,7 @@ import DesertAnt
 public enum ClearModel: ModelDeclaration {
     public static let id = "clear"
     public static let product = "Clear"
-    // The Hub repo's `v0.1.0` tag predates the LiteRT export, so pinning it
-    // would leave Android/Linux/web with no artifact. Tracks `main` until the
-    // next tag carries `clear-studio.tflite`, then becomes that `v`-tag.
-    public static let revision = "main"
+    public static let revision = "v0.2.0"
     /// No published npm/Maven package yet, so nothing cross-checks this the way
     /// ModelCatalogTests checks emo and redact; keep it in step with
     /// packages/clear-* when they land.

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -72,6 +72,11 @@ public final class Clear: @unchecked Sendable {
         /// artifact is not a published one (a custom export, or a wasm host
         /// that compiled the model itself).
         public let modelVariant: ModelVariant?
+        /// The repo revision the model was resolved from - for a ranged
+        /// ``RevisionRequirement`` this is the concrete tag it landed on. Nil
+        /// when nothing was downloaded (a local `modelPath`, explicit assets,
+        /// or a self-hosted wasm model).
+        public let modelRevision: String?
         public var realtimeFactor: Double { processingSec > 0 ? durationSec / processingSec : 0 }
     }
 
@@ -123,6 +128,26 @@ public final class Clear: @unchecked Sendable {
     // same loader.
     let model: LoadedModel<ModelAssets>
 
+    /// The variant this instance loads, or nil when it was built from an
+    /// explicit artifact/assets whose variant only the caller knows.
+    public let variant: ModelVariant?
+    /// The revision requirement this instance resolves: `.exact` of the
+    /// `revision` passed at init (else the SDK's pinned
+    /// ``Clear/modelRevision``), or the range you passed. Nil when the instance
+    /// was built from a local `modelPath` or explicit assets (nothing is
+    /// downloaded, so no repo revision applies).
+    public let revisionRequirement: RevisionRequirement?
+    /// The concrete model revision this instance resolves, when it is knowable
+    /// without the network: the exact revision, or nil for a ranged
+    /// requirement (resolved at load time against the Hub's tags; the loaded
+    /// one is reported on ``Result/modelRevision``).
+    ///
+    /// This is the revision that *will* be downloaded (or that the cache is
+    /// checked against - see ``isDownloaded()``). For a branch revision like
+    /// `"main"` the cache holds whatever commit was current at download time;
+    /// only a tag or commit hash pins the exact contents.
+    public var modelRevision: String? { revisionRequirement?.exactRevision }
+
     /// Default model sessions to run chunks in parallel over. Native LiteRT is
     /// single-threaded per run, so a pool uses multiple cores; Apple (fast) and
     /// wasm (LiteRT.js is already multi-threaded) use one.
@@ -144,10 +169,33 @@ public final class Clear: @unchecked Sendable {
     /// Nothing is bundled with this package. To ship the model with your app,
     /// point `directory` at a folder you populated with the model files: it is
     /// used as-is, offline, and nothing is downloaded.
+    ///
+    /// `revision` pins a specific published model version (a Hub tag like
+    /// `v0.2.0`, a branch, or a commit hash) instead of the revision this SDK
+    /// was built against (``Clear/modelRevision``). Each revision caches
+    /// separately, so switching versions never clobbers another's files.
     public convenience init(directory: String? = nil, variant: ModelVariant = .default,
+                            revision: String? = nil,
                             computeUnits: ComputeUnits = .cpuOnly,
                             concurrency: Int = Clear.defaultConcurrency) {
         self.init(directory: directory, cacheRoot: nil, variant: variant,
+                  revision: .exact(revision ?? ClearModel.revision),
+                  computeUnits: computeUnits, concurrency: concurrency)
+    }
+
+    /// Like `init(revision: String)`, but with a ``RevisionRequirement``:
+    /// `.exact("v0.2.0")` behaves as above, while
+    /// `.from("v0.2.0")` (SwiftPM semantics: up to the next major) resolves to
+    /// the newest published tag
+    /// with the same major version at load time - and, offline, to the newest
+    /// already-downloaded revision in range, so an installed device keeps
+    /// working without the network. The resolved revision is reported on each
+    /// ``Result/modelRevision``.
+    public convenience init(directory: String? = nil, variant: ModelVariant = .default,
+                            revision: RevisionRequirement,
+                            computeUnits: ComputeUnits = .cpuOnly,
+                            concurrency: Int = Clear.defaultConcurrency) {
+        self.init(directory: directory, cacheRoot: nil, variant: variant, revision: revision,
                   computeUnits: computeUnits, concurrency: concurrency)
     }
 
@@ -158,12 +206,31 @@ public final class Clear: @unchecked Sendable {
     @_spi(ClearBindings)
     public init(directory: String?, cacheRoot: String?,
                 variant: ModelVariant = .default,
+                revision requirement: RevisionRequirement = .exact(ClearModel.revision),
                 computeUnits: ComputeUnits = .cpuOnly,
                 concurrency: Int = Clear.defaultConcurrency) {
         // A variant is its own slice of the model repo, so the loader resolves
-        // that distribution rather than the catalog entry's default one.
-        model = LoadedModel(variant.distribution, directory: directory, cacheRoot: cacheRoot) { files in
-            try await .clear(files: files, variant: variant, computeUnits: computeUnits, concurrency: concurrency)
+        // that distribution rather than the catalog entry's default one; the
+        // requirement decides the revision (for ranges, at load time).
+        self.variant = variant
+        self.revisionRequirement = requirement
+        let base = variant.distribution(revision: ClearModel.revision)
+        model = LoadedModel(
+            resolve: { await base.resolving(requirement, cacheRoot: cacheRoot) },
+            isAvailable: {
+                // Offline answer: an exact revision checks itself (including a
+                // user-populated directory); a range is available when any
+                // downloaded revision satisfies it.
+                let revisions = requirement.exactRevision.map { [$0] }
+                    ?? base.downloadedRevisions(satisfying: requirement, cacheRoot: cacheRoot)
+                return revisions.contains {
+                    variant.distribution(revision: $0)
+                        .isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot)
+                }
+            },
+            directory: directory, cacheRoot: cacheRoot) { files, distribution in
+            try await .clear(files: files, variant: variant, revision: distribution.revision,
+                             computeUnits: computeUnits, concurrency: concurrency)
         }
     }
 
@@ -171,6 +238,8 @@ public final class Clear: @unchecked Sendable {
     /// custom-deployment paths).
     @_spi(ClearBindings)
     public init(assets: ModelAssets) {
+        variant = nil
+        revisionRequirement = nil
         model = LoadedModel { assets }
     }
 
@@ -182,7 +251,35 @@ public final class Clear: @unchecked Sendable {
         // Built eagerly (this initializer throws), then handed to the loader so
         // the rest of the class has one path to its assets.
         let assets = try ModelAssets(modelPath: modelPath, computeUnits: computeUnits, concurrency: concurrency)
+        variant = ModelVariant.inferred(fromPath: modelPath)
+        revisionRequirement = nil
         model = LoadedModel { assets }
+    }
+
+    /// Paths of every downloaded version of the clear model in the managed
+    /// cache, one per revision, sorted. The last path component of each entry
+    /// is the revision (`.../desert-ant-models/desert-ant-labs/clear/v0.2.0`),
+    /// so `models().map { ($0 as NSString).lastPathComponent }` lists the
+    /// versions available offline. Only completed downloads appear; a folder
+    /// you populated yourself (an explicit `directory`) is not part of the
+    /// managed cache and is not listed.
+    ///
+    /// Note: a revision directory may hold one or both variants' files - the
+    /// per-variant check is ``isDownloaded(variant:revision:directory:cacheRoot:)``.
+    public static func models(cacheRoot: String? = nil) -> [String] {
+        ModelVariant.default.distribution.installedModels(cacheRoot: cacheRoot)
+    }
+
+    /// Whether a given variant/revision is already downloaded and intact
+    /// (usable offline), without constructing an enhancer. `revision` defaults
+    /// to the SDK's pinned ``Clear/modelRevision``; `directory` mirrors the
+    /// initializer's parameter (nil = the managed cache).
+    public static func isDownloaded(variant: ModelVariant = .default,
+                                    revision: String? = nil,
+                                    directory: String? = nil,
+                                    cacheRoot: String? = nil) -> Bool {
+        variant.distribution(revision: revision ?? ClearModel.revision)
+            .isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot)
     }
 
     /// Whether the model is available for this enhancer with no network:
@@ -196,9 +293,19 @@ public final class Clear: @unchecked Sendable {
         _ = try await model.value()
     }
 
-    /// Download the model if needed, reporting progress 0...1.
+    /// Download the model if needed, reporting download progress 0...1.
     public func download(progress: @escaping @Sendable (Double) -> Void = { _ in }) async throws {
         try await model.download(progress: progress)
+    }
+
+    /// Download (if needed) and fully load the model, reporting phase-aware
+    /// progress: ``ModelLoadPhase/downloading`` with a bytes-based fraction,
+    /// then ``ModelLoadPhase/preparing`` while the inference session is built
+    /// (on Apple, the first launch's Core ML compile lands here). Returns once
+    /// the model is ready, so the first `enhance` starts instantly. Concurrent
+    /// callers join the same load.
+    public func load(progress: @escaping @Sendable (ModelLoadProgress) -> Void = { _ in }) async throws {
+        try await model.load(progress: progress)
     }
 
     /// Enhance mono/stereo `samples` at `sampleRate`, returning 48 kHz mono.
@@ -262,7 +369,7 @@ public final class Clear: @unchecked Sendable {
                       durationSec: Double(out.count) / ClearDSP.sampleRate,
                       processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
                       measuredTruePeakDBFS: truePeak,
-                      modelVariant: assets.variant)
+                      modelVariant: assets.variant, modelRevision: assets.revision)
     }
 
     func elapsedSeconds(since start: ContinuousClock.Instant) -> Double {

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -63,6 +63,11 @@ public final class Clear: @unchecked Sendable {
         public let durationSec: Double
         public let processingSec: Double
         public let measuredLUFS: Double?
+        /// True peak of the delivered audio in dBFS, by 4x oversampling, or nil
+        /// when mastering was bypassed. Measured *after* limiting, so this is
+        /// what a caller can assert a delivery spec against - unlike
+        /// ``measuredLUFS``, which reports the input.
+        public let measuredTruePeakDBFS: Double?
         /// Which published model variant produced this output, or nil when the
         /// artifact is not a published one (a custom export, or a wasm host
         /// that compiled the model itself).
@@ -240,6 +245,7 @@ public final class Clear: @unchecked Sendable {
         // and peak ceiling. `loudnessRangeLU` is not applied (no range stage
         // yet); see `Mastering`.
         var measured: Double? = nil
+        var truePeak: Double? = nil
         let mastering = options.mastering
         if mastering.enabled {
             // In place: a returned master would sit alongside `out`, and both
@@ -247,6 +253,7 @@ public final class Clear: @unchecked Sendable {
             measured = Loudness.normalizeInPlace(
                 &out, sampleRate: ClearDSP.sampleRate, targetLUFS: mastering.integratedLUFS,
                 maxGainDB: mastering.maxLoudnessGainDB, peakCeilingDBFS: mastering.truePeakDBTP)
+            truePeak = Limiter.truePeakDBFS([out])
         }
         // Mastering is the tail of `enhancing`, so the phase ends at 1 only
         // once the audio is actually final.
@@ -254,6 +261,7 @@ public final class Clear: @unchecked Sendable {
         return Result(samples: out, sampleRate: ClearDSP.sampleRate,
                       durationSec: Double(out.count) / ClearDSP.sampleRate,
                       processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
+                      measuredTruePeakDBFS: truePeak,
                       modelVariant: assets.variant)
     }
 

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -248,13 +248,22 @@ public final class Clear: @unchecked Sendable {
     /// Load a local model file directly (a `.mlmodelc` on Apple, a `.tflite`
     /// elsewhere), skipping the store entirely. For tests and custom
     /// deployments; apps point `directory` at their files instead.
-    public init(modelPath: String, computeUnits: ComputeUnits = .all,
+    ///
+    /// A local file resolves nothing, so `revision` is a declaration, not a
+    /// requirement: the exact revision you know the file came from (a tag or
+    /// commit hash). It is reported back on ``revisionRequirement``,
+    /// ``modelRevision``, and every ``Result/modelRevision``, so a CI cache
+    /// keyed by revision produces self-identifying runs. It is never checked
+    /// against the file - there is nothing offline to check it against.
+    public init(modelPath: String, revision: String? = nil,
+                computeUnits: ComputeUnits = .all,
                 concurrency: Int = Clear.defaultConcurrency) throws {
         // Built eagerly (this initializer throws), then handed to the loader so
         // the rest of the class has one path to its assets.
-        let assets = try ModelAssets(modelPath: modelPath, computeUnits: computeUnits, concurrency: concurrency)
+        let assets = try ModelAssets(modelPath: modelPath, revision: revision,
+                                     computeUnits: computeUnits, concurrency: concurrency)
         variant = ModelVariant.inferred(fromPath: modelPath)
-        revisionRequirement = nil
+        revisionRequirement = revision.map { .exact($0) }
         model = LoadedModel { assets }
     }
 

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -162,8 +162,10 @@ public final class Clear: @unchecked Sendable {
     }
 
     /// `computeUnits` selects the Core ML compute units on Apple (ignored by the
-    /// LiteRT/JS backends). Default `.cpuOnly`: the palettized model benchmarks
-    /// ~2x faster on the CPU than the Neural Engine or GPU on M-series Macs.
+    /// LiteRT/JS backends). Default `.all`, letting Core ML place the work
+    /// itself; pass `.cpuOnly` if CPU-only benchmarks better for your model
+    /// and hardware (the palettized model has run ~2x faster on the CPU than
+    /// the Neural Engine or GPU on some M-series Macs).
     /// `concurrency` is the model-session pool size (see `defaultConcurrency`).
     ///
     /// Nothing is bundled with this package. To ship the model with your app,
@@ -176,7 +178,7 @@ public final class Clear: @unchecked Sendable {
     /// separately, so switching versions never clobbers another's files.
     public convenience init(directory: String? = nil, variant: ModelVariant = .default,
                             revision: String? = nil,
-                            computeUnits: ComputeUnits = .cpuOnly,
+                            computeUnits: ComputeUnits = .all,
                             concurrency: Int = Clear.defaultConcurrency) {
         self.init(directory: directory, cacheRoot: nil, variant: variant,
                   revision: .exact(revision ?? ClearModel.revision),
@@ -193,7 +195,7 @@ public final class Clear: @unchecked Sendable {
     /// ``Result/modelRevision``.
     public convenience init(directory: String? = nil, variant: ModelVariant = .default,
                             revision: RevisionRequirement,
-                            computeUnits: ComputeUnits = .cpuOnly,
+                            computeUnits: ComputeUnits = .all,
                             concurrency: Int = Clear.defaultConcurrency) {
         self.init(directory: directory, cacheRoot: nil, variant: variant, revision: revision,
                   computeUnits: computeUnits, concurrency: concurrency)
@@ -207,7 +209,7 @@ public final class Clear: @unchecked Sendable {
     public init(directory: String?, cacheRoot: String?,
                 variant: ModelVariant = .default,
                 revision requirement: RevisionRequirement = .exact(ClearModel.revision),
-                computeUnits: ComputeUnits = .cpuOnly,
+                computeUnits: ComputeUnits = .all,
                 concurrency: Int = Clear.defaultConcurrency) {
         // A variant is its own slice of the model repo, so the loader resolves
         // that distribution rather than the catalog entry's default one; the
@@ -246,7 +248,7 @@ public final class Clear: @unchecked Sendable {
     /// Load a local model file directly (a `.mlmodelc` on Apple, a `.tflite`
     /// elsewhere), skipping the store entirely. For tests and custom
     /// deployments; apps point `directory` at their files instead.
-    public init(modelPath: String, computeUnits: ComputeUnits = .cpuOnly,
+    public init(modelPath: String, computeUnits: ComputeUnits = .all,
                 concurrency: Int = Clear.defaultConcurrency) throws {
         // Built eagerly (this initializer throws), then handed to the loader so
         // the rest of the class has one path to its assets.

--- a/Sources/Clear/Enhancer.swift
+++ b/Sources/Clear/Enhancer.swift
@@ -61,6 +61,19 @@ struct ClearEnhancer {
     let chunkLen: Int
     private let stft = ClearSTFT()
 
+    /// How many independent chunks one `run` consumes, and in which layout.
+    ///
+    /// The Core ML export is ANE-shaped: planar `[B, C, F, T]` tensors with a
+    /// fixed batch of four windows (`spec (4,2,481,200)`,
+    /// `feat_erb (4,1,32,200)`, `feat_spec (4,2,96,200)`). Every other runtime
+    /// (LiteRT/ONNX/JS host) keeps the original DFN3 layout: one window per
+    /// run, interleaved `[1, 1, T, F, 2]`.
+    #if canImport(CoreML)
+    static let batchSize = 4
+    #else
+    static let batchSize = 1
+    #endif
+
     init(sessions: [any InferenceSession], chunkLen: Int = 200) {
         self.sessions = sessions.isEmpty ? [] : sessions
         self.chunkLen = chunkLen
@@ -95,7 +108,9 @@ struct ClearEnhancer {
         defer { outRe.deinitialize(count: count); outRe.deallocate(); outIm.deinitialize(count: count); outIm.deallocate() }
 
         let nChunks = (nFrames + chunkLen - 1) / chunkLen
-        let workers = max(1, min(sessions.count, nChunks))
+        let batch = Self.batchSize
+        let nGroups = (nChunks + batch - 1) / batch
+        let workers = max(1, min(sessions.count, nGroups))
         let chunkLen = self.chunkLen
         // Each worker owns one session and a strided set of chunks; output
         // ranges are disjoint per chunk, so the shared buffers need no locking.
@@ -106,14 +121,16 @@ struct ClearEnhancer {
                 group.addTask {
                     let (outRe, outIm, sessions, fe, fsr, fsi, sr, si) = box.value
                     let session = sessions[w]
-                    var c = w
-                    while c < nChunks {
-                        let start = c * chunkLen, end = min(start + chunkLen, nFrames)
-                        try await Self.runChunk(session: session, start: start, end: end, nFrames: nFrames, chunkLen: chunkLen,
+                    var g = w
+                    while g < nGroups {
+                        let firstChunk = g * batch
+                        let chunks = min(batch, nChunks - firstChunk)
+                        try await Self.runGroup(session: session, firstChunk: firstChunk, chunks: chunks,
+                                                nFrames: nFrames, chunkLen: chunkLen,
                                                 featErb: fe, featSpecReal: fsr, featSpecImag: fsi,
                                                 specReal: sr, specImag: si, outRe: outRe, outIm: outIm)
-                        completed.finishOne()
-                        c += workers
+                        for _ in 0..<chunks { completed.finishOne() }
+                        g += workers
                     }
                 }
             }
@@ -128,6 +145,28 @@ struct ClearEnhancer {
         return enhanced
     }
 
+    /// Run one group of `chunks` consecutive windows (`batchSize` of them at
+    /// most) through `session` and scatter the result into the output planes.
+    private static func runGroup(session: any InferenceSession, firstChunk: Int, chunks: Int,
+                                 nFrames: Int, chunkLen: Int,
+                                 featErb: [Float], featSpecReal: [Float], featSpecImag: [Float],
+                                 specReal: [Float], specImag: [Float],
+                                 outRe: UnsafeMutablePointer<Float>, outIm: UnsafeMutablePointer<Float>) async throws {
+        #if canImport(CoreML)
+        try await runPlanarBatch(session: session, firstChunk: firstChunk, chunks: chunks,
+                                 nFrames: nFrames, chunkLen: chunkLen,
+                                 featErb: featErb, featSpecReal: featSpecReal, featSpecImag: featSpecImag,
+                                 specReal: specReal, specImag: specImag, outRe: outRe, outIm: outIm)
+        #else
+        let start = firstChunk * chunkLen
+        try await runChunk(session: session, start: start, end: min(start + chunkLen, nFrames),
+                           nFrames: nFrames, chunkLen: chunkLen,
+                           featErb: featErb, featSpecReal: featSpecReal, featSpecImag: featSpecImag,
+                           specReal: specReal, specImag: specImag, outRe: outRe, outIm: outIm)
+        #endif
+    }
+
+    /// The original DFN3 layout: one window per run, interleaved complex.
     private static func runChunk(session: any InferenceSession, start: Int, end: Int, nFrames: Int, chunkLen: Int,
                                  featErb: [Float], featSpecReal: [Float], featSpecImag: [Float],
                                  specReal: [Float], specImag: [Float],
@@ -202,6 +241,112 @@ struct ClearEnhancer {
         }
         #endif
     }
+
+    #if canImport(CoreML)
+    /// The Core ML export's layout: a fixed batch of `batchSize` independent
+    /// windows as planar `[B, C, F, T]` tensors (frequency-major, time last),
+    /// which is what the ANE program declares. Unused batch elements are left
+    /// zero and their outputs ignored.
+    private static func runPlanarBatch(session: any InferenceSession, firstChunk: Int, chunks: Int,
+                                       nFrames: Int, chunkLen: Int,
+                                       featErb: [Float], featSpecReal: [Float], featSpecImag: [Float],
+                                       specReal: [Float], specImag: [Float],
+                                       outRe: UnsafeMutablePointer<Float>, outIm: UnsafeMutablePointer<Float>) async throws {
+        let T = chunkLen, B = batchSize
+        let nFreq = ClearDSP.nFreq, nErb = ClearDSP.nErb, nDf = ClearDSP.nDf
+        let look = ClearDSP.convLookahead
+
+        var specBuf = [Float](repeating: 0, count: B * 2 * nFreq * T)
+        var erbBuf = [Float](repeating: 0, count: B * nErb * T)
+        var featSpecBuf = [Float](repeating: 0, count: B * 2 * nDf * T)
+
+        for b in 0..<chunks {
+            let start = (firstChunk + b) * T
+            // Features are read `convLookahead` frames ahead of the window; the
+            // spectrum is read at the window itself. Both clamp at the tail.
+            let tEnd = min(T, nFrames - start - look)
+            let sEnd = min(T, nFrames - start)
+            if tEnd > 0 {
+                toPlanar(featErb, srcFrame: start + look, frames: tEnd, cols: nErb,
+                         into: &erbBuf, planeOffset: b * nErb * T, T: T)
+                toPlanar(featSpecReal, srcFrame: start + look, frames: tEnd, cols: nDf,
+                         into: &featSpecBuf, planeOffset: (b * 2) * nDf * T, T: T)
+                toPlanar(featSpecImag, srcFrame: start + look, frames: tEnd, cols: nDf,
+                         into: &featSpecBuf, planeOffset: (b * 2 + 1) * nDf * T, T: T)
+            }
+            if sEnd > 0 {
+                toPlanar(specReal, srcFrame: start, frames: sEnd, cols: nFreq,
+                         into: &specBuf, planeOffset: (b * 2) * nFreq * T, T: T)
+                toPlanar(specImag, srcFrame: start, frames: sEnd, cols: nFreq,
+                         into: &specBuf, planeOffset: (b * 2 + 1) * nFreq * T, T: T)
+            }
+        }
+
+        let outputs = try await session.run(
+            inputs: [
+                "spec": Tensor(float32: specBuf, shape: [B, 2, nFreq, T]),
+                "feat_erb": Tensor(float32: erbBuf, shape: [B, 1, nErb, T]),
+                "feat_spec": Tensor(float32: featSpecBuf, shape: [B, 2, nDf, T]),
+            ],
+            outputs: ["spec_enhanced"])
+        guard let enh = outputs.first?.float32Values, enh.count >= B * 2 * nFreq * T else {
+            throw ClearError.inferenceFailed("spec_enhanced missing or wrong size")
+        }
+
+        for b in 0..<chunks {
+            let start = (firstChunk + b) * T
+            let valid = min(T, nFrames - start)
+            guard valid > 0 else { continue }
+            fromPlanar(enh, planeOffset: (b * 2) * nFreq * T, cols: nFreq, T: T,
+                       frames: valid, into: outRe + start * nFreq)
+            fromPlanar(enh, planeOffset: (b * 2 + 1) * nFreq * T, cols: nFreq, T: T,
+                       frames: valid, into: outIm + start * nFreq)
+        }
+    }
+
+    /// Frame-major source (`[frame][cols]`, starting at `srcFrame`) into one
+    /// `[cols][T]` plane of `dst` at `planeOffset`. A full window transposes
+    /// straight into place; a short tail window transposes into scratch and
+    /// then copies the columns it has, leaving the rest zero.
+    private static func toPlanar(_ src: [Float], srcFrame: Int, frames: Int, cols: Int,
+                                 into dst: inout [Float], planeOffset: Int, T: Int) {
+        src.withUnsafeBufferPointer { sp in
+            let s = sp.baseAddress! + srcFrame * cols
+            dst.withUnsafeMutableBufferPointer { dp in
+                let d = dp.baseAddress! + planeOffset
+                if frames == T {
+                    vDSP_mtrans(s, 1, d, 1, vDSP_Length(cols), vDSP_Length(frames))
+                } else {
+                    var scratch = [Float](repeating: 0, count: cols * frames)
+                    scratch.withUnsafeMutableBufferPointer { tp in
+                        vDSP_mtrans(s, 1, tp.baseAddress!, 1, vDSP_Length(cols), vDSP_Length(frames))
+                        vDSP_mmov(tp.baseAddress!, d, vDSP_Length(frames), vDSP_Length(cols),
+                                  vDSP_Length(frames), vDSP_Length(T))
+                    }
+                }
+            }
+        }
+    }
+
+    /// The inverse: one `[cols][T]` plane of `src` back to `frames` rows of a
+    /// frame-major destination.
+    private static func fromPlanar(_ src: [Float], planeOffset: Int, cols: Int, T: Int,
+                                   frames: Int, into dst: UnsafeMutablePointer<Float>) {
+        src.withUnsafeBufferPointer { sp in
+            let s = sp.baseAddress! + planeOffset
+            if frames == T {
+                vDSP_mtrans(s, 1, dst, 1, vDSP_Length(frames), vDSP_Length(cols))
+            } else {
+                var scratch = [Float](repeating: 0, count: cols * frames)
+                scratch.withUnsafeMutableBufferPointer { tp in
+                    vDSP_mmov(s, tp.baseAddress!, vDSP_Length(frames), vDSP_Length(cols),
+                              vDSP_Length(T), vDSP_Length(frames))
+                    vDSP_mtrans(tp.baseAddress!, 1, dst, 1, vDSP_Length(frames), vDSP_Length(cols))
+                }
+            }
+        }
+    }
+    #endif
 
     #if canImport(Accelerate)
     private static func interleave(_ re: [Float], _ im: [Float], srcOffset: Int, into dst: inout [Float], dstOffset: Int, count: Int) {

--- a/Sources/Clear/Mastering.swift
+++ b/Sources/Clear/Mastering.swift
@@ -20,10 +20,12 @@ public extension Clear {
 
         /// True-peak ceiling in dBTP. -1.5 dBTP leaves headroom for lossy codecs.
         ///
-        /// The current limiter measures *sample* peak, not true peak (no 4x
-        /// oversampling), so this is applied as a dBFS ceiling. It is therefore
-        /// slightly optimistic on inter-sample peaks - which is what the default
-        /// -1.5 dBTP of headroom absorbs.
+        /// The look-ahead limiter rides *sample* peak, so the ceiling it holds
+        /// is slightly optimistic about inter-sample peaks - which is what the
+        /// default -1.5 dBTP of headroom absorbs. The true peak that resulted is
+        /// measured with 4x oversampling and reported as
+        /// ``Clear/Result/measuredTruePeakDBFS``, so a caller can assert against
+        /// a delivery spec rather than trust the ceiling.
         public var truePeakDBTP: Double
 
         /// Loudness range target in LU (spoken word is <= 7 LU; EBU R128

--- a/Sources/Clear/ModelLoading.swift
+++ b/Sources/Clear/ModelLoading.swift
@@ -22,10 +22,15 @@ public struct ModelAssets: Sendable {
     /// when the artifact is not a published variant (a custom export, or a
     /// wasm host that compiled the model itself).
     let variant: ModelVariant?
+    /// The repo revision the sessions' artifact was resolved from, reported on
+    /// `Result`. Nil for a local `modelPath`, explicit assets, or a wasm host
+    /// (nothing was downloaded, so no revision applies).
+    let revision: String?
 
-    init(sessions: [any InferenceSession], variant: ModelVariant? = nil) {
+    init(sessions: [any InferenceSession], variant: ModelVariant? = nil, revision: String? = nil) {
         self.sessions = sessions
         self.variant = variant
+        self.revision = revision
     }
 
     /// Bindings entry point: build from an already-constructed session (e.g. the
@@ -48,7 +53,7 @@ public struct ModelAssets: Sendable {
 
     /// Build from a resolved model directory: one session per worker over this
     /// platform's artifact.
-    static func clear(files: StoredModel, variant: ModelVariant,
+    static func clear(files: StoredModel, variant: ModelVariant, revision: String? = nil,
                       computeUnits: ComputeUnits, concurrency: Int) async throws -> ModelAssets {
         var sessions: [any InferenceSession] = []
         for _ in 0..<max(1, concurrency) {
@@ -56,7 +61,7 @@ public struct ModelAssets: Sendable {
                 model: variant.artifact,
                 computeUnits: computeUnits, sdk: ClearModel.sdkInfo))
         }
-        return ModelAssets(sessions: sessions, variant: variant)
+        return ModelAssets(sessions: sessions, variant: variant, revision: revision)
     }
 }
 

--- a/Sources/Clear/ModelLoading.swift
+++ b/Sources/Clear/ModelLoading.swift
@@ -43,7 +43,7 @@ public struct ModelAssets: Sendable {
     /// Sessions over an artifact already on disk. The variant is read off the
     /// file name, so a pre-downloaded artifact still identifies itself on
     /// `Result`.
-    init(modelPath: String, computeUnits: ComputeUnits = .cpuOnly, concurrency: Int = 1) throws {
+    init(modelPath: String, computeUnits: ComputeUnits = .all, concurrency: Int = 1) throws {
         self.init(
             sessions: try (0..<max(1, concurrency)).map { _ in
                 try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)

--- a/Sources/Clear/ModelLoading.swift
+++ b/Sources/Clear/ModelLoading.swift
@@ -43,12 +43,14 @@ public struct ModelAssets: Sendable {
     /// Sessions over an artifact already on disk. The variant is read off the
     /// file name, so a pre-downloaded artifact still identifies itself on
     /// `Result`.
-    init(modelPath: String, computeUnits: ComputeUnits = .all, concurrency: Int = 1) throws {
+    init(modelPath: String, revision: String? = nil,
+         computeUnits: ComputeUnits = .all, concurrency: Int = 1) throws {
         self.init(
             sessions: try (0..<max(1, concurrency)).map { _ in
                 try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)
             },
-            variant: ModelVariant.inferred(fromPath: modelPath))
+            variant: ModelVariant.inferred(fromPath: modelPath),
+            revision: revision)
     }
 
     /// Build from a resolved model directory: one session per worker over this

--- a/Sources/Clear/Streaming.swift
+++ b/Sources/Clear/Streaming.swift
@@ -191,7 +191,7 @@ extension Clear {
                       durationSec: Double(totalFrames) / sampleRate,
                       processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
                       measuredTruePeakDBFS: truePeakMeter?.dBFS,
-                      modelVariant: assets.variant)
+                      modelVariant: assets.variant, modelRevision: assets.revision)
     }
 }
 #endif

--- a/Sources/Clear/Streaming.swift
+++ b/Sources/Clear/Streaming.swift
@@ -162,6 +162,7 @@ extension Clear {
             ? Limiter.Streaming(ceilingDBTP: mastering.truePeakDBTP,
                                 sampleRate: sampleRate, channels: 1)
             : nil
+        let truePeakMeter = applyGain ? Limiter.TruePeakMeter() : nil
         while true {
             try Task.checkCancellation()
             let data = try readHandle.read(upToCount: blockBytes) ?? Data()
@@ -173,11 +174,15 @@ extension Clear {
                 for i in 0..<block.count { block[i] *= gain }
                 block = limiter.process([block])[0]
             }
+            truePeakMeter?.consume(block)
             try writer.write(block)
         }
         if let limiter {
             let tail = limiter.flush()[0]
-            if !tail.isEmpty { try writer.write(tail) }
+            if !tail.isEmpty {
+                truePeakMeter?.consume(tail)
+                try writer.write(tail)
+            }
         }
         writer.finish()
 
@@ -185,6 +190,7 @@ extension Clear {
         return Result(samples: [], sampleRate: sampleRate,
                       durationSec: Double(totalFrames) / sampleRate,
                       processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
+                      measuredTruePeakDBFS: truePeakMeter?.dBFS,
                       modelVariant: assets.variant)
     }
 }

--- a/Sources/Clear/Streaming.swift
+++ b/Sources/Clear/Streaming.swift
@@ -136,7 +136,9 @@ extension Clear {
         }
 
         // Mastering: one gain for the whole file, from the enhanced signal's own
-        // loudness and peak, matching what the in-memory path computes.
+        // loudness, matching what the in-memory path computes. The peak ceiling
+        // is the limiter's job in the second pass, not this gain's - backing the
+        // whole file off to fit its loudest transient would miss the target.
         var measured: Double? = nil
         var gain: Float = 1
         let mastering = options.mastering
@@ -145,9 +147,6 @@ extension Clear {
             var gainDB = mastering.integratedLUFS - lufs
             if gainDB > mastering.maxLoudnessGainDB { gainDB = mastering.maxLoudnessGainDB }
             gain = Float(pow(10, gainDB / 20))
-            let ceiling = Float(pow(10, mastering.truePeakDBTP / 20))
-            let peak = meter.peak
-            if peak * gain > ceiling, peak > 0 { gain = ceiling / peak }
         }
 
         // Second pass: scratch -> encoder, applying the gain. No model, no DSP.
@@ -157,6 +156,12 @@ extension Clear {
         defer { try? readHandle.close() }
         let blockBytes = (1 << 16) * MemoryLayout<Float>.size
         let applyGain = mastering.enabled
+        // Carries the gain envelope and its look-ahead tail across blocks, so a
+        // file mastered here matches the same audio mastered in memory.
+        let limiter = applyGain
+            ? Limiter.Streaming(ceilingDBTP: mastering.truePeakDBTP,
+                                sampleRate: sampleRate, channels: 1)
+            : nil
         while true {
             try Task.checkCancellation()
             let data = try readHandle.read(upToCount: blockBytes) ?? Data()
@@ -164,10 +169,15 @@ extension Clear {
             var block = data.withUnsafeBytes { raw -> [Float] in
                 Array(raw.bindMemory(to: Float.self))
             }
-            if applyGain {
-                for i in 0..<block.count { block[i] = max(-1, min(1, block[i] * gain)) }
+            if let limiter {
+                for i in 0..<block.count { block[i] *= gain }
+                block = limiter.process([block])[0]
             }
             try writer.write(block)
+        }
+        if let limiter {
+            let tail = limiter.flush()[0]
+            if !tail.isEmpty { try writer.write(tail) }
         }
         writer.finish()
 

--- a/Sources/Clear/Variant.swift
+++ b/Sources/Clear/Variant.swift
@@ -57,8 +57,13 @@ public enum ModelVariant: String, Sendable, Equatable, CaseIterable, Identifiabl
     /// This variant's slice of the model repo: the same repo and pinned
     /// revision as the catalog entry, but only this variant's files, so
     /// choosing one variant never downloads the other.
-    public var distribution: ModelDistribution {
-        ModelDistribution(repo: ClearModel.repo, revision: ClearModel.revision, files: files)
+    public var distribution: ModelDistribution { distribution(revision: ClearModel.revision) }
+
+    /// The same slice pinned to an explicit repo `revision` (a tag like
+    /// `v0.2.0`, a branch, or a commit hash) instead of the SDK's pinned one.
+    /// Each revision caches separately, so switching never clobbers another.
+    public func distribution(revision: String) -> ModelDistribution {
+        ModelDistribution(repo: ClearModel.repo, revision: revision, files: files)
     }
 
     /// The variant an artifact path belongs to, by its file name

--- a/Sources/ModelCatalog/LoadedModel.swift
+++ b/Sources/ModelCatalog/LoadedModel.swift
@@ -36,6 +36,28 @@ import PlatformSupport
 /// downloading into it or into the managed cache) and builds the runtime once,
 /// sharing that single load with every concurrent caller. A failed load is not
 /// cached, so a later call retries.
+/// Which stage a model load is in. `downloading` runs to completion before
+/// `preparing` starts, and the fraction resets at the transition.
+public enum ModelLoadPhase: Sendable, Equatable {
+    /// Fetching (or verifying) the model files; fraction is bytes-based.
+    /// Reports 1 immediately when everything is already cached.
+    case downloading
+    /// Building the runtime from the resolved files. Coarse: most backends
+    /// report only 0 and 1 (Core ML compilation exposes no progress).
+    case preparing
+}
+
+/// A phase-aware model load report: which ``ModelLoadPhase`` and how far into
+/// it (`0...1`).
+public struct ModelLoadProgress: Sendable, Equatable {
+    public let phase: ModelLoadPhase
+    public let fraction: Double
+    public init(phase: ModelLoadPhase, fraction: Double) {
+        self.phase = phase
+        self.fraction = fraction
+    }
+}
+
 public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
     private let loader: LazyLoader<Runtime>
     private let availability: @Sendable () -> Bool
@@ -72,12 +94,38 @@ public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
         cacheRoot: String? = nil,
         build: @escaping @Sendable (StoredModel) async throws -> Runtime
     ) {
+        // The loader's Double carries both phases: [0, 0.5) is the download
+        // fraction (halved), [0.5, 1] is preparing/build. `download` and `load`
+        // decode it back, so the Double API keeps its old meaning.
         loader = LazyLoader { progress in
             let files = try await distribution.resolve(
-                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction) }
+                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction * 0.5) }
+            progress(0.5)
             return try await build(files)
         }
         availability = { distribution.isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot) }
+    }
+
+    /// Load from a distribution that is itself resolved asynchronously (a
+    /// ranged ``RevisionRequirement``, where the concrete revision comes from
+    /// the Hub's tags at load time). `resolve` runs once, at the front of the
+    /// shared load; `isAvailable` must answer offline-availability without it
+    /// (typically: any cached revision satisfies the requirement).
+    public init(
+        resolve: @escaping @Sendable () async throws -> ModelDistribution,
+        isAvailable: @escaping @Sendable () -> Bool,
+        directory: String? = nil,
+        cacheRoot: String? = nil,
+        build: @escaping @Sendable (StoredModel, ModelDistribution) async throws -> Runtime
+    ) {
+        loader = LazyLoader { progress in
+            let distribution = try await resolve()
+            let files = try await distribution.resolve(
+                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction * 0.5) }
+            progress(0.5)
+            return try await build(files, distribution)
+        }
+        availability = isAvailable
     }
 
     /// Wrap a runtime the caller already has the inputs for (the cross-language
@@ -97,7 +145,19 @@ public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
     /// Reports progress `0...1`. Concurrent calls, and an implicit load from a
     /// first use, share one download.
     public func download(progress: @Sendable @escaping (Double) -> Void = { _ in }) async throws {
-        try await loader.run(progress: progress)
+        try await loader.run { progress(Self.decode($0).phase == .downloading ? Self.decode($0).fraction : 1) }
+    }
+
+    /// Like ``download(progress:)`` but phase-aware: reports the download
+    /// (byte-level fraction) and then the preparing phase (building the
+    /// runtime; on Apple the first launch's Core ML compile lands here).
+    public func load(progress: @Sendable @escaping (ModelLoadProgress) -> Void) async throws {
+        try await loader.run { progress(Self.decode($0)) }
+    }
+
+    private static func decode(_ v: Double) -> ModelLoadProgress {
+        v < 0.5 ? ModelLoadProgress(phase: .downloading, fraction: min(1, v * 2))
+                : ModelLoadProgress(phase: .preparing, fraction: min(1, (v - 0.5) * 2))
     }
 
     /// The runtime, loading it on first use.

--- a/Sources/ModelStore/FoundationBackend.swift
+++ b/Sources/ModelStore/FoundationBackend.swift
@@ -37,6 +37,19 @@ public struct FoundationTransport: ModelTransport {
         }
     }
 
+    public func tags(_ url: String) async throws -> [String] {
+        guard let u = URL(string: url) else { throw ModelStoreError.io("bad url: \(url)") }
+        let (data, resp) = try await URLSession.shared.data(for: URLRequest(url: u))
+        guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw ModelStoreError.io("refs \(url): HTTP \((resp as? HTTPURLResponse)?.statusCode ?? -1)")
+        }
+        struct Refs: Decodable {
+            struct Ref: Decodable { let name: String }
+            let tags: [Ref]?
+        }
+        return try JSONDecoder().decode(Refs.self, from: data).tags?.map(\.name) ?? []
+    }
+
     private struct TreeItem: Decodable {
         let type: String
         let path: String
@@ -117,6 +130,10 @@ public struct FoundationFileSystem: FileSystem {
     }
 
     public func remove(_ path: String) { try? FileManager.default.removeItem(atPath: path) }
+
+    public func listDirectory(_ path: String) -> [String] {
+        (try? FileManager.default.contentsOfDirectory(atPath: path)) ?? []
+    }
 
     public func defaultCacheRoot() -> String {
         if let cacheRoot { return cacheRoot }

--- a/Sources/ModelStore/ModelDistribution.swift
+++ b/Sources/ModelStore/ModelDistribution.swift
@@ -76,6 +76,36 @@ public struct ModelDistribution: Sendable, Equatable {
         return store.isDownloaded(spec(cacheDirectory))
     }
 
+    /// Directories of every downloaded version of this model's repo in the
+    /// managed cache (see ``ModelStore/downloadedModels(repo:)``): one path per
+    /// revision, its last component the revision itself.
+    public func installedModels(cacheRoot: String? = nil) -> [String] {
+        guard let store = try? ModelStore.platformDefault(cacheRoot: cacheRoot) else { return [] }
+        return store.downloadedModels(repo: repo)
+    }
+
+    /// This distribution re-pointed at the concrete revision a
+    /// ``RevisionRequirement`` resolves to (see
+    /// ``ModelStore/resolveRevision(_:repo:)`` for the network/cache/fallback
+    /// order). `exact` never touches the network.
+    public func resolving(_ requirement: RevisionRequirement, cacheRoot: String? = nil) async -> ModelDistribution {
+        if let revision = requirement.exactRevision {
+            return ModelDistribution(repo: repo, revision: revision, files: files)
+        }
+        guard let store = try? ModelStore.platformDefault(cacheRoot: cacheRoot) else { return self }
+        let revision = await store.resolveRevision(requirement, repo: repo)
+        return ModelDistribution(repo: repo, revision: revision, files: files)
+    }
+
+    /// The downloaded revisions of this repo satisfying `requirement` (offline;
+    /// the managed cache only). The best match is last-sorted by the
+    /// requirement's own ordering via ``RevisionRequirement/bestMatch(in:)``.
+    public func downloadedRevisions(satisfying requirement: RevisionRequirement,
+                                    cacheRoot: String? = nil) -> [String] {
+        guard let store = try? ModelStore.platformDefault(cacheRoot: cacheRoot) else { return [] }
+        return store.downloadedRevisions(repo: repo).filter { requirement.bestMatch(in: [$0]) != nil }
+    }
+
     /// Get the model for `cacheDirectory`, downloading it there on demand. Files
     /// you placed there yourself are adopted offline; our own cache is reused
     /// offline; otherwise the model is downloaded. `nil` uses the managed cache.

--- a/Sources/ModelStore/ModelStore.swift
+++ b/Sources/ModelStore/ModelStore.swift
@@ -142,6 +142,45 @@ public struct ModelStore: Sendable {
         return storedModel(for: model)
     }
 
+    /// Directories of every revision of `repo` present in the managed cache,
+    /// sorted by revision. Only completed downloads are listed (the store's
+    /// manifest marks completion); an interrupted download is not. The last
+    /// path component of each entry is the revision. Locations you populated
+    /// yourself (an explicit `cacheDirectory`) are outside the managed layout
+    /// and are not listed.
+    public func downloadedModels(repo: String) -> [String] {
+        let base = join(fs.defaultCacheRoot(), "desert-ant-models", repo)
+        return downloadedRevisions(repo: repo).map { join(base, $0) }
+    }
+
+    /// The revisions of `repo` with a completed download in the managed cache,
+    /// sorted. (`downloadedModels(repo:)` returns the same entries as paths.)
+    public func downloadedRevisions(repo: String) -> [String] {
+        let base = join(fs.defaultCacheRoot(), "desert-ant-models", repo)
+        return fs.listDirectory(base)
+            .filter { fs.exists(join(base, $0, Self.metadataDirectory, "manifest")) }
+            .sorted()
+    }
+
+    /// Resolve a ``RevisionRequirement`` to a concrete revision for `repo`.
+    /// `exact` needs nothing. A range asks the Hub for the repo's tags; when
+    /// that fails (offline, or a transport without a refs call), it falls back
+    /// to the newest *downloaded* revision in range, then to the range's `from`
+    /// - so a device that downloaded once keeps working offline, and a fresh
+    /// offline install still points at a valid revision to try.
+    public func resolveRevision(_ requirement: RevisionRequirement, repo: String) async -> String {
+        switch requirement {
+        case .exact(let revision):
+            return revision
+        case .from(let from):
+            if let tags = try? await transport.tags("\(endpoint)/api/models/\(repo)/refs"),
+               let best = requirement.bestMatch(in: tags) {
+                return best
+            }
+            return requirement.bestMatch(in: downloadedRevisions(repo: repo)) ?? from
+        }
+    }
+
     // MARK: internals
 
     /// Expand the requested files/folders against the repo tree.

--- a/Sources/ModelStore/RevisionRequirement.swift
+++ b/Sources/ModelStore/RevisionRequirement.swift
@@ -1,0 +1,72 @@
+// Which model revision a caller wants: a fixed ref, or a semver range over the
+// repo's published tags (SwiftPM-style `from:`, i.e. up to the next major).
+// Foundation-free like
+// the rest of the module's orchestration.
+
+/// A model revision requirement.
+///
+/// `exact` is any Hub ref used as-is: a tag, branch, or commit hash. Ranges
+/// select among the repo's published `v`-tags at resolve time: `from` (the
+/// same meaning as SwiftPM's `from:` - up to the next major) picks the highest
+/// tag `>= from` with the same major version (`v0.2.0` -> the newest `v0.x`,
+/// never `v1.0.0`), so a deployment tracks compatible model updates without
+/// chasing a branch. Resolution asks the Hub for tags; offline
+/// it falls back to the newest *downloaded* revision in range, then to `from`.
+public enum RevisionRequirement: Sendable, Equatable {
+    /// A fixed ref, used verbatim (tag, branch, or commit hash).
+    case exact(String)
+    /// The highest published tag greater than or equal to this one, sharing
+    /// its major version (SwiftPM's `from:` semantics). Must be a
+    /// semantic-version tag (`v0.2.0` or `0.2.0`).
+    case from(String)
+
+    /// The revision when it needs no resolution (`exact`), else nil.
+    public var exactRevision: String? {
+        if case .exact(let revision) = self { return revision }
+        return nil
+    }
+
+    /// The best `candidates` entry satisfying this requirement, or nil.
+    /// Non-semver candidates never satisfy a range; `exact` matches only
+    /// itself. Used both for Hub tags and for the offline cache fallback.
+    public func bestMatch(in candidates: [String]) -> String? {
+        switch self {
+        case .exact(let revision):
+            return candidates.contains(revision) ? revision : nil
+        case .from(let from):
+            guard let floor = SemanticVersion(tag: from) else { return nil }
+            return candidates
+                .compactMap { tag in SemanticVersion(tag: tag).map { (tag, $0) } }
+                .filter { $0.1 >= floor && $0.1.major == floor.major }
+                .max { $0.1 < $1.1 }?.0
+        }
+    }
+}
+
+/// A parsed `v`-tag: `v1.2.3`, `1.2.3`, or a shortened `v1.2`/`v1` (missing
+/// components are 0). Anything else - branches, commits, prerelease suffixes -
+/// does not parse and so never satisfies a ranged requirement.
+struct SemanticVersion: Comparable, Sendable {
+    let major: Int
+    let minor: Int
+    let patch: Int
+
+    init?(tag: String) {
+        let body = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+        let parts = body.split(separator: ".", omittingEmptySubsequences: false)
+        guard (1...3).contains(parts.count) else { return nil }
+        var numbers: [Int] = []
+        for part in parts {
+            guard !part.isEmpty, part.allSatisfy({ $0.isASCII && $0.isNumber }),
+                  let n = Int(part) else { return nil }
+            numbers.append(n)
+        }
+        major = numbers[0]
+        minor = numbers.count > 1 ? numbers[1] : 0
+        patch = numbers.count > 2 ? numbers[2] : 0
+    }
+
+    static func < (a: SemanticVersion, b: SemanticVersion) -> Bool {
+        (a.major, a.minor, a.patch) < (b.major, b.minor, b.patch)
+    }
+}

--- a/Sources/ModelStore/Transport.swift
+++ b/Sources/ModelStore/Transport.swift
@@ -24,7 +24,19 @@ public struct RemoteEntry: Sendable, Equatable {
 /// verification hashes; `download` streams a file, reporting cumulative bytes.
 public protocol ModelTransport: Sendable {
     func tree(_ url: String) async throws -> [RemoteEntry]
+    /// Tag names published for a repo (the Hub refs API). Only ranged
+    /// ``RevisionRequirement`` resolution calls this; backends without it
+    /// throw, and resolution falls back to the downloaded cache.
+    func tags(_ url: String) async throws -> [String]
     func download(_ url: String, to destinationPath: String, onBytes: @escaping @Sendable (Int64) -> Void) async throws
+}
+
+public extension ModelTransport {
+    /// Default for backends without a refs call (Android host bridge, wasm):
+    /// ranged resolution then relies on its cache fallback.
+    func tags(_ url: String) async throws -> [String] {
+        throw ModelStoreError.io("tag listing not supported by this transport")
+    }
 }
 
 /// Filesystem seam: the small set of operations the store needs. `move` must be
@@ -40,6 +52,15 @@ public protocol FileSystem: Sendable {
     func remove(_ path: String)                         // best-effort
     /// Default cache root when a model gives no `cacheDirectory`.
     func defaultCacheRoot() -> String
+    /// Names of the entries directly under `path` (not recursive). A missing
+    /// or unreadable directory is `[]`.
+    func listDirectory(_ path: String) -> [String]
+}
+
+public extension FileSystem {
+    /// Backends without directory enumeration (the wasm in-memory store) list
+    /// nothing rather than failing to conform.
+    func listDirectory(_ path: String) -> [String] { [] }
 }
 
 public enum ModelStoreError: Error, CustomStringConvertible {

--- a/Tests/AudioDSPTests/AudioDSPTests.swift
+++ b/Tests/AudioDSPTests/AudioDSPTests.swift
@@ -96,6 +96,117 @@ final class AudioDSPTests: XCTestCase {
         XCTAssertTrue(y.allSatisfy { abs($0) <= 1 })       // never clips
     }
 
+    // MARK: limiter
+
+    /// The regression the limiter exists to fix. A signal that is quiet apart
+    /// from one loud transient cannot be mastered by a single static gain: to
+    /// keep the transient under the ceiling the whole file has to come down,
+    /// landing well below the requested loudness. The limiter takes the gain
+    /// out of the transient alone, so the target survives.
+    func testLimiterHoldsLoudnessTargetThroughATransient() {
+        let sr = 48_000.0
+        let n = Int(3 * sr)
+        var x = (0..<n).map { Float(0.05 * sin(2 * .pi * 1000 * Double($0) / sr)) }
+        // One 2 ms transient at full scale, a long way above the rest.
+        for i in Int(1.5 * sr)..<(Int(1.5 * sr) + Int(0.002 * sr)) { x[i] = 0.99 }
+
+        let (y, measured) = Loudness.normalize(x, sampleRate: sr, targetLUFS: -19,
+                                               maxGainDB: 30, peakCeilingDBFS: -1)
+        let after = Loudness.integratedLUFS(y, sampleRate: sr)!
+        let ceiling = Float(pow(10, -1.0 / 20))
+
+        // What the static backoff this replaced would have produced: one gain
+        // for the whole signal, scaled down until the transient fits.
+        let staticGain = Float(pow(10, min(-19 - measured!, 30) / 20))
+        var scaled = x.map { $0 * staticGain }
+        let peak = scaled.map { abs($0) }.max()!
+        if peak > ceiling { scaled = scaled.map { $0 * (ceiling / peak) } }
+        let staticAfter = Loudness.integratedLUFS(scaled, sampleRate: sr)!
+
+        // The limiter lands near the target. It does not land exactly on it,
+        // and cannot: the transient inflates the *input* measurement, so the
+        // gain is chosen for a signal whose energy the limiter then removes.
+        XCTAssertEqual(after, -19, accuracy: 1.5)
+        // The backoff misses by far more - that is the regression being fixed.
+        XCTAssertLessThan(staticAfter, after - 5)
+
+        // And the ceiling still holds, which is all the backoff ever bought.
+        XCTAssertTrue(y.allSatisfy { abs($0) <= ceiling + 1e-4 },
+                      "peak \(y.map { abs($0) }.max()!) exceeds ceiling \(ceiling)")
+    }
+
+    func testLimiterCeilingIsRespectedAndGainRecovers() {
+        let sr = 48_000.0
+        // Full-scale tone: every sample needs limiting.
+        var channels = [(0..<Int(sr)).map { Float(0.99 * sin(2 * .pi * 200 * Double($0) / sr)) }]
+        Limiter.apply(&channels, ceilingDBTP: -6, sampleRate: sr)
+        let ceiling = Float(pow(10, -6.0 / 20))
+        XCTAssertTrue(channels[0].allSatisfy { abs($0) <= ceiling + 1e-4 })
+
+        // After a lone transient the envelope must return to unity, otherwise
+        // the release is not working and the tail stays ducked.
+        var quiet = [[Float]](repeating: [Float](repeating: 0.01, count: Int(sr)), count: 1)
+        quiet[0][100] = 0.99
+        Limiter.apply(&quiet, ceilingDBTP: -6, sampleRate: sr)
+        XCTAssertEqual(quiet[0][Int(sr) - 1], 0.01, accuracy: 1e-4)
+    }
+
+    /// One envelope drives every channel: a peak in one channel must duck the
+    /// other by the same amount, or the stereo image shifts while it limits.
+    func testLimiterGainIsJointAcrossChannels() {
+        let sr = 48_000.0
+        let n = 4_800
+        var channels = [[Float]](repeating: [Float](repeating: 0.5, count: n), count: 2)
+        channels[0][2_000] = 0.99                       // peak in the left only
+        let before = channels[1][2_000]
+        Limiter.apply(&channels, ceilingDBTP: -6, sampleRate: sr)
+        XCTAssertLessThan(channels[1][2_000], before)   // right ducked too
+        XCTAssertEqual(channels[0][2_000] / 0.99, channels[1][2_000] / 0.5, accuracy: 1e-4)
+    }
+
+    /// Inter-sample peaks sit between samples, so true peak is never below the
+    /// sample peak and is strictly above it when a waveform straddles one.
+    func testTruePeakMeetsOrExceedsSamplePeak() {
+        let sr = 48_000.0
+        let x = (0..<Int(sr)).map { Float(0.9 * sin(2 * .pi * 11_000 * Double($0) / sr)) }
+        let samplePeak = 20 * log10(Double(x.map { abs($0) }.max()!))
+        let truePeak = Limiter.truePeakDBFS([x])
+        XCTAssertGreaterThanOrEqual(truePeak, samplePeak - 1e-9)
+        XCTAssertEqual(Limiter.truePeakDBFS([[Float](repeating: 0, count: 100)]), -.infinity)
+    }
+
+    /// The streaming limiter has to produce the same samples as the in-memory
+    /// one whatever the chunk sizes are, or a long file mastered through the
+    /// file path would not match the same audio mastered in memory. Both the
+    /// gain envelope and the held-back look-ahead tail have to cross chunk
+    /// boundaries for that to hold.
+    func testStreamingLimiterMatchesWholeSignal() {
+        let sr = 48_000.0
+        let n = 40_000
+        var x = (0..<n).map { Float(0.3 * sin(2 * .pi * 440 * Double($0) / sr)) }
+        for i in stride(from: 5_000, to: n, by: 9_000) { x[i] = 0.95 }
+
+        var whole = [x]
+        Limiter.apply(&whole, ceilingDBTP: -3, sampleRate: sr)
+
+        let streaming = Limiter.Streaming(ceilingDBTP: -3, sampleRate: sr, channels: 1)
+        var chunked = [Float]()
+        var offset = 0
+        for size in [1, 17, 4_800, 240, 12_000, 9_999] {
+            let end = min(offset + size, n)
+            if offset >= end { break }
+            chunked.append(contentsOf: streaming.process([Array(x[offset..<end])])[0])
+            offset = end
+        }
+        if offset < n { chunked.append(contentsOf: streaming.process([Array(x[offset...])])[0]) }
+        chunked.append(contentsOf: streaming.flush()[0])
+
+        XCTAssertEqual(chunked.count, whole[0].count)
+        for i in 0..<chunked.count {
+            XCTAssertEqual(chunked[i], whole[0][i], accuracy: 1e-6, "sample \(i)")
+        }
+    }
+
     // MARK: streaming meter
 
     /// The whole point of the streaming meter: chunked measurement has to agree

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -216,6 +216,10 @@ struct ClearTests {
         _ = try await ModelFixture.files(ClearModel.self)
         // Availability is per instance (LoadedModel owns it), so ask one.
         #expect(Clear().isDownloaded())
+        // The managed cache lists the downloaded version, its last path
+        // component the revision the SDK is pinned to.
+        let models = Clear.models()
+        #expect(models.contains { $0.hasSuffix("/\(ClearModel.repo)/\(Clear.modelRevision)") })
     }
 
     /// The file-in/file-out path (Apple/Linux): decode any audio file, enhance,

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -199,6 +199,15 @@ struct ClearTests {
         #expect(rms(spotify.samples) > rms(broadcast.samples))
         #expect(spotify.measuredLUFS != nil)
         #expect(bypassed.measuredLUFS == nil)
+
+        // True peak is measured after limiting, so it reports the delivered
+        // audio and has to sit under the ceiling the preset asked for.
+        #expect(bypassed.measuredTruePeakDBFS == nil)
+        let truePeak = try #require(spotify.measuredTruePeakDBFS)
+        #expect(truePeak <= Clear.Mastering.spotify.truePeakDBTP + 0.5)
+        // 4x oversampling can only find peaks a sample-peak reading misses.
+        let samplePeak = 20 * log10(Double(spotify.samples.map { abs($0) }.max() ?? 0))
+        #expect(truePeak >= samplePeak - 1e-9)
     }
 
     /// The store path the SDK's own initializer takes: resolve the pinned model

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -157,7 +157,7 @@ struct ClearTests {
     /// once per process and every test here reuses it.
     private func enhancer() async throws -> Clear {
         let files = try await ModelFixture.files(ClearModel.self)
-        return try Clear(modelPath: files.path(ClearModel.artifact))
+        return try Clear(modelPath: files.path(ClearModel.artifact), revision: "1d8810f")
     }
 
     @Test func enhanceEndToEnd() async throws {
@@ -293,7 +293,7 @@ struct ClearTests {
     @Test func progressReportsModelLoad() async throws {
         _ = try await ModelFixture.files(ClearModel.self)   // cached; the load is local
         let log = ProgressLog()
-        _ = try await Clear().enhance(samples: tone(48_000), sampleRate: 48_000) { log.append($0) }
+        _ = try await enhancer().enhance(samples: tone(48_000), sampleRate: 48_000) { log.append($0) }
         #expect(log.all().first?.phase == .loadingModel)
     }
 }

--- a/Tests/ModelCatalogTests/ModelCatalogTests.swift
+++ b/Tests/ModelCatalogTests/ModelCatalogTests.swift
@@ -22,10 +22,13 @@ struct ModelCatalogTests {
         for model in catalog {
             #expect(model.id == model.id.lowercased() && !model.id.isEmpty)
             #expect(model.repo == "desert-ant-labs/\(model.id)")
-            // A v-tag, or `main` for a model whose first tag predates one of its
-            // platform artifacts (clear: the Hub tag has no LiteRT export yet).
-            #expect(model.revision.hasPrefix("v") || model.revision == "main",
-                    "\(model.id): revision must be a v-tag (or a documented `main` pin)")
+            // A v-tag; or, for a model whose latest tag lacks one of its
+            // platform artifacts, a documented pin of `main` itself or a full
+            // commit hash of it (immutable, unlike the branch - clear pins the
+            // commit carrying the ANE-shaped Core ML export until it is tagged).
+            let isCommitHash = model.revision.count == 40 && model.revision.allSatisfy(\.isHexDigit)
+            #expect(model.revision.hasPrefix("v") || model.revision == "main" || isCommitHash,
+                    "\(model.id): revision must be a v-tag (or a documented main/commit pin)")
             #expect(model.product.first?.isUppercase == true, "\(model.id): product is capitalized")
             #expect(!model.summary.isEmpty)
         }

--- a/Tests/ModelStoreTests/RevisionRequirementTests.swift
+++ b/Tests/ModelStoreTests/RevisionRequirementTests.swift
@@ -1,0 +1,46 @@
+// The semver selection behind ranged revision requirements: which published
+// tag (or cached revision) a requirement lands on, and what never qualifies.
+
+import Testing
+@testable import ModelStore
+
+struct RevisionRequirementTests {
+
+    /// `exact` matches only itself - it is a ref, not a version.
+    @Test func exactMatchesOnlyItself() {
+        let r = RevisionRequirement.exact("v0.2.0")
+        #expect(r.bestMatch(in: ["v0.1.0", "v0.2.0", "v0.3.0"]) == "v0.2.0")
+        #expect(r.bestMatch(in: ["v0.3.0"]) == nil)
+        #expect(r.exactRevision == "v0.2.0")
+    }
+
+    /// `from` picks the highest tag >= from within the same major (SwiftPM's
+    /// from: semantics): from v0.2.0, the newest v0.x - never v1.0.0, never an
+    /// older v0.1.
+    @Test func fromStaysWithinTheMajor() {
+        let r = RevisionRequirement.from("v0.2.0")
+        #expect(r.bestMatch(in: ["v0.1.0", "v0.2.0", "v0.2.1", "v0.10.0", "v1.0.0"]) == "v0.10.0")
+        #expect(r.bestMatch(in: ["v0.1.0", "v1.0.0"]) == nil)   // nothing in range
+        #expect(r.exactRevision == nil)
+    }
+
+    /// Numeric ordering, not lexicographic: v0.10.0 > v0.9.0.
+    @Test func ordersNumerically() {
+        let r = RevisionRequirement.from("v0.9.0")
+        #expect(r.bestMatch(in: ["v0.9.0", "v0.10.0"]) == "v0.10.0")
+    }
+
+    /// Branches, commits, and prerelease tags never satisfy a range; bare and
+    /// shortened version tags do (v1 == 1.0.0).
+    @Test func onlySemverTagsQualify() {
+        let r = RevisionRequirement.from("1.0.0")
+        #expect(r.bestMatch(in: ["main", "deadbeef", "v1.1.0-rc.1", "v1.1"]) == "v1.1")
+        #expect(SemanticVersion(tag: "main") == nil)
+        #expect(SemanticVersion(tag: "v1.2.3-beta") == nil)
+        #expect(SemanticVersion(tag: "v1") == SemanticVersion(tag: "1.0.0"))
+    }
+}
+
+extension SemanticVersion: Equatable {
+    static func == (a: SemanticVersion, b: SemanticVersion) -> Bool { !(a < b) && !(b < a) }
+}

--- a/js/src/ffi.js
+++ b/js/src/ffi.js
@@ -39,6 +39,19 @@ export class FfiReader {
     return v;
   }
 
+  /** Read a uint32 count, then that many big-endian floats. The audio payload:
+   *  a fresh Float32Array, not a view, because the source bytes are big-endian
+   *  and the platform is not. */
+  f32Array() {
+    const n = this.u32();
+    const out = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      out[i] = this._view.getFloat32(this._o, false);
+      this._o += 4;
+    }
+    return out;
+  }
+
   /** Read a uint32-length-prefixed UTF-8 string. */
   str() {
     const n = this.u32();
@@ -83,6 +96,17 @@ export class FfiWriter {
   f64(v) {
     const b = new Uint8Array(8);
     new DataView(b.buffer).setFloat64(0, v, false);
+    return this._push(b);
+  }
+
+  /** Append a uint32 element count, then that many big-endian floats: the
+   *  portable audio payload, matching Swift's `FFIWriter.f32Array`. */
+  f32Array(values) {
+    const a = values instanceof Float32Array ? values : Float32Array.from(values ?? []);
+    this.u32(a.length);
+    const b = new Uint8Array(a.length * 4);
+    const view = new DataView(b.buffer);
+    for (let i = 0; i < a.length; i++) view.setFloat32(i * 4, a[i], false);
     return this._push(b);
   }
 

--- a/js/test/ffi.test.mjs
+++ b/js/test/ffi.test.mjs
@@ -28,6 +28,36 @@ test("FfiReader reads u32/i32/f64/str big-endian in order", () => {
   assert.equal(r.remaining, 0);
 });
 
+test("FfiReader reads an f32Array the way Swift writes one", () => {
+  // Built independently of FfiWriter, so this pins the wire format rather than
+  // just proving the writer and reader agree with each other.
+  const parts = [];
+  const count = Buffer.alloc(4);
+  count.writeUInt32BE(4);
+  parts.push(count);
+  const values = [0.5, -0.25, 0, 1];
+  for (const v of values) {
+    const b = Buffer.alloc(4);
+    b.writeFloatBE(v);
+    parts.push(b);
+  }
+  const r = new FfiReader(new Uint8Array(Buffer.concat(parts)));
+  assert.deepEqual(Array.from(r.f32Array()), values);
+  assert.equal(r.remaining, 0);
+});
+
+test("FfiWriter round-trips an f32Array, taking arrays or Float32Array", () => {
+  const values = [0, 1, -1, 0.5, -0.25];
+  for (const input of [values, Float32Array.from(values)]) {
+    const bytes = new FfiWriter().f32Array(input).f64(48_000).done();
+    assert.equal(bytes.length, 4 + values.length * 4 + 8);
+    const r = new FfiReader(bytes);
+    assert.deepEqual(Array.from(r.f32Array()), values);
+    assert.equal(r.f64(), 48_000);
+    assert.equal(r.remaining, 0);
+  }
+});
+
 test("FfiReader mirrors a shapes-style line payload", () => {
   // present(1), kind line(1), from(x,y), to(x,y)
   const b = buildPayload();

--- a/kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt
+++ b/kotlin/src/main/kotlin/ai/desertant/core/HostBridge.kt
@@ -357,6 +357,16 @@ class FfiReader(bytes: ByteArray) {
     fun int(): Int = buf.int
     fun double(): Double = buf.double
 
+    /** Whether any bytes are left, for fields appended after a first release. */
+    fun hasRemaining(): Boolean = buf.hasRemaining()
+
+    /** Read an int count, then that many big-endian floats: the audio payload. */
+    fun floats(): FloatArray {
+        val out = FloatArray(buf.int)
+        for (i in out.indices) out[i] = buf.float
+        return out
+    }
+
     fun string(): String {
         val b = ByteArray(buf.int)
         buf.get(b)
@@ -380,6 +390,13 @@ class FfiWriter {
 
     /** Append a big-endian IEEE-754 double. */
     fun double(v: Double): FfiWriter = apply { data.writeDouble(v) }
+
+    /** Append an int element count, then that many big-endian floats: the
+     *  portable audio payload, matching Swift's `FFIWriter.f32Array`. */
+    fun floats(values: FloatArray): FfiWriter = apply {
+        data.writeInt(values.size)
+        for (v in values) data.writeFloat(v)
+    }
 
     /** Append a uint32 UTF-8 byte count, then the UTF-8 bytes. */
     fun string(s: String): FfiWriter = apply {

--- a/kotlin/src/test/kotlin/ai/desertant/core/LoadedModelTest.kt
+++ b/kotlin/src/test/kotlin/ai/desertant/core/LoadedModelTest.kt
@@ -9,6 +9,29 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class LoadedModelTest {
+    /** The audio payload: an int count then big-endian floats, matching Swift's
+     *  `FFIWriter.f32Array` and the JavaScript `FfiWriter.f32Array`. */
+    @Test fun floatArraysRoundTripThroughTheFfiCodec() {
+        val values = floatArrayOf(0f, 1f, -1f, 0.5f, -0.25f)
+        val bytes = FfiWriter().floats(values).double(48_000.0).done()
+        assertEquals(4 + values.size * 4 + 8, bytes.size)
+
+        val r = FfiReader(bytes)
+        assertArrayEquals(values, r.floats(), 0f)
+        assertEquals(48_000.0, r.double(), 0.0)
+        assertFalse(r.hasRemaining())
+    }
+
+    /** A field appended after a release has to read as absent, not as garbage,
+     *  for a host built against the older schema. */
+    @Test fun hasRemainingGuardsAnAppendedField() {
+        val r = FfiReader(FfiWriter().floats(floatArrayOf(1f)).double(1.0).done())
+        r.floats()
+        assertTrue(r.hasRemaining())
+        r.double()
+        assertFalse(r.hasRemaining())
+    }
+
     @Test fun createsTheRightCatalogHandleWithoutLoadingTheRuntime() {
         val native = FakeNative()
         model(native, directory = "/models/emo")

--- a/mise-tasks/test/swift
+++ b/mise-tasks/test/swift
@@ -12,7 +12,10 @@ dal_start_echo_server 8199
 # Own scratch dir: the Xcode toolchain's artifacts are incompatible with the
 # swift.org toolchain the wasm tasks use, so they must never share one.
 if [ "$(uname)" = Darwin ]; then
-    swift test --scratch-path .build-host
+    # xcrun pins the Xcode toolchain even when a mise-managed swift is on PATH:
+    # older mise ignores the tools os=["linux"] filter above, and the swift.org
+    # toolchain cannot build against the Xcode SDK.
+    xcrun swift test --scratch-path .build-host
 else
     litert=$(dal_litert_dir)
     LD_LIBRARY_PATH="$litert${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,10 @@
       "integrity": "sha512-FlRBYttPRLcWORzBe6g8nmYTafBkOEFeOqMYM4tAHJzFsQy4+xJA94z85a9BCs8S+Uzfh9LrkpII7DXr2iUVFg==",
       "license": "MIT OR Apache-2.0"
     },
+    "node_modules/@desert-ant-labs/clear": {
+      "resolved": "packages/clear-node",
+      "link": true
+    },
     "node_modules/@desert-ant-labs/core": {
       "resolved": "js",
       "link": true
@@ -126,6 +130,28 @@
         "node": ">=20"
       }
     },
+    "packages/clear-node": {
+      "version": "1.0.5",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bjorn3/browser_wasi_shim": "^0.3.0",
+        "@desert-ant-labs/core": "^1.0.5"
+      },
+      "devDependencies": {
+        "@litertjs/core": "^2.5.2"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@litertjs/core": ">=2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@litertjs/core": {
+          "optional": true
+        }
+      }
+    },
     "packages/emo-node": {
       "name": "@desert-ant-labs/emo",
       "version": "1.0.5",
@@ -155,7 +181,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.3.0",
-        "@desert-ant-labs/core": "^1.0.4"
+        "@desert-ant-labs/core": "^1.0.5"
       },
       "devDependencies": {
         "@litertjs/core": "^2.5.2"

--- a/packages/clear-kotlin/build.gradle.kts
+++ b/packages/clear-kotlin/build.gradle.kts
@@ -1,0 +1,11 @@
+// Android library (AAR) for Clear: ai.desertant:clear. Everything structural -
+// AGP, Kotlin, publishing, the ai.desertant:core dependency, and the Swift JNI
+// cross-compile - lives in the shared ai.desertant.model-sdk convention plugin
+// (gradle-plugin/). The version comes from VERSION at the repo root, so the only
+// thing left here is what is genuinely Clear's.
+plugins { id("ai.desertant.model-sdk") }
+
+desertAntSdk {
+    description = "On-device speech enhancement for Android: denoise, dereverb, and " +
+        "loudness-normalize a noisy recording to a podcast-ready 48 kHz mono file."
+}

--- a/packages/clear-kotlin/src/androidTest/kotlin/ai/desertant/clear/ClearTest.kt
+++ b/packages/clear-kotlin/src/androidTest/kotlin/ai/desertant/clear/ClearTest.kt
@@ -1,0 +1,70 @@
+package ai.desertant.clear
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.PI
+import kotlin.math.sin
+
+/**
+ * Instrumented tests for the Android binding, exercising the real on-device path
+ * via JNI: the LiteRT runtime, the DSP front end, and the static-stdlib runtime.
+ * The AAR ships no model, so the suite downloads the pinned revision into the
+ * app cache once and reuses it.
+ */
+@RunWith(AndroidJUnit4::class)
+class ClearTest {
+    private lateinit var clear: Clear
+
+    @Before fun setUp() {
+        clear = Clear(InstrumentationRegistry.getInstrumentation().targetContext)
+    }
+    // Null-safe: if setUp() throws, an unguarded close() replaces the real
+    // failure with UninitializedPropertyAccessException and hides the cause.
+    @After fun tearDown() { if (::clear.isInitialized) clear.close() }
+
+    /** A second of tone plus noise: enough frames for several model chunks. */
+    private fun noisyTone(seconds: Double = 1.0, sampleRate: Int = 48_000): FloatArray {
+        var seed = 12_345L
+        return FloatArray((seconds * sampleRate).toInt()) { i ->
+            seed = (seed * 1_103_515_245 + 12_345) and 0x7fffffff
+            val noise = (seed.toFloat() / 0x7fffffff - 0.5f) * 0.1f
+            (0.3 * sin(2 * PI * 220 * i / sampleRate)).toFloat() + noise
+        }
+    }
+
+    @Test fun enhanceEndToEnd() = runTest {
+        val r = clear.enhance(noisyTone())
+        assertEquals(48_000.0, r.sampleRate, 0.0)
+        assertTrue(r.samples.isNotEmpty())
+        assertTrue(r.samples.all { it.isFinite() })
+        assertTrue(r.durationSec > 0)
+    }
+
+    @Test fun masteringReportsBothMeasurements() = runTest {
+        val r = clear.enhance(
+            noisyTone(),
+            options = Options(mastering = Mastering.of(LoudnessPreset.SPOTIFY)),
+        )
+        assertNotNull(r.measuredLufs)
+        val truePeak = r.measuredTruePeakDbfs
+        assertNotNull(truePeak)
+        // Limited to the default -1.5 dBTP ceiling, with a little slack for the
+        // inter-sample peaks a sample-peak limiter does not see.
+        assertTrue("true peak $truePeak above ceiling", truePeak!! <= -1.0)
+    }
+
+    @Test fun bypassReportsNoMeasurements() = runTest {
+        val r = clear.enhance(noisyTone(), options = Options(mastering = Mastering.BYPASS))
+        assertNull(r.measuredLufs)
+        assertNull(r.measuredTruePeakDbfs)
+    }
+}

--- a/packages/clear-kotlin/src/main/AndroidManifest.xml
+++ b/packages/clear-kotlin/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Needed for the on-demand model download; a directory you pre-populate uses no network. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/packages/clear-kotlin/src/main/kotlin/ai/desertant/clear/Clear.kt
+++ b/packages/clear-kotlin/src/main/kotlin/ai/desertant/clear/Clear.kt
@@ -1,0 +1,177 @@
+package ai.desertant.clear
+
+import ai.desertant.core.FfiWriter
+import ai.desertant.core.LoadedModel
+
+/** The catalog id, which is how the shared native layer is asked for Clear. */
+private const val MODEL_ID = "clear"
+private const val MODEL_NAME = "Clear"
+
+/** Standard delivery loudness targets, in integrated LUFS. */
+enum class LoudnessPreset(val integratedLufs: Double) {
+    APPLE_PODCASTS(-19.0),
+    SPOTIFY(-14.0),
+    YOUTUBE(-14.0),
+    BROADCAST(-23.0),
+}
+
+/** Post-DSP mastering: where the enhanced audio should land, loudness-wise. */
+data class Mastering(
+    /** Integrated loudness target in LUFS. */
+    val integratedLufs: Double = LoudnessPreset.APPLE_PODCASTS.integratedLufs,
+    /** True-peak ceiling in dBTP. -1.5 leaves headroom for lossy codecs. */
+    val truePeakDbtp: Double = -1.5,
+    /** Upper bound on the loudness gain in dB, so a very quiet input lands
+     *  under target rather than lifting the model's noise floor with it. */
+    val maxLoudnessGainDb: Double = 9.0,
+    /** Set false to return the unmastered model output. */
+    val enabled: Boolean = true,
+) {
+    companion object {
+        fun of(preset: LoudnessPreset): Mastering = Mastering(integratedLufs = preset.integratedLufs)
+
+        /** Skip mastering: the output level tracks the input. */
+        val BYPASS: Mastering = Mastering(enabled = false)
+    }
+}
+
+/** Options controlling enhancement and mastering. */
+data class Options(
+    /** Enhancement blend in `0.0..1.0`. 1.0 is the full model output. */
+    val strength: Double = 1.0,
+    val mastering: Mastering = Mastering(),
+)
+
+/** The enhanced audio, and what mastering measured on the way out. */
+data class Result(
+    /** Enhanced audio: 48 kHz mono, whatever the input rate was. */
+    val samples: FloatArray,
+    /** Always 48000.0. */
+    val sampleRate: Double,
+    /** Length of the output in seconds. */
+    val durationSec: Double,
+    /** Wall-clock time the enhance took. */
+    val processingSec: Double,
+    /** Integrated loudness of the *input*, or null when mastering was bypassed. */
+    val measuredLufs: Double?,
+    /**
+     * True peak of the delivered audio in dBFS (4x oversampled), or null when
+     * mastering was bypassed. Measured after limiting, so it is what to assert
+     * a delivery spec against.
+     */
+    val measuredTruePeakDbfs: Double?,
+) {
+    /** Above 1.0 is faster than real time. */
+    val realtimeFactor: Double get() = if (processingSec > 0) durationSec / processingSec else 0.0
+
+    // FloatArray needs identity-free equals/hashCode to behave as a data class.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Result) return false
+        return samples.contentEquals(other.samples) &&
+            sampleRate == other.sampleRate &&
+            durationSec == other.durationSec &&
+            processingSec == other.processingSec &&
+            measuredLufs == other.measuredLufs &&
+            measuredTruePeakDbfs == other.measuredTruePeakDbfs
+    }
+
+    override fun hashCode(): Int {
+        var result = samples.contentHashCode()
+        result = 31 * result + sampleRate.hashCode()
+        result = 31 * result + durationSec.hashCode()
+        result = 31 * result + processingSec.hashCode()
+        result = 31 * result + (measuredLufs?.hashCode() ?: 0)
+        result = 31 * result + (measuredTruePeakDbfs?.hashCode() ?: 0)
+        return result
+    }
+}
+
+/** Thrown when the model cannot be created, loaded, or run. */
+class ClearException(message: String) : Exception(message)
+
+/**
+ * On-device speech enhancement: denoise, dereverb, and loudness-normalize.
+ * Mirrors the iOS/Swift SDK: create one `Clear` and reuse it; the model loads
+ * lazily on the first [enhance] (or eagerly via [download]).
+ *
+ * ```kotlin
+ * val clear = Clear(context)                   // downloads on first use
+ * val r = clear.enhance(samples, 48_000.0)
+ * r.samples                                    // 48 kHz mono
+ * clear.close()
+ * ```
+ *
+ * Creating, downloading, running, and releasing the model are the shared
+ * `ai.desertant:core` shell ([LoadedModel]); what lives here is Clear's API and
+ * its payload schemas.
+ *
+ * @param directory the model's home. Files already there are adopted (so an app
+ *   that ships the model just points at the folder it unpacked it into),
+ *   otherwise the model is downloaded into it. Omit to use the app cache.
+ */
+class Clear(
+    context: android.content.Context,
+    directory: String? = null,
+) : AutoCloseable {
+    private val model = LoadedModel(MODEL_ID, MODEL_NAME, context, directory, ::ClearException, ClearNative)
+
+    companion object
+
+    /** Whether the model is available for this enhancer with no network. */
+    fun isDownloaded(): Boolean = model.isDownloaded()
+
+    /**
+     * Download the model ahead of time so the first [enhance] is instant. A
+     * no-op once available (see [isDownloaded]). Suspends on a background
+     * dispatcher.
+     */
+    suspend fun download() = model.download()
+
+    /**
+     * Enhance mono [samples] at [sampleRate], returning 48 kHz mono whatever
+     * the input rate. Loads the model lazily on first call.
+     */
+    suspend fun enhance(
+        samples: FloatArray,
+        sampleRate: Double = 48_000.0,
+        options: Options = Options(),
+    ): Result {
+        // Input payload: the samples, then the sample rate. Options payload:
+        // f64 strength, then the mastering chain as f64 integratedLUFS (NaN
+        // bypasses), f64 truePeakDBTP, f64 maxLoudnessGainDB. Result payload:
+        // the samples, then f64 sampleRate/durationSec/processingSec, and the
+        // two measurements (NaN when bypassed). All three must match
+        // Sources/Clear/Binding.swift.
+        val input = FfiWriter().floats(samples).double(sampleRate).done()
+        val m = options.mastering
+        val payload = FfiWriter()
+            .double(options.strength)
+            .double(if (m.enabled) m.integratedLufs else Double.NaN)
+            .double(m.truePeakDbtp)
+            .double(m.maxLoudnessGainDb)
+            .done()
+        return model.run(input, payload, failureMessage = "enhance failed") { r ->
+            val out = r.floats()
+            val rate = r.double()
+            val duration = r.double()
+            val processing = r.double()
+            val lufs = r.double()
+            // Appended after the first release: a core built before it leaves
+            // nothing to read, and the field reads as absent.
+            val truePeak = if (r.hasRemaining()) r.double() else Double.NaN
+            Result(
+                samples = out,
+                sampleRate = rate,
+                durationSec = duration,
+                processingSec = processing,
+                measuredLufs = lufs.takeUnless { it.isNaN() },
+                measuredTruePeakDbfs = truePeak.takeUnless { it.isNaN() },
+            )
+        }
+    }
+
+    /** Release the native model. The enhancer is unusable afterwards; calling
+     *  this again is a no-op. */
+    @Synchronized override fun close() = model.close()
+}

--- a/packages/clear-kotlin/src/main/kotlin/ai/desertant/clear/ClearNative.kt
+++ b/packages/clear-kotlin/src/main/kotlin/ai/desertant/clear/ClearNative.kt
@@ -1,0 +1,13 @@
+package ai.desertant.clear
+
+import ai.desertant.core.NativeLibraries
+import ai.desertant.core.NativeModelApi
+
+internal object ClearNative : NativeModelApi {
+    override fun ensureLoaded() = NativeLibraries.loadModel("ClearAndroid")
+    override external fun create(modelId: ByteArray, cacheRoot: ByteArray?, directory: ByteArray?): Long
+    override external fun destroy(handle: Long)
+    override external fun isDownloaded(handle: Long): Int
+    override external fun download(handle: Long): Int
+    override external fun run(handle: Long, input: ByteArray, options: ByteArray?): ByteArray?
+}

--- a/packages/clear-node/README.md
+++ b/packages/clear-node/README.md
@@ -1,0 +1,98 @@
+# @desert-ant-labs/clear
+
+On-device speech enhancement for JavaScript. Takes a noisy mono recording
+(laptop mic, untreated room, traffic) and returns podcast-ready 48 kHz audio:
+denoise and dereverb from a fine-tuned [DeepFilterNet 3][dfn], then loudness
+normalization to a delivery target. Everything runs locally, so the audio never
+leaves the device or browser.
+
+[dfn]: https://github.com/Rikorose/DeepFilterNet
+
+Two entries share one `Clear` API:
+
+- **`@desert-ant-labs/clear`** (default): a WebAssembly pipeline with
+  [LiteRT.js](https://www.npmjs.com/package/@litertjs/core) inference
+  (XNNPACK-accelerated CPU by default, optional WebGPU), for the **browser**. It
+  has no native dependencies, so a single import builds cleanly for every target
+  of a multi-target bundler (Next.js, Remix, SvelteKit, Nuxt), including the
+  browser bundle and the Client-Component SSR pass those frameworks render in
+  Node. It is safe to *import* during server-side rendering, but LiteRT.js needs
+  a browser (or Web Worker) to initialize, so `Clear.load()` runs inference only
+  in the browser; calling it in plain Node throws an actionable error pointing
+  you to `/native`.
+- **`@desert-ant-labs/clear/native`**: a prebuilt native core (LiteRT on Linux,
+  Core ML on macOS), for **server-side inference** in Node. No `@litertjs/core`,
+  no build tools, no flags. Import it from server-only code (API routes, server
+  actions, plain Node scripts). Do not import it from a component that also
+  renders in the browser.
+
+```bash
+# Browser (default entry):
+npm i @desert-ant-labs/clear @litertjs/core
+
+# Server-side inference in Node (/native entry) needs no extra install:
+npm i @desert-ant-labs/clear
+```
+
+## Usage
+
+```ts
+import { Clear } from "@desert-ant-labs/clear";           // browser
+// import { Clear } from "@desert-ant-labs/clear/native"; // server-side Node
+
+const clear = await Clear.load();          // downloads and caches on first use
+const result = await clear.enhance(samples, 48_000);
+
+result.samples;                // Float32Array, 48 kHz mono, whatever went in
+result.measuredLUFS;           // integrated loudness of the input
+result.measuredTruePeakDBFS;   // true peak of the output, after limiting
+result.realtimeFactor;         // above 1 is faster than real time
+
+clear.dispose();
+```
+
+Input can be a `Float32Array` or a plain array of numbers, at any sample rate;
+the output is always 48 kHz mono.
+
+## Mastering
+
+By default the output is normalized to the Apple Podcasts target (-19 LUFS) with
+a -1.5 dBTP ceiling, held by a look-ahead limiter rather than by turning the
+whole file down to fit its loudest transient.
+
+```ts
+await clear.enhance(samples, 48_000, { targetLUFS: "spotify" });   // -14 LUFS
+await clear.enhance(samples, 48_000, { targetLUFS: -23 });         // an explicit target
+await clear.enhance(samples, 48_000, { targetLUFS: null });        // skip mastering
+```
+
+`LOUDNESS_PRESETS` carries the published platform targets (`applePodcasts`,
+`spotify`, `youtube`, `broadcast`). Two more knobs are available:
+`peakCeilingDBFS` (default -1.5) and `maxGainDB` (default 9), which bounds how
+far a very quiet input is lifted so the model's noise floor does not come up
+with it.
+
+`strength` blends the enhanced signal against the original, for when full
+denoising sounds too processed:
+
+```ts
+await clear.enhance(samples, 48_000, { strength: 0.7 });
+```
+
+## Self-hosting and progress
+
+```ts
+const clear = await Clear.load({
+  modelBaseUrl: "/assets/clear/",     // browser: serve the files yourself
+  directory: "/var/cache/clear",      // Node: adopt or download here
+  onProgress: (fraction) => console.log(fraction),
+});
+```
+
+The model repo and revision are pinned to this SDK version, so an install is
+reproducible. Weights live on [Hugging
+Face](https://huggingface.co/desert-ant-labs/clear).
+
+## License
+
+See [LICENSE.md](./LICENSE.md).

--- a/packages/clear-node/browser.js
+++ b/packages/clear-node/browser.js
@@ -1,0 +1,29 @@
+// On-device speech enhancement for JavaScript: the universal entry. It runs in
+// the browser and, via the platform seam, server-side in Node (the
+// Client-Component SSR pass frameworks render in Node), both on the same
+// WebAssembly + @litertjs/core (LiteRT.js) pipeline: XNNPACK-accelerated CPU
+// ("wasm") by default, with optional WebGPU in the browser.
+//
+// There is nothing model-specific left in the wiring: @desert-ant-labs/core owns
+// the LiteRT.js session, the Hub download, and the `modelBaseUrl` opt-out, and
+// the public API is `clear.js` (shared with the native entry). For a prebuilt
+// native server core (no @litertjs/core, best server throughput), import
+// `@desert-ant-labs/clear/native`.
+//
+// All node-only code lives behind the `#platform` import, which bundlers resolve
+// at build time by condition (browser -> platform-browser.js, otherwise
+// platform-node.js), so this file never references `node:*` and one import
+// builds cleanly for every target of a multi-target bundler.
+import * as platform from "#platform";
+import { createWasmSdk } from "@desert-ant-labs/core";
+import { PACKAGE_NAME } from "./codec.js";
+import { makeClear, LOUDNESS_PRESETS } from "./clear.js";
+
+export { LOUDNESS_PRESETS };
+
+// The wasm core instantiates at import time (top-level await); the model is only
+// wired in Clear.load().
+export const Clear = makeClear(await createWasmSdk({
+  platform,
+  packageName: PACKAGE_NAME,
+}));

--- a/packages/clear-node/clear.js
+++ b/packages/clear-node/clear.js
@@ -1,0 +1,80 @@
+// Clear's public API, over whichever core the entry point bound: the browser's
+// WebAssembly + LiteRT.js core (browser.js) or the prebuilt native core
+// (node.js). Both expose the same ABI, and @desert-ant-labs/core turns either
+// one into the same `LoadedModel`, so the API is written once here instead of
+// once per runtime.
+import { decodeResult, encodeInput, encodeOptions, LOUDNESS_PRESETS } from "./codec.js";
+
+export { LOUDNESS_PRESETS };
+
+/**
+ * Build the `Clear` class over a bound SDK (`createWasmSdk` /
+ * `createNativeSdk`). The entry points do nothing but call this.
+ */
+export function makeClear(sdk) {
+  /**
+   * On-device speech enhancement. Create one with `await Clear.load(...)` and
+   * reuse it, mirroring the Swift and Kotlin SDKs.
+   *
+   * ```js
+   * const clear = await Clear.load();                 // download on demand, cached
+   * const r = await clear.enhance(samples, 48000);
+   * r.samples; r.measuredLUFS; r.measuredTruePeakDBFS;
+   * clear.dispose();
+   * ```
+   */
+  return class Clear {
+    #model;
+    constructor(model) { this.#model = model; }
+
+    /**
+     * Load the model and return a ready enhancer. By default the model is
+     * downloaded from the Hugging Face Hub at the pinned revision, verified, and
+     * cached (the filesystem under Node, the runtime's cache in the browser).
+     * Pass `directory` (Node) or `modelBaseUrl` (browser) to use files you host
+     * yourself. The repo and revision are pinned to the SDK.
+     */
+    static async load(options = {}) {
+      return new Clear(await sdk.open(options));
+    }
+
+    /**
+     * Enhance mono `samples` at `sampleRate`: denoise, dereverb, then master to
+     * a delivery target. Returns 48 kHz mono, whatever the input rate.
+     *
+     * `options.targetLUFS` takes a number or a key of {@link LOUDNESS_PRESETS};
+     * pass null to skip mastering and get the model's own level back.
+     *
+     * `options.deviceId` (a string or a zero-arg function returning one)
+     * attributes usage to a specific end-user device; it is collected per call,
+     * so it is safe for concurrent multi-tenant hosts. `options.group` (an id
+     * from {@link withCallGroup}) bills several calls as one.
+     */
+    async enhance(samples, sampleRate = 48_000, options = {}) {
+      const target = options.targetLUFS === undefined
+        ? LOUDNESS_PRESETS.applePodcasts
+        : options.targetLUFS;
+      const payload = encodeOptions({
+        strength: options.strength ?? 1,
+        targetLUFS: typeof target === "string" ? LOUDNESS_PRESETS[target] : target,
+        peakCeilingDBFS: options.peakCeilingDBFS ?? -1.5,
+        maxGainDB: options.maxGainDB ?? 9,
+      });
+      return decodeResult(
+        await this.#model.run(encodeInput(samples, sampleRate), payload, options));
+    }
+
+    /** Whether the model is usable with no network. */
+    isDownloaded() { return this.#model.isDownloaded(); }
+
+    /**
+     * Run `body(group)` with a fresh call-group id, so every
+     * `enhance({ group })` inside it bills as a single usage call. The group is
+     * released when `body` settles.
+     */
+    withCallGroup(body) { return this.#model.withCallGroup(body); }
+
+    /** Release the model. The enhancer is unusable afterwards. */
+    dispose() { this.#model.dispose(); }
+  };
+}

--- a/packages/clear-node/codec.js
+++ b/packages/clear-node/codec.js
@@ -1,0 +1,69 @@
+// Clear's FFI payload schemas: the options a run takes and the result it
+// returns.
+//
+// These are the only model-specific part of talking to the core, and both cores
+// speak the same payloads - the native `dal_run` (node.js) and the WebAssembly
+// `run` (browser.js) - so they live here once instead of in each entry point.
+// Mirrors the reader/writer in Sources/Clear/Binding.swift.
+import { FfiWriter } from "@desert-ant-labs/core";
+
+/** The catalog id: how both cores are asked for Clear, and the key its
+ *  WebAssembly exports are registered under. */
+export const MODEL_ID = "clear";
+
+export const PACKAGE_NAME = "@desert-ant-labs/clear";
+
+/** Integrated-LUFS targets for the platforms Clear ships presets for. The
+ *  presets themselves live in Swift (`Clear.LoudnessPreset`); what crosses the
+ *  boundary is the number, so adding one here breaks no core. */
+export const LOUDNESS_PRESETS = Object.freeze({
+  applePodcasts: -19,
+  podcast: -19,
+  spotify: -14,
+  youtube: -14,
+  broadcast: -23,
+});
+
+/** Input payload: `f32Array samples` (mono), then `f64 sampleRate`. */
+export function encodeInput(samples, sampleRate) {
+  return new FfiWriter().f32Array(samples).f64(sampleRate).done();
+}
+
+/** Options payload: `f64 strength`, then the mastering chain as
+ *  `f64 integratedLUFS` (NaN bypasses mastering), `f64 truePeakDBTP`,
+ *  `f64 maxLoudnessGainDB`. */
+export function encodeOptions({ strength, targetLUFS, peakCeilingDBFS, maxGainDB }) {
+  return new FfiWriter()
+    .f64(strength)
+    .f64(targetLUFS === null || targetLUFS === undefined ? NaN : targetLUFS)
+    .f64(peakCeilingDBFS)
+    .f64(maxGainDB)
+    .done();
+}
+
+/** Result payload: `f32Array samples` (48 kHz mono), then `f64 sampleRate`,
+ *  `f64 durationSec`, `f64 processingSec`, `f64 measuredLUFS`, and
+ *  `f64 measuredTruePeakDBFS`. The two measurements are NaN when mastering was
+ *  bypassed, which surfaces as null rather than as a NaN a caller has to know
+ *  to test for. `r` is an FfiReader positioned at the payload. */
+export function decodeResult(r) {
+  const samples = r.f32Array();
+  const sampleRate = r.f64();
+  const durationSec = r.f64();
+  const processingSec = r.f64();
+  const measuredLUFS = r.f64();
+  // Appended after the first release: a core built before it leaves nothing to
+  // read, and the field reads as absent rather than as a decode failure.
+  const measuredTruePeakDBFS = r.remaining >= 8 ? r.f64() : NaN;
+  return {
+    samples,
+    sampleRate,
+    durationSec,
+    processingSec,
+    measuredLUFS: Number.isNaN(measuredLUFS) ? null : measuredLUFS,
+    measuredTruePeakDBFS: Number.isNaN(measuredTruePeakDBFS) ? null : measuredTruePeakDBFS,
+    get realtimeFactor() {
+      return processingSec > 0 ? durationSec / processingSec : 0;
+    },
+  };
+}

--- a/packages/clear-node/index.d.ts
+++ b/packages/clear-node/index.d.ts
@@ -1,0 +1,67 @@
+// The model-specific half of this package's types. Everything that is the same
+// for every model - how a model is loaded, how a call is billed and attributed -
+// comes from @desert-ant-labs/core, so it is documented in one place.
+import type { CallOptions, ModelLoadOptions } from "@desert-ant-labs/core";
+
+/** The delivery targets Clear ships presets for, in integrated LUFS. */
+export declare const LOUDNESS_PRESETS: {
+  readonly applePodcasts: -19;
+  readonly podcast: -19;
+  readonly spotify: -14;
+  readonly youtube: -14;
+  readonly broadcast: -23;
+};
+
+/** A key of {@link LOUDNESS_PRESETS}. */
+export type LoudnessPreset = keyof typeof LOUDNESS_PRESETS;
+
+/** The enhanced audio, and what mastering measured on the way out. */
+export interface ClearResult {
+  /** Enhanced audio: 48 kHz mono, whatever the input rate was. */
+  samples: Float32Array;
+  /** Always 48000. */
+  sampleRate: number;
+  /** Length of the output in seconds. */
+  durationSec: number;
+  /** Wall-clock time the enhance took. */
+  processingSec: number;
+  /** Integrated loudness of the *input*, or null when mastering was bypassed. */
+  measuredLUFS: number | null;
+  /**
+   * True peak of the delivered audio in dBFS (4x oversampled), or null when
+   * mastering was bypassed. Measured after limiting, so it is what to assert a
+   * delivery spec against.
+   */
+  measuredTruePeakDBFS: number | null;
+  /** `durationSec / processingSec`: above 1 is faster than real time. */
+  readonly realtimeFactor: number;
+}
+
+export interface EnhanceOptions extends CallOptions {
+  /** Enhancement blend in `0..1`. 1 (default) is the full model output. */
+  strength?: number;
+  /**
+   * Integrated-LUFS target, a {@link LoudnessPreset} name, or null to skip
+   * mastering and return the model's own level. Defaults to `"applePodcasts"`.
+   */
+  targetLUFS?: number | LoudnessPreset | null;
+  /** True-peak ceiling in dBTP. Defaults to -1.5. */
+  peakCeilingDBFS?: number;
+  /** Upper bound on the loudness gain in dB. Defaults to 9. */
+  maxGainDB?: number;
+}
+
+/** On-device speech enhancement: denoise, dereverb, loudness-normalize. */
+export declare class Clear {
+  /** Load the model, downloading and caching it on first use. */
+  static load(options?: ModelLoadOptions): Promise<Clear>;
+  /** Enhance mono `samples`, returning 48 kHz mono. */
+  enhance(samples: Float32Array | number[], sampleRate?: number,
+          options?: EnhanceOptions): Promise<ClearResult>;
+  /** Whether the model is usable with no network. */
+  isDownloaded(): boolean;
+  /** Bill every call made inside `body` as one usage call. */
+  withCallGroup<T>(body: (group: string) => Promise<T>): Promise<T>;
+  /** Release the model. */
+  dispose(): void;
+}

--- a/packages/clear-node/node.js
+++ b/packages/clear-node/node.js
@@ -1,0 +1,26 @@
+// On-device speech enhancement for JavaScript, server-side (Node). This is the
+// `node` conditional-exports entry: the same Clear API as the browser build, but
+// natively via the prebuilt Swift core (LiteRT/Core ML under the hood) instead
+// of WebAssembly + LiteRT.js. Consumers just `import { Clear }` - Node resolves
+// this file, browsers resolve `browser.js`. No flags, no setup.
+//
+// The koffi harness (resolve native/<platform>-<arch>, load the runtime, bind
+// the generic `dal_*` C ABI, run blocking calls off the event loop) lives in
+// @desert-ant-labs/core/node, and the public API is `clear.js`, shared with the
+// browser entry; this file only binds the two together.
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { createNativeSdk } from "@desert-ant-labs/core/node";
+import { MODEL_ID, PACKAGE_NAME } from "./codec.js";
+import { makeClear, LOUDNESS_PRESETS } from "./clear.js";
+
+export { LOUDNESS_PRESETS };
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const Clear = makeClear(createNativeSdk({
+  here: HERE,
+  packageName: PACKAGE_NAME,
+  modelId: MODEL_ID,
+  coreName: "ClearNode",
+}));

--- a/packages/clear-node/package.json
+++ b/packages/clear-node/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@desert-ant-labs/clear",
+  "version": "1.0.5",
+  "description": "On-device speech enhancement for JavaScript: denoise, dereverb, and loudness-normalize to a podcast-ready 48 kHz. Runs in the browser (WebAssembly + LiteRT.js) and server-side in Node (native), from one import.",
+  "type": "module",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "homepage": "https://desertant.com/models/clear/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Desert-Ant-Labs/desert-ant-core.git",
+    "directory": "packages/clear-node"
+  },
+  "keywords": [
+    "speech-enhancement",
+    "denoise",
+    "dereverb",
+    "audio",
+    "loudness",
+    "lufs",
+    "on-device",
+    "wasm",
+    "litert",
+    "isomorphic"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./browser.js",
+  "browser": "./browser.js",
+  "types": "./index.d.ts",
+  "scripts": {
+    "test": "node --test test/clear.test.mjs"
+  },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./browser.js"
+    },
+    "./native": {
+      "types": "./index.d.ts",
+      "default": "./node.js"
+    },
+    "./browser": {
+      "types": "./index.d.ts",
+      "default": "./browser.js"
+    },
+    "./wasm": "./dist/ClearWeb.wasm"
+  },
+  "imports": {
+    "#platform": {
+      "browser": "./platform-browser.js",
+      "default": "./platform-node.js"
+    }
+  },
+  "files": [
+    "browser.js",
+    "clear.js",
+    "codec.js",
+    "node.js",
+    "platform-browser.js",
+    "platform-node.js",
+    "index.d.ts",
+    "dist",
+    "native",
+    "LICENSE.md",
+    "README.md"
+  ],
+  "dependencies": {
+    "@bjorn3/browser_wasi_shim": "^0.3.0",
+    "@desert-ant-labs/core": "^1.0.5"
+  },
+  "optionalDependencies": {
+    "koffi": "^2.9.0"
+  },
+  "peerDependencies": {
+    "@litertjs/core": ">=2.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@litertjs/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@litertjs/core": "^2.5.2"
+  }
+}

--- a/packages/clear-node/platform-browser.js
+++ b/packages/clear-node/platform-browser.js
@@ -1,0 +1,16 @@
+// Browser half of the platform seam for the universal WebAssembly entry
+// (browser.js). Bundlers resolve this file through the "browser" import
+// condition of `#platform` (see package.json "imports"), so none of the
+// node-only code in platform-node.js ever enters the browser module graph.
+// This is what lets one `@desert-ant-labs/clear` import build cleanly for the
+// browser target of multi-target bundlers (Next, Remix, SvelteKit, Nuxt). The
+// shared instantiation logic lives in @desert-ant-labs/core.
+import { browserSetup, browserWasmDir, browserReadModelSource, browserCacheRoot } from "@desert-ant-labs/core";
+
+export function setupCore() {
+  return browserSetup({ init: () => import("./dist/index.js") });
+}
+
+export const defaultWasmDir = browserWasmDir;
+export const readModelSource = browserReadModelSource;
+export const defaultCacheRoot = browserCacheRoot;

--- a/packages/clear-node/platform-node.js
+++ b/packages/clear-node/platform-node.js
@@ -1,0 +1,23 @@
+// Node half of the platform seam for the universal WebAssembly entry
+// (browser.js) when it runs server-side, e.g. the Client-Component SSR pass a
+// framework renders in Node. The node-only work (WASI instantiate + node fs
+// seam) lives in @desert-ant-labs/core/platform-node; this file binds it to
+// Clear's dist entry points. Bundlers resolve this file only through the
+// non-browser ("default") condition of `#platform`, so the browser bundle never
+// sees `node:*`.
+//
+// This imports the koffi-free "/platform-node" entry, never "/node": the native
+// loader behind "/node" drags koffi's native addons into the SSR chunk, which
+// bundlers cannot place in ESM output.
+import { nodeSetup, nodeWasmDir, nodeReadModelSource, nodeCacheRoot } from "@desert-ant-labs/core/platform-node";
+
+export function setupCore() {
+  return nodeSetup({
+    instantiate: () => import("./dist/instantiate.js"),
+    nodePlatform: () => import("./dist/platforms/node.js"),
+  });
+}
+
+export const defaultWasmDir = nodeWasmDir;
+export const readModelSource = nodeReadModelSource;
+export const defaultCacheRoot = nodeCacheRoot;

--- a/packages/clear-node/test/clear.test.mjs
+++ b/packages/clear-node/test/clear.test.mjs
@@ -1,0 +1,114 @@
+// The clear-node test suite. Runs server-side in Node against the native core
+// (the `@desert-ant-labs/clear/native` entry, i.e. node.js). No model is
+// committed, so the suite downloads the pinned revision into a directory under
+// the package on the first run and reuses it offline afterward. The native core
+// picks each OS's runtime and artifact itself: Core ML (.mlmodelc) on macOS,
+// LiteRT (.tflite) on Linux. The default universal WebAssembly + LiteRT.js entry
+// is exercised by the headless-Chromium example.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { FfiReader, FfiWriter } from "@desert-ant-labs/core";
+
+import { Clear } from "../node.js";
+// From codec.js, not node.js: pure data, so these assert without a native core.
+import { LOUDNESS_PRESETS, encodeInput, encodeOptions, decodeResult } from "../codec.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const directory = path.join(here, ".model-cache");
+
+let clear;
+let loadError;
+try {
+  clear = await Clear.load({ directory });
+} catch (e) {
+  loadError = e;
+}
+const modelOpts = clear ? {} : { skip: `native model unavailable: ${String(loadError).slice(0, 100)}` };
+
+// A second of noisy tone: enough for several model chunks, cheap to run.
+function noisyTone(seconds = 1, sampleRate = 48_000) {
+  const n = Math.floor(seconds * sampleRate);
+  const out = new Float32Array(n);
+  let seed = 12_345;
+  for (let i = 0; i < n; i++) {
+    seed = (seed * 1_103_515_245 + 12_345) & 0x7fffffff;
+    const noise = (seed / 0x7fffffff - 0.5) * 0.1;
+    out[i] = 0.3 * Math.sin((2 * Math.PI * 220 * i) / sampleRate) + noise;
+  }
+  return out;
+}
+
+test("the input payload is samples then sample rate", () => {
+  const bytes = encodeInput(Float32Array.from([0.5, -0.25]), 48_000);
+  const r = new FfiReader(bytes);
+  assert.deepEqual(Array.from(r.f32Array()), [0.5, -0.25]);
+  assert.equal(r.f64(), 48_000);
+  assert.equal(r.remaining, 0);
+});
+
+test("a null target bypasses mastering as NaN on the wire", () => {
+  const r = new FfiReader(encodeOptions({
+    strength: 1, targetLUFS: null, peakCeilingDBFS: -1.5, maxGainDB: 9,
+  }));
+  assert.equal(r.f64(), 1);
+  assert.ok(Number.isNaN(r.f64()));
+  assert.equal(r.f64(), -1.5);
+  assert.equal(r.f64(), 9);
+});
+
+test("NaN measurements decode as null, not NaN", () => {
+  const bytes = new FfiWriter()
+    .f32Array([0.1, 0.2]).f64(48_000).f64(2).f64(0.5).f64(NaN).f64(NaN).done();
+  const result = decodeResult(new FfiReader(bytes));
+  assert.equal(result.measuredLUFS, null);
+  assert.equal(result.measuredTruePeakDBFS, null);
+  assert.equal(result.realtimeFactor, 4);
+});
+
+test("a core built before true peak still decodes", () => {
+  // The field is appended, so a short payload has to read as absent rather
+  // than throw or return garbage.
+  const bytes = new FfiWriter()
+    .f32Array([0.1]).f64(48_000).f64(1).f64(1).f64(-19).done();
+  const result = decodeResult(new FfiReader(bytes));
+  assert.equal(result.measuredLUFS, -19);
+  assert.equal(result.measuredTruePeakDBFS, null);
+});
+
+test("presets carry the published platform targets", () => {
+  assert.equal(LOUDNESS_PRESETS.applePodcasts, -19);
+  assert.equal(LOUDNESS_PRESETS.spotify, -14);
+  assert.equal(LOUDNESS_PRESETS.broadcast, -23);
+});
+
+test("enhance returns 48 kHz mono", modelOpts, async () => {
+  const r = await clear.enhance(noisyTone(), 48_000);
+  assert.equal(r.sampleRate, 48_000);
+  assert.ok(r.samples.length > 0);
+  assert.ok(r.samples.every(Number.isFinite));
+  assert.ok(r.durationSec > 0);
+});
+
+test("mastering hits the ceiling and reports both measurements", modelOpts, async () => {
+  const r = await clear.enhance(noisyTone(), 48_000, { targetLUFS: "spotify" });
+  assert.ok(r.measuredLUFS !== null);
+  assert.ok(r.measuredTruePeakDBFS !== null);
+  // Limited to the default -1.5 dBTP ceiling, with a little slack for the
+  // inter-sample peaks a sample-peak limiter does not see.
+  assert.ok(r.measuredTruePeakDBFS <= -1.0,
+            `true peak ${r.measuredTruePeakDBFS} above ceiling`);
+});
+
+test("bypassing mastering reports no measurements", modelOpts, async () => {
+  const r = await clear.enhance(noisyTone(), 48_000, { targetLUFS: null });
+  assert.equal(r.measuredLUFS, null);
+  assert.equal(r.measuredTruePeakDBFS, null);
+});
+
+test("the enhancer is unusable after dispose", modelOpts, async () => {
+  const one = await Clear.load({ directory });
+  one.dispose();
+  await assert.rejects(() => one.enhance(noisyTone(0.1), 48_000));
+});


### PR DESCRIPTION
- Pin clear to the Hub's `v0.2.0` tag, replacing the floating `main`
- Master with a look-ahead limiter instead of a static peak backoff, so a transient no longer drags the whole file below its loudness target
- Batch limiting is one pass of the streaming limiter, so the in-memory and file paths cannot drift
- Measure true peak (4x oversampled, after limiting) and report it as `measuredTruePeakDBFS` on all three platforms
- Add `packages/clear-node` (`@desert-ant-labs/clear`) and `packages/clear-kotlin` (`ai.desertant:clear`)
- Add `f32Array`/`floats` to the JS and Kotlin FFI codecs, matching Swift's
- Document Clear as shipping on all three platforms
