### PR TITLE
Let Clear pin, range, and introspect its model revision

### DIFF
--- a/Sources/Clear/Catalog.swift
+++ b/Sources/Clear/Catalog.swift
@@ -8,7 +8,12 @@ import DesertAnt
 public enum ClearModel: ModelDeclaration {
     public static let id = "clear"
     public static let product = "Clear"
-    public static let revision = "v0.2.0"
+    // Not the v0.2.0 tag: that tag's Core ML export predates the ANE-shaped
+    // batch-4 layout the enhancer now feeds (Enhancer.batchSize), so Apple
+    // would fail with a shape mismatch on every run. This commit of `main`
+    // carries the re-shaped .mlmodelc alongside the LiteRT exports; becomes
+    // the next `v`-tag once one is cut with it.
+    public static let revision = "1d8810fa86077c319952ffc2080b31bab86a2ad7"
     /// Matches packages/clear-node/package.json and packages/clear-kotlin/build.gradle.kts
     /// (ModelCatalogTests enforces it).
     public static let sdkVersion = "1.0.5"

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -72,6 +72,11 @@ public final class Clear: @unchecked Sendable {
         /// artifact is not a published one (a custom export, or a wasm host
         /// that compiled the model itself).
         public let modelVariant: ModelVariant?
+        /// The repo revision the model was resolved from - for a ranged
+        /// ``RevisionRequirement`` this is the concrete tag it landed on. Nil
+        /// when nothing was downloaded (a local `modelPath`, explicit assets,
+        /// or a self-hosted wasm model).
+        public let modelRevision: String?
         public var realtimeFactor: Double { processingSec > 0 ? durationSec / processingSec : 0 }
     }
 
@@ -123,6 +128,26 @@ public final class Clear: @unchecked Sendable {
     // same loader.
     let model: LoadedModel<ModelAssets>
 
+    /// The variant this instance loads, or nil when it was built from an
+    /// explicit artifact/assets whose variant only the caller knows.
+    public let variant: ModelVariant?
+    /// The revision requirement this instance resolves: `.exact` of the
+    /// `revision` passed at init (else the SDK's pinned
+    /// ``Clear/modelRevision``), or the range you passed. Nil when the instance
+    /// was built from a local `modelPath` or explicit assets (nothing is
+    /// downloaded, so no repo revision applies).
+    public let revisionRequirement: RevisionRequirement?
+    /// The concrete model revision this instance resolves, when it is knowable
+    /// without the network: the exact revision, or nil for a ranged
+    /// requirement (resolved at load time against the Hub's tags; the loaded
+    /// one is reported on ``Result/modelRevision``).
+    ///
+    /// This is the revision that *will* be downloaded (or that the cache is
+    /// checked against - see ``isDownloaded()``). For a branch revision like
+    /// `"main"` the cache holds whatever commit was current at download time;
+    /// only a tag or commit hash pins the exact contents.
+    public var modelRevision: String? { revisionRequirement?.exactRevision }
+
     /// Default model sessions to run chunks in parallel over. Native LiteRT is
     /// single-threaded per run, so a pool uses multiple cores; Apple (fast) and
     /// wasm (LiteRT.js is already multi-threaded) use one.
@@ -144,10 +169,33 @@ public final class Clear: @unchecked Sendable {
     /// Nothing is bundled with this package. To ship the model with your app,
     /// point `directory` at a folder you populated with the model files: it is
     /// used as-is, offline, and nothing is downloaded.
+    ///
+    /// `revision` pins a specific published model version (a Hub tag like
+    /// `v0.2.0`, a branch, or a commit hash) instead of the revision this SDK
+    /// was built against (``Clear/modelRevision``). Each revision caches
+    /// separately, so switching versions never clobbers another's files.
     public convenience init(directory: String? = nil, variant: ModelVariant = .default,
+                            revision: String? = nil,
                             computeUnits: ComputeUnits = .cpuOnly,
                             concurrency: Int = Clear.defaultConcurrency) {
         self.init(directory: directory, cacheRoot: nil, variant: variant,
+                  revision: .exact(revision ?? ClearModel.revision),
+                  computeUnits: computeUnits, concurrency: concurrency)
+    }
+
+    /// Like `init(revision: String)`, but with a ``RevisionRequirement``:
+    /// `.exact("v0.2.0")` behaves as above, while
+    /// `.from("v0.2.0")` (SwiftPM semantics: up to the next major) resolves to
+    /// the newest published tag
+    /// with the same major version at load time - and, offline, to the newest
+    /// already-downloaded revision in range, so an installed device keeps
+    /// working without the network. The resolved revision is reported on each
+    /// ``Result/modelRevision``.
+    public convenience init(directory: String? = nil, variant: ModelVariant = .default,
+                            revision: RevisionRequirement,
+                            computeUnits: ComputeUnits = .cpuOnly,
+                            concurrency: Int = Clear.defaultConcurrency) {
+        self.init(directory: directory, cacheRoot: nil, variant: variant, revision: revision,
                   computeUnits: computeUnits, concurrency: concurrency)
     }
 
@@ -158,12 +206,31 @@ public final class Clear: @unchecked Sendable {
     @_spi(ClearBindings)
     public init(directory: String?, cacheRoot: String?,
                 variant: ModelVariant = .default,
+                revision requirement: RevisionRequirement = .exact(ClearModel.revision),
                 computeUnits: ComputeUnits = .cpuOnly,
                 concurrency: Int = Clear.defaultConcurrency) {
         // A variant is its own slice of the model repo, so the loader resolves
-        // that distribution rather than the catalog entry's default one.
-        model = LoadedModel(variant.distribution, directory: directory, cacheRoot: cacheRoot) { files in
-            try await .clear(files: files, variant: variant, computeUnits: computeUnits, concurrency: concurrency)
+        // that distribution rather than the catalog entry's default one; the
+        // requirement decides the revision (for ranges, at load time).
+        self.variant = variant
+        self.revisionRequirement = requirement
+        let base = variant.distribution(revision: ClearModel.revision)
+        model = LoadedModel(
+            resolve: { await base.resolving(requirement, cacheRoot: cacheRoot) },
+            isAvailable: {
+                // Offline answer: an exact revision checks itself (including a
+                // user-populated directory); a range is available when any
+                // downloaded revision satisfies it.
+                let revisions = requirement.exactRevision.map { [$0] }
+                    ?? base.downloadedRevisions(satisfying: requirement, cacheRoot: cacheRoot)
+                return revisions.contains {
+                    variant.distribution(revision: $0)
+                        .isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot)
+                }
+            },
+            directory: directory, cacheRoot: cacheRoot) { files, distribution in
+            try await .clear(files: files, variant: variant, revision: distribution.revision,
+                             computeUnits: computeUnits, concurrency: concurrency)
         }
     }
 
@@ -171,6 +238,8 @@ public final class Clear: @unchecked Sendable {
     /// custom-deployment paths).
     @_spi(ClearBindings)
     public init(assets: ModelAssets) {
+        variant = nil
+        revisionRequirement = nil
         model = LoadedModel { assets }
     }
 
@@ -182,7 +251,35 @@ public final class Clear: @unchecked Sendable {
         // Built eagerly (this initializer throws), then handed to the loader so
         // the rest of the class has one path to its assets.
         let assets = try ModelAssets(modelPath: modelPath, computeUnits: computeUnits, concurrency: concurrency)
+        variant = ModelVariant.inferred(fromPath: modelPath)
+        revisionRequirement = nil
         model = LoadedModel { assets }
+    }
+
+    /// Paths of every downloaded version of the clear model in the managed
+    /// cache, one per revision, sorted. The last path component of each entry
+    /// is the revision (`.../desert-ant-models/desert-ant-labs/clear/v0.2.0`),
+    /// so `models().map { ($0 as NSString).lastPathComponent }` lists the
+    /// versions available offline. Only completed downloads appear; a folder
+    /// you populated yourself (an explicit `directory`) is not part of the
+    /// managed cache and is not listed.
+    ///
+    /// Note: a revision directory may hold one or both variants' files - the
+    /// per-variant check is ``isDownloaded(variant:revision:directory:cacheRoot:)``.
+    public static func models(cacheRoot: String? = nil) -> [String] {
+        ModelVariant.default.distribution.installedModels(cacheRoot: cacheRoot)
+    }
+
+    /// Whether a given variant/revision is already downloaded and intact
+    /// (usable offline), without constructing an enhancer. `revision` defaults
+    /// to the SDK's pinned ``Clear/modelRevision``; `directory` mirrors the
+    /// initializer's parameter (nil = the managed cache).
+    public static func isDownloaded(variant: ModelVariant = .default,
+                                    revision: String? = nil,
+                                    directory: String? = nil,
+                                    cacheRoot: String? = nil) -> Bool {
+        variant.distribution(revision: revision ?? ClearModel.revision)
+            .isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot)
     }
 
     /// Whether the model is available for this enhancer with no network:
@@ -196,9 +293,19 @@ public final class Clear: @unchecked Sendable {
         _ = try await model.value()
     }
 
-    /// Download the model if needed, reporting progress 0...1.
+    /// Download the model if needed, reporting download progress 0...1.
     public func download(progress: @escaping @Sendable (Double) -> Void = { _ in }) async throws {
         try await model.download(progress: progress)
+    }
+
+    /// Download (if needed) and fully load the model, reporting phase-aware
+    /// progress: ``ModelLoadPhase/downloading`` with a bytes-based fraction,
+    /// then ``ModelLoadPhase/preparing`` while the inference session is built
+    /// (on Apple, the first launch's Core ML compile lands here). Returns once
+    /// the model is ready, so the first `enhance` starts instantly. Concurrent
+    /// callers join the same load.
+    public func load(progress: @escaping @Sendable (ModelLoadProgress) -> Void = { _ in }) async throws {
+        try await model.load(progress: progress)
     }
 
     /// Enhance mono/stereo `samples` at `sampleRate`, returning 48 kHz mono.
@@ -262,7 +369,7 @@ public final class Clear: @unchecked Sendable {
                       durationSec: Double(out.count) / ClearDSP.sampleRate,
                       processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
                       measuredTruePeakDBFS: truePeak,
-                      modelVariant: assets.variant)
+                      modelVariant: assets.variant, modelRevision: assets.revision)
     }
 
     func elapsedSeconds(since start: ContinuousClock.Instant) -> Double {

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -248,13 +248,22 @@ public final class Clear: @unchecked Sendable {
     /// Load a local model file directly (a `.mlmodelc` on Apple, a `.tflite`
     /// elsewhere), skipping the store entirely. For tests and custom
     /// deployments; apps point `directory` at their files instead.
-    public init(modelPath: String, computeUnits: ComputeUnits = .all,
+    ///
+    /// A local file resolves nothing, so `revision` is a declaration, not a
+    /// requirement: the exact revision you know the file came from (a tag or
+    /// commit hash). It is reported back on ``revisionRequirement``,
+    /// ``modelRevision``, and every ``Result/modelRevision``, so a CI cache
+    /// keyed by revision produces self-identifying runs. It is never checked
+    /// against the file - there is nothing offline to check it against.
+    public init(modelPath: String, revision: String? = nil,
+                computeUnits: ComputeUnits = .all,
                 concurrency: Int = Clear.defaultConcurrency) throws {
         // Built eagerly (this initializer throws), then handed to the loader so
         // the rest of the class has one path to its assets.
-        let assets = try ModelAssets(modelPath: modelPath, computeUnits: computeUnits, concurrency: concurrency)
+        let assets = try ModelAssets(modelPath: modelPath, revision: revision,
+                                     computeUnits: computeUnits, concurrency: concurrency)
         variant = ModelVariant.inferred(fromPath: modelPath)
-        revisionRequirement = nil
+        revisionRequirement = revision.map { .exact($0) }
         model = LoadedModel { assets }
     }
 

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -162,8 +162,10 @@ public final class Clear: @unchecked Sendable {
     }
 
     /// `computeUnits` selects the Core ML compute units on Apple (ignored by the
-    /// LiteRT/JS backends). Default `.cpuOnly`: the palettized model benchmarks
-    /// ~2x faster on the CPU than the Neural Engine or GPU on M-series Macs.
+    /// LiteRT/JS backends). Default `.all`, letting Core ML place the work
+    /// itself; pass `.cpuOnly` if CPU-only benchmarks better for your model
+    /// and hardware (the palettized model has run ~2x faster on the CPU than
+    /// the Neural Engine or GPU on some M-series Macs).
     /// `concurrency` is the model-session pool size (see `defaultConcurrency`).
     ///
     /// Nothing is bundled with this package. To ship the model with your app,
@@ -176,7 +178,7 @@ public final class Clear: @unchecked Sendable {
     /// separately, so switching versions never clobbers another's files.
     public convenience init(directory: String? = nil, variant: ModelVariant = .default,
                             revision: String? = nil,
-                            computeUnits: ComputeUnits = .cpuOnly,
+                            computeUnits: ComputeUnits = .all,
                             concurrency: Int = Clear.defaultConcurrency) {
         self.init(directory: directory, cacheRoot: nil, variant: variant,
                   revision: .exact(revision ?? ClearModel.revision),
@@ -193,7 +195,7 @@ public final class Clear: @unchecked Sendable {
     /// ``Result/modelRevision``.
     public convenience init(directory: String? = nil, variant: ModelVariant = .default,
                             revision: RevisionRequirement,
-                            computeUnits: ComputeUnits = .cpuOnly,
+                            computeUnits: ComputeUnits = .all,
                             concurrency: Int = Clear.defaultConcurrency) {
         self.init(directory: directory, cacheRoot: nil, variant: variant, revision: revision,
                   computeUnits: computeUnits, concurrency: concurrency)
@@ -207,7 +209,7 @@ public final class Clear: @unchecked Sendable {
     public init(directory: String?, cacheRoot: String?,
                 variant: ModelVariant = .default,
                 revision requirement: RevisionRequirement = .exact(ClearModel.revision),
-                computeUnits: ComputeUnits = .cpuOnly,
+                computeUnits: ComputeUnits = .all,
                 concurrency: Int = Clear.defaultConcurrency) {
         // A variant is its own slice of the model repo, so the loader resolves
         // that distribution rather than the catalog entry's default one; the
@@ -246,7 +248,7 @@ public final class Clear: @unchecked Sendable {
     /// Load a local model file directly (a `.mlmodelc` on Apple, a `.tflite`
     /// elsewhere), skipping the store entirely. For tests and custom
     /// deployments; apps point `directory` at their files instead.
-    public init(modelPath: String, computeUnits: ComputeUnits = .cpuOnly,
+    public init(modelPath: String, computeUnits: ComputeUnits = .all,
                 concurrency: Int = Clear.defaultConcurrency) throws {
         // Built eagerly (this initializer throws), then handed to the loader so
         // the rest of the class has one path to its assets.

--- a/Sources/Clear/Enhancer.swift
+++ b/Sources/Clear/Enhancer.swift
@@ -61,6 +61,19 @@ struct ClearEnhancer {
     let chunkLen: Int
     private let stft = ClearSTFT()
 
+    /// How many independent chunks one `run` consumes, and in which layout.
+    ///
+    /// The Core ML export is ANE-shaped: planar `[B, C, F, T]` tensors with a
+    /// fixed batch of four windows (`spec (4,2,481,200)`,
+    /// `feat_erb (4,1,32,200)`, `feat_spec (4,2,96,200)`). Every other runtime
+    /// (LiteRT/ONNX/JS host) keeps the original DFN3 layout: one window per
+    /// run, interleaved `[1, 1, T, F, 2]`.
+    #if canImport(CoreML)
+    static let batchSize = 4
+    #else
+    static let batchSize = 1
+    #endif
+
     init(sessions: [any InferenceSession], chunkLen: Int = 200) {
         self.sessions = sessions.isEmpty ? [] : sessions
         self.chunkLen = chunkLen
@@ -95,7 +108,9 @@ struct ClearEnhancer {
         defer { outRe.deinitialize(count: count); outRe.deallocate(); outIm.deinitialize(count: count); outIm.deallocate() }
 
         let nChunks = (nFrames + chunkLen - 1) / chunkLen
-        let workers = max(1, min(sessions.count, nChunks))
+        let batch = Self.batchSize
+        let nGroups = (nChunks + batch - 1) / batch
+        let workers = max(1, min(sessions.count, nGroups))
         let chunkLen = self.chunkLen
         // Each worker owns one session and a strided set of chunks; output
         // ranges are disjoint per chunk, so the shared buffers need no locking.
@@ -106,14 +121,16 @@ struct ClearEnhancer {
                 group.addTask {
                     let (outRe, outIm, sessions, fe, fsr, fsi, sr, si) = box.value
                     let session = sessions[w]
-                    var c = w
-                    while c < nChunks {
-                        let start = c * chunkLen, end = min(start + chunkLen, nFrames)
-                        try await Self.runChunk(session: session, start: start, end: end, nFrames: nFrames, chunkLen: chunkLen,
+                    var g = w
+                    while g < nGroups {
+                        let firstChunk = g * batch
+                        let chunks = min(batch, nChunks - firstChunk)
+                        try await Self.runGroup(session: session, firstChunk: firstChunk, chunks: chunks,
+                                                nFrames: nFrames, chunkLen: chunkLen,
                                                 featErb: fe, featSpecReal: fsr, featSpecImag: fsi,
                                                 specReal: sr, specImag: si, outRe: outRe, outIm: outIm)
-                        completed.finishOne()
-                        c += workers
+                        for _ in 0..<chunks { completed.finishOne() }
+                        g += workers
                     }
                 }
             }
@@ -128,6 +145,28 @@ struct ClearEnhancer {
         return enhanced
     }
 
+    /// Run one group of `chunks` consecutive windows (`batchSize` of them at
+    /// most) through `session` and scatter the result into the output planes.
+    private static func runGroup(session: any InferenceSession, firstChunk: Int, chunks: Int,
+                                 nFrames: Int, chunkLen: Int,
+                                 featErb: [Float], featSpecReal: [Float], featSpecImag: [Float],
+                                 specReal: [Float], specImag: [Float],
+                                 outRe: UnsafeMutablePointer<Float>, outIm: UnsafeMutablePointer<Float>) async throws {
+        #if canImport(CoreML)
+        try await runPlanarBatch(session: session, firstChunk: firstChunk, chunks: chunks,
+                                 nFrames: nFrames, chunkLen: chunkLen,
+                                 featErb: featErb, featSpecReal: featSpecReal, featSpecImag: featSpecImag,
+                                 specReal: specReal, specImag: specImag, outRe: outRe, outIm: outIm)
+        #else
+        let start = firstChunk * chunkLen
+        try await runChunk(session: session, start: start, end: min(start + chunkLen, nFrames),
+                           nFrames: nFrames, chunkLen: chunkLen,
+                           featErb: featErb, featSpecReal: featSpecReal, featSpecImag: featSpecImag,
+                           specReal: specReal, specImag: specImag, outRe: outRe, outIm: outIm)
+        #endif
+    }
+
+    /// The original DFN3 layout: one window per run, interleaved complex.
     private static func runChunk(session: any InferenceSession, start: Int, end: Int, nFrames: Int, chunkLen: Int,
                                  featErb: [Float], featSpecReal: [Float], featSpecImag: [Float],
                                  specReal: [Float], specImag: [Float],
@@ -202,6 +241,112 @@ struct ClearEnhancer {
         }
         #endif
     }
+
+    #if canImport(CoreML)
+    /// The Core ML export's layout: a fixed batch of `batchSize` independent
+    /// windows as planar `[B, C, F, T]` tensors (frequency-major, time last),
+    /// which is what the ANE program declares. Unused batch elements are left
+    /// zero and their outputs ignored.
+    private static func runPlanarBatch(session: any InferenceSession, firstChunk: Int, chunks: Int,
+                                       nFrames: Int, chunkLen: Int,
+                                       featErb: [Float], featSpecReal: [Float], featSpecImag: [Float],
+                                       specReal: [Float], specImag: [Float],
+                                       outRe: UnsafeMutablePointer<Float>, outIm: UnsafeMutablePointer<Float>) async throws {
+        let T = chunkLen, B = batchSize
+        let nFreq = ClearDSP.nFreq, nErb = ClearDSP.nErb, nDf = ClearDSP.nDf
+        let look = ClearDSP.convLookahead
+
+        var specBuf = [Float](repeating: 0, count: B * 2 * nFreq * T)
+        var erbBuf = [Float](repeating: 0, count: B * nErb * T)
+        var featSpecBuf = [Float](repeating: 0, count: B * 2 * nDf * T)
+
+        for b in 0..<chunks {
+            let start = (firstChunk + b) * T
+            // Features are read `convLookahead` frames ahead of the window; the
+            // spectrum is read at the window itself. Both clamp at the tail.
+            let tEnd = min(T, nFrames - start - look)
+            let sEnd = min(T, nFrames - start)
+            if tEnd > 0 {
+                toPlanar(featErb, srcFrame: start + look, frames: tEnd, cols: nErb,
+                         into: &erbBuf, planeOffset: b * nErb * T, T: T)
+                toPlanar(featSpecReal, srcFrame: start + look, frames: tEnd, cols: nDf,
+                         into: &featSpecBuf, planeOffset: (b * 2) * nDf * T, T: T)
+                toPlanar(featSpecImag, srcFrame: start + look, frames: tEnd, cols: nDf,
+                         into: &featSpecBuf, planeOffset: (b * 2 + 1) * nDf * T, T: T)
+            }
+            if sEnd > 0 {
+                toPlanar(specReal, srcFrame: start, frames: sEnd, cols: nFreq,
+                         into: &specBuf, planeOffset: (b * 2) * nFreq * T, T: T)
+                toPlanar(specImag, srcFrame: start, frames: sEnd, cols: nFreq,
+                         into: &specBuf, planeOffset: (b * 2 + 1) * nFreq * T, T: T)
+            }
+        }
+
+        let outputs = try await session.run(
+            inputs: [
+                "spec": Tensor(float32: specBuf, shape: [B, 2, nFreq, T]),
+                "feat_erb": Tensor(float32: erbBuf, shape: [B, 1, nErb, T]),
+                "feat_spec": Tensor(float32: featSpecBuf, shape: [B, 2, nDf, T]),
+            ],
+            outputs: ["spec_enhanced"])
+        guard let enh = outputs.first?.float32Values, enh.count >= B * 2 * nFreq * T else {
+            throw ClearError.inferenceFailed("spec_enhanced missing or wrong size")
+        }
+
+        for b in 0..<chunks {
+            let start = (firstChunk + b) * T
+            let valid = min(T, nFrames - start)
+            guard valid > 0 else { continue }
+            fromPlanar(enh, planeOffset: (b * 2) * nFreq * T, cols: nFreq, T: T,
+                       frames: valid, into: outRe + start * nFreq)
+            fromPlanar(enh, planeOffset: (b * 2 + 1) * nFreq * T, cols: nFreq, T: T,
+                       frames: valid, into: outIm + start * nFreq)
+        }
+    }
+
+    /// Frame-major source (`[frame][cols]`, starting at `srcFrame`) into one
+    /// `[cols][T]` plane of `dst` at `planeOffset`. A full window transposes
+    /// straight into place; a short tail window transposes into scratch and
+    /// then copies the columns it has, leaving the rest zero.
+    private static func toPlanar(_ src: [Float], srcFrame: Int, frames: Int, cols: Int,
+                                 into dst: inout [Float], planeOffset: Int, T: Int) {
+        src.withUnsafeBufferPointer { sp in
+            let s = sp.baseAddress! + srcFrame * cols
+            dst.withUnsafeMutableBufferPointer { dp in
+                let d = dp.baseAddress! + planeOffset
+                if frames == T {
+                    vDSP_mtrans(s, 1, d, 1, vDSP_Length(cols), vDSP_Length(frames))
+                } else {
+                    var scratch = [Float](repeating: 0, count: cols * frames)
+                    scratch.withUnsafeMutableBufferPointer { tp in
+                        vDSP_mtrans(s, 1, tp.baseAddress!, 1, vDSP_Length(cols), vDSP_Length(frames))
+                        vDSP_mmov(tp.baseAddress!, d, vDSP_Length(frames), vDSP_Length(cols),
+                                  vDSP_Length(frames), vDSP_Length(T))
+                    }
+                }
+            }
+        }
+    }
+
+    /// The inverse: one `[cols][T]` plane of `src` back to `frames` rows of a
+    /// frame-major destination.
+    private static func fromPlanar(_ src: [Float], planeOffset: Int, cols: Int, T: Int,
+                                   frames: Int, into dst: UnsafeMutablePointer<Float>) {
+        src.withUnsafeBufferPointer { sp in
+            let s = sp.baseAddress! + planeOffset
+            if frames == T {
+                vDSP_mtrans(s, 1, dst, 1, vDSP_Length(frames), vDSP_Length(cols))
+            } else {
+                var scratch = [Float](repeating: 0, count: cols * frames)
+                scratch.withUnsafeMutableBufferPointer { tp in
+                    vDSP_mmov(s, tp.baseAddress!, vDSP_Length(frames), vDSP_Length(cols),
+                              vDSP_Length(T), vDSP_Length(frames))
+                    vDSP_mtrans(tp.baseAddress!, 1, dst, 1, vDSP_Length(frames), vDSP_Length(cols))
+                }
+            }
+        }
+    }
+    #endif
 
     #if canImport(Accelerate)
     private static func interleave(_ re: [Float], _ im: [Float], srcOffset: Int, into dst: inout [Float], dstOffset: Int, count: Int) {

--- a/Sources/Clear/ModelLoading.swift
+++ b/Sources/Clear/ModelLoading.swift
@@ -22,10 +22,15 @@ public struct ModelAssets: Sendable {
     /// when the artifact is not a published variant (a custom export, or a
     /// wasm host that compiled the model itself).
     let variant: ModelVariant?
+    /// The repo revision the sessions' artifact was resolved from, reported on
+    /// `Result`. Nil for a local `modelPath`, explicit assets, or a wasm host
+    /// (nothing was downloaded, so no revision applies).
+    let revision: String?
 
-    init(sessions: [any InferenceSession], variant: ModelVariant? = nil) {
+    init(sessions: [any InferenceSession], variant: ModelVariant? = nil, revision: String? = nil) {
         self.sessions = sessions
         self.variant = variant
+        self.revision = revision
     }
 
     /// Bindings entry point: build from an already-constructed session (e.g. the
@@ -48,7 +53,7 @@ public struct ModelAssets: Sendable {
 
     /// Build from a resolved model directory: one session per worker over this
     /// platform's artifact.
-    static func clear(files: StoredModel, variant: ModelVariant,
+    static func clear(files: StoredModel, variant: ModelVariant, revision: String? = nil,
                       computeUnits: ComputeUnits, concurrency: Int) async throws -> ModelAssets {
         var sessions: [any InferenceSession] = []
         for _ in 0..<max(1, concurrency) {
@@ -56,7 +61,7 @@ public struct ModelAssets: Sendable {
                 model: variant.artifact,
                 computeUnits: computeUnits, sdk: ClearModel.sdkInfo))
         }
-        return ModelAssets(sessions: sessions, variant: variant)
+        return ModelAssets(sessions: sessions, variant: variant, revision: revision)
     }
 }
 

--- a/Sources/Clear/ModelLoading.swift
+++ b/Sources/Clear/ModelLoading.swift
@@ -43,7 +43,7 @@ public struct ModelAssets: Sendable {
     /// Sessions over an artifact already on disk. The variant is read off the
     /// file name, so a pre-downloaded artifact still identifies itself on
     /// `Result`.
-    init(modelPath: String, computeUnits: ComputeUnits = .cpuOnly, concurrency: Int = 1) throws {
+    init(modelPath: String, computeUnits: ComputeUnits = .all, concurrency: Int = 1) throws {
         self.init(
             sessions: try (0..<max(1, concurrency)).map { _ in
                 try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)

--- a/Sources/Clear/ModelLoading.swift
+++ b/Sources/Clear/ModelLoading.swift
@@ -43,12 +43,14 @@ public struct ModelAssets: Sendable {
     /// Sessions over an artifact already on disk. The variant is read off the
     /// file name, so a pre-downloaded artifact still identifies itself on
     /// `Result`.
-    init(modelPath: String, computeUnits: ComputeUnits = .all, concurrency: Int = 1) throws {
+    init(modelPath: String, revision: String? = nil,
+         computeUnits: ComputeUnits = .all, concurrency: Int = 1) throws {
         self.init(
             sessions: try (0..<max(1, concurrency)).map { _ in
                 try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)
             },
-            variant: ModelVariant.inferred(fromPath: modelPath))
+            variant: ModelVariant.inferred(fromPath: modelPath),
+            revision: revision)
     }
 
     /// Build from a resolved model directory: one session per worker over this

--- a/Sources/Clear/Streaming.swift
+++ b/Sources/Clear/Streaming.swift
@@ -191,7 +191,7 @@ extension Clear {
                       durationSec: Double(totalFrames) / sampleRate,
                       processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
                       measuredTruePeakDBFS: truePeakMeter?.dBFS,
-                      modelVariant: assets.variant)
+                      modelVariant: assets.variant, modelRevision: assets.revision)
     }
 }
 #endif

--- a/Sources/Clear/Variant.swift
+++ b/Sources/Clear/Variant.swift
@@ -57,8 +57,13 @@ public enum ModelVariant: String, Sendable, Equatable, CaseIterable, Identifiabl
     /// This variant's slice of the model repo: the same repo and pinned
     /// revision as the catalog entry, but only this variant's files, so
     /// choosing one variant never downloads the other.
-    public var distribution: ModelDistribution {
-        ModelDistribution(repo: ClearModel.repo, revision: ClearModel.revision, files: files)
+    public var distribution: ModelDistribution { distribution(revision: ClearModel.revision) }
+
+    /// The same slice pinned to an explicit repo `revision` (a tag like
+    /// `v0.2.0`, a branch, or a commit hash) instead of the SDK's pinned one.
+    /// Each revision caches separately, so switching never clobbers another.
+    public func distribution(revision: String) -> ModelDistribution {
+        ModelDistribution(repo: ClearModel.repo, revision: revision, files: files)
     }
 
     /// The variant an artifact path belongs to, by its file name

--- a/Sources/ModelCatalog/LoadedModel.swift
+++ b/Sources/ModelCatalog/LoadedModel.swift
@@ -36,6 +36,28 @@ import PlatformSupport
 /// downloading into it or into the managed cache) and builds the runtime once,
 /// sharing that single load with every concurrent caller. A failed load is not
 /// cached, so a later call retries.
+/// Which stage a model load is in. `downloading` runs to completion before
+/// `preparing` starts, and the fraction resets at the transition.
+public enum ModelLoadPhase: Sendable, Equatable {
+    /// Fetching (or verifying) the model files; fraction is bytes-based.
+    /// Reports 1 immediately when everything is already cached.
+    case downloading
+    /// Building the runtime from the resolved files. Coarse: most backends
+    /// report only 0 and 1 (Core ML compilation exposes no progress).
+    case preparing
+}
+
+/// A phase-aware model load report: which ``ModelLoadPhase`` and how far into
+/// it (`0...1`).
+public struct ModelLoadProgress: Sendable, Equatable {
+    public let phase: ModelLoadPhase
+    public let fraction: Double
+    public init(phase: ModelLoadPhase, fraction: Double) {
+        self.phase = phase
+        self.fraction = fraction
+    }
+}
+
 public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
     private let loader: LazyLoader<Runtime>
     private let availability: @Sendable () -> Bool
@@ -72,12 +94,38 @@ public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
         cacheRoot: String? = nil,
         build: @escaping @Sendable (StoredModel) async throws -> Runtime
     ) {
+        // The loader's Double carries both phases: [0, 0.5) is the download
+        // fraction (halved), [0.5, 1] is preparing/build. `download` and `load`
+        // decode it back, so the Double API keeps its old meaning.
         loader = LazyLoader { progress in
             let files = try await distribution.resolve(
-                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction) }
+                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction * 0.5) }
+            progress(0.5)
             return try await build(files)
         }
         availability = { distribution.isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot) }
+    }
+
+    /// Load from a distribution that is itself resolved asynchronously (a
+    /// ranged ``RevisionRequirement``, where the concrete revision comes from
+    /// the Hub's tags at load time). `resolve` runs once, at the front of the
+    /// shared load; `isAvailable` must answer offline-availability without it
+    /// (typically: any cached revision satisfies the requirement).
+    public init(
+        resolve: @escaping @Sendable () async throws -> ModelDistribution,
+        isAvailable: @escaping @Sendable () -> Bool,
+        directory: String? = nil,
+        cacheRoot: String? = nil,
+        build: @escaping @Sendable (StoredModel, ModelDistribution) async throws -> Runtime
+    ) {
+        loader = LazyLoader { progress in
+            let distribution = try await resolve()
+            let files = try await distribution.resolve(
+                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction * 0.5) }
+            progress(0.5)
+            return try await build(files, distribution)
+        }
+        availability = isAvailable
     }
 
     /// Wrap a runtime the caller already has the inputs for (the cross-language
@@ -97,7 +145,19 @@ public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
     /// Reports progress `0...1`. Concurrent calls, and an implicit load from a
     /// first use, share one download.
     public func download(progress: @Sendable @escaping (Double) -> Void = { _ in }) async throws {
-        try await loader.run(progress: progress)
+        try await loader.run { progress(Self.decode($0).phase == .downloading ? Self.decode($0).fraction : 1) }
+    }
+
+    /// Like ``download(progress:)`` but phase-aware: reports the download
+    /// (byte-level fraction) and then the preparing phase (building the
+    /// runtime; on Apple the first launch's Core ML compile lands here).
+    public func load(progress: @Sendable @escaping (ModelLoadProgress) -> Void) async throws {
+        try await loader.run { progress(Self.decode($0)) }
+    }
+
+    private static func decode(_ v: Double) -> ModelLoadProgress {
+        v < 0.5 ? ModelLoadProgress(phase: .downloading, fraction: min(1, v * 2))
+                : ModelLoadProgress(phase: .preparing, fraction: min(1, (v - 0.5) * 2))
     }
 
     /// The runtime, loading it on first use.

--- a/Sources/ModelStore/FoundationBackend.swift
+++ b/Sources/ModelStore/FoundationBackend.swift
@@ -37,6 +37,19 @@ public struct FoundationTransport: ModelTransport {
         }
     }
 
+    public func tags(_ url: String) async throws -> [String] {
+        guard let u = URL(string: url) else { throw ModelStoreError.io("bad url: \(url)") }
+        let (data, resp) = try await URLSession.shared.data(for: URLRequest(url: u))
+        guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw ModelStoreError.io("refs \(url): HTTP \((resp as? HTTPURLResponse)?.statusCode ?? -1)")
+        }
+        struct Refs: Decodable {
+            struct Ref: Decodable { let name: String }
+            let tags: [Ref]?
+        }
+        return try JSONDecoder().decode(Refs.self, from: data).tags?.map(\.name) ?? []
+    }
+
     private struct TreeItem: Decodable {
         let type: String
         let path: String
@@ -117,6 +130,10 @@ public struct FoundationFileSystem: FileSystem {
     }
 
     public func remove(_ path: String) { try? FileManager.default.removeItem(atPath: path) }
+
+    public func listDirectory(_ path: String) -> [String] {
+        (try? FileManager.default.contentsOfDirectory(atPath: path)) ?? []
+    }
 
     public func defaultCacheRoot() -> String {
         if let cacheRoot { return cacheRoot }

--- a/Sources/ModelStore/ModelDistribution.swift
+++ b/Sources/ModelStore/ModelDistribution.swift
@@ -76,6 +76,36 @@ public struct ModelDistribution: Sendable, Equatable {
         return store.isDownloaded(spec(cacheDirectory))
     }
 
+    /// Directories of every downloaded version of this model's repo in the
+    /// managed cache (see ``ModelStore/downloadedModels(repo:)``): one path per
+    /// revision, its last component the revision itself.
+    public func installedModels(cacheRoot: String? = nil) -> [String] {
+        guard let store = try? ModelStore.platformDefault(cacheRoot: cacheRoot) else { return [] }
+        return store.downloadedModels(repo: repo)
+    }
+
+    /// This distribution re-pointed at the concrete revision a
+    /// ``RevisionRequirement`` resolves to (see
+    /// ``ModelStore/resolveRevision(_:repo:)`` for the network/cache/fallback
+    /// order). `exact` never touches the network.
+    public func resolving(_ requirement: RevisionRequirement, cacheRoot: String? = nil) async -> ModelDistribution {
+        if let revision = requirement.exactRevision {
+            return ModelDistribution(repo: repo, revision: revision, files: files)
+        }
+        guard let store = try? ModelStore.platformDefault(cacheRoot: cacheRoot) else { return self }
+        let revision = await store.resolveRevision(requirement, repo: repo)
+        return ModelDistribution(repo: repo, revision: revision, files: files)
+    }
+
+    /// The downloaded revisions of this repo satisfying `requirement` (offline;
+    /// the managed cache only). The best match is last-sorted by the
+    /// requirement's own ordering via ``RevisionRequirement/bestMatch(in:)``.
+    public func downloadedRevisions(satisfying requirement: RevisionRequirement,
+                                    cacheRoot: String? = nil) -> [String] {
+        guard let store = try? ModelStore.platformDefault(cacheRoot: cacheRoot) else { return [] }
+        return store.downloadedRevisions(repo: repo).filter { requirement.bestMatch(in: [$0]) != nil }
+    }
+
     /// Get the model for `cacheDirectory`, downloading it there on demand. Files
     /// you placed there yourself are adopted offline; our own cache is reused
     /// offline; otherwise the model is downloaded. `nil` uses the managed cache.

--- a/Sources/ModelStore/ModelStore.swift
+++ b/Sources/ModelStore/ModelStore.swift
@@ -142,6 +142,45 @@ public struct ModelStore: Sendable {
         return storedModel(for: model)
     }
 
+    /// Directories of every revision of `repo` present in the managed cache,
+    /// sorted by revision. Only completed downloads are listed (the store's
+    /// manifest marks completion); an interrupted download is not. The last
+    /// path component of each entry is the revision. Locations you populated
+    /// yourself (an explicit `cacheDirectory`) are outside the managed layout
+    /// and are not listed.
+    public func downloadedModels(repo: String) -> [String] {
+        let base = join(fs.defaultCacheRoot(), "desert-ant-models", repo)
+        return downloadedRevisions(repo: repo).map { join(base, $0) }
+    }
+
+    /// The revisions of `repo` with a completed download in the managed cache,
+    /// sorted. (`downloadedModels(repo:)` returns the same entries as paths.)
+    public func downloadedRevisions(repo: String) -> [String] {
+        let base = join(fs.defaultCacheRoot(), "desert-ant-models", repo)
+        return fs.listDirectory(base)
+            .filter { fs.exists(join(base, $0, Self.metadataDirectory, "manifest")) }
+            .sorted()
+    }
+
+    /// Resolve a ``RevisionRequirement`` to a concrete revision for `repo`.
+    /// `exact` needs nothing. A range asks the Hub for the repo's tags; when
+    /// that fails (offline, or a transport without a refs call), it falls back
+    /// to the newest *downloaded* revision in range, then to the range's `from`
+    /// - so a device that downloaded once keeps working offline, and a fresh
+    /// offline install still points at a valid revision to try.
+    public func resolveRevision(_ requirement: RevisionRequirement, repo: String) async -> String {
+        switch requirement {
+        case .exact(let revision):
+            return revision
+        case .from(let from):
+            if let tags = try? await transport.tags("\(endpoint)/api/models/\(repo)/refs"),
+               let best = requirement.bestMatch(in: tags) {
+                return best
+            }
+            return requirement.bestMatch(in: downloadedRevisions(repo: repo)) ?? from
+        }
+    }
+
     // MARK: internals
 
     /// Expand the requested files/folders against the repo tree.

--- a/Sources/ModelStore/RevisionRequirement.swift
+++ b/Sources/ModelStore/RevisionRequirement.swift
@@ -1,0 +1,72 @@
+// Which model revision a caller wants: a fixed ref, or a semver range over the
+// repo's published tags (SwiftPM-style `from:`, i.e. up to the next major).
+// Foundation-free like
+// the rest of the module's orchestration.
+
+/// A model revision requirement.
+///
+/// `exact` is any Hub ref used as-is: a tag, branch, or commit hash. Ranges
+/// select among the repo's published `v`-tags at resolve time: `from` (the
+/// same meaning as SwiftPM's `from:` - up to the next major) picks the highest
+/// tag `>= from` with the same major version (`v0.2.0` -> the newest `v0.x`,
+/// never `v1.0.0`), so a deployment tracks compatible model updates without
+/// chasing a branch. Resolution asks the Hub for tags; offline
+/// it falls back to the newest *downloaded* revision in range, then to `from`.
+public enum RevisionRequirement: Sendable, Equatable {
+    /// A fixed ref, used verbatim (tag, branch, or commit hash).
+    case exact(String)
+    /// The highest published tag greater than or equal to this one, sharing
+    /// its major version (SwiftPM's `from:` semantics). Must be a
+    /// semantic-version tag (`v0.2.0` or `0.2.0`).
+    case from(String)
+
+    /// The revision when it needs no resolution (`exact`), else nil.
+    public var exactRevision: String? {
+        if case .exact(let revision) = self { return revision }
+        return nil
+    }
+
+    /// The best `candidates` entry satisfying this requirement, or nil.
+    /// Non-semver candidates never satisfy a range; `exact` matches only
+    /// itself. Used both for Hub tags and for the offline cache fallback.
+    public func bestMatch(in candidates: [String]) -> String? {
+        switch self {
+        case .exact(let revision):
+            return candidates.contains(revision) ? revision : nil
+        case .from(let from):
+            guard let floor = SemanticVersion(tag: from) else { return nil }
+            return candidates
+                .compactMap { tag in SemanticVersion(tag: tag).map { (tag, $0) } }
+                .filter { $0.1 >= floor && $0.1.major == floor.major }
+                .max { $0.1 < $1.1 }?.0
+        }
+    }
+}
+
+/// A parsed `v`-tag: `v1.2.3`, `1.2.3`, or a shortened `v1.2`/`v1` (missing
+/// components are 0). Anything else - branches, commits, prerelease suffixes -
+/// does not parse and so never satisfies a ranged requirement.
+struct SemanticVersion: Comparable, Sendable {
+    let major: Int
+    let minor: Int
+    let patch: Int
+
+    init?(tag: String) {
+        let body = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+        let parts = body.split(separator: ".", omittingEmptySubsequences: false)
+        guard (1...3).contains(parts.count) else { return nil }
+        var numbers: [Int] = []
+        for part in parts {
+            guard !part.isEmpty, part.allSatisfy({ $0.isASCII && $0.isNumber }),
+                  let n = Int(part) else { return nil }
+            numbers.append(n)
+        }
+        major = numbers[0]
+        minor = numbers.count > 1 ? numbers[1] : 0
+        patch = numbers.count > 2 ? numbers[2] : 0
+    }
+
+    static func < (a: SemanticVersion, b: SemanticVersion) -> Bool {
+        (a.major, a.minor, a.patch) < (b.major, b.minor, b.patch)
+    }
+}

--- a/Sources/ModelStore/Transport.swift
+++ b/Sources/ModelStore/Transport.swift
@@ -24,7 +24,19 @@ public struct RemoteEntry: Sendable, Equatable {
 /// verification hashes; `download` streams a file, reporting cumulative bytes.
 public protocol ModelTransport: Sendable {
     func tree(_ url: String) async throws -> [RemoteEntry]
+    /// Tag names published for a repo (the Hub refs API). Only ranged
+    /// ``RevisionRequirement`` resolution calls this; backends without it
+    /// throw, and resolution falls back to the downloaded cache.
+    func tags(_ url: String) async throws -> [String]
     func download(_ url: String, to destinationPath: String, onBytes: @escaping @Sendable (Int64) -> Void) async throws
+}
+
+public extension ModelTransport {
+    /// Default for backends without a refs call (Android host bridge, wasm):
+    /// ranged resolution then relies on its cache fallback.
+    func tags(_ url: String) async throws -> [String] {
+        throw ModelStoreError.io("tag listing not supported by this transport")
+    }
 }
 
 /// Filesystem seam: the small set of operations the store needs. `move` must be
@@ -40,6 +52,15 @@ public protocol FileSystem: Sendable {
     func remove(_ path: String)                         // best-effort
     /// Default cache root when a model gives no `cacheDirectory`.
     func defaultCacheRoot() -> String
+    /// Names of the entries directly under `path` (not recursive). A missing
+    /// or unreadable directory is `[]`.
+    func listDirectory(_ path: String) -> [String]
+}
+
+public extension FileSystem {
+    /// Backends without directory enumeration (the wasm in-memory store) list
+    /// nothing rather than failing to conform.
+    func listDirectory(_ path: String) -> [String] { [] }
 }
 
 public enum ModelStoreError: Error, CustomStringConvertible {

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -216,6 +216,10 @@ struct ClearTests {
         _ = try await ModelFixture.files(ClearModel.self)
         // Availability is per instance (LoadedModel owns it), so ask one.
         #expect(Clear().isDownloaded())
+        // The managed cache lists the downloaded version, its last path
+        // component the revision the SDK is pinned to.
+        let models = Clear.models()
+        #expect(models.contains { $0.hasSuffix("/\(ClearModel.repo)/\(Clear.modelRevision)") })
     }
 
     /// The file-in/file-out path (Apple/Linux): decode any audio file, enhance,

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -157,7 +157,7 @@ struct ClearTests {
     /// once per process and every test here reuses it.
     private func enhancer() async throws -> Clear {
         let files = try await ModelFixture.files(ClearModel.self)
-        return try Clear(modelPath: files.path(ClearModel.artifact))
+        return try Clear(modelPath: files.path(ClearModel.artifact), revision: "1d8810f")
     }
 
     @Test func enhanceEndToEnd() async throws {
@@ -293,7 +293,7 @@ struct ClearTests {
     @Test func progressReportsModelLoad() async throws {
         _ = try await ModelFixture.files(ClearModel.self)   // cached; the load is local
         let log = ProgressLog()
-        _ = try await Clear().enhance(samples: tone(48_000), sampleRate: 48_000) { log.append($0) }
+        _ = try await enhancer().enhance(samples: tone(48_000), sampleRate: 48_000) { log.append($0) }
         #expect(log.all().first?.phase == .loadingModel)
     }
 }

--- a/Tests/ModelCatalogTests/ModelCatalogTests.swift
+++ b/Tests/ModelCatalogTests/ModelCatalogTests.swift
@@ -22,10 +22,13 @@ struct ModelCatalogTests {
         for model in catalog {
             #expect(model.id == model.id.lowercased() && !model.id.isEmpty)
             #expect(model.repo == "desert-ant-labs/\(model.id)")
-            // A v-tag, or `main` for a model whose first tag predates one of its
-            // platform artifacts (clear: the Hub tag has no LiteRT export yet).
-            #expect(model.revision.hasPrefix("v") || model.revision == "main",
-                    "\(model.id): revision must be a v-tag (or a documented `main` pin)")
+            // A v-tag; or, for a model whose latest tag lacks one of its
+            // platform artifacts, a documented pin of `main` itself or a full
+            // commit hash of it (immutable, unlike the branch - clear pins the
+            // commit carrying the ANE-shaped Core ML export until it is tagged).
+            let isCommitHash = model.revision.count == 40 && model.revision.allSatisfy(\.isHexDigit)
+            #expect(model.revision.hasPrefix("v") || model.revision == "main" || isCommitHash,
+                    "\(model.id): revision must be a v-tag (or a documented main/commit pin)")
             #expect(model.product.first?.isUppercase == true, "\(model.id): product is capitalized")
             #expect(!model.summary.isEmpty)
         }

--- a/Tests/ModelStoreTests/RevisionRequirementTests.swift
+++ b/Tests/ModelStoreTests/RevisionRequirementTests.swift
@@ -1,0 +1,46 @@
+// The semver selection behind ranged revision requirements: which published
+// tag (or cached revision) a requirement lands on, and what never qualifies.
+
+import Testing
+@testable import ModelStore
+
+struct RevisionRequirementTests {
+
+    /// `exact` matches only itself - it is a ref, not a version.
+    @Test func exactMatchesOnlyItself() {
+        let r = RevisionRequirement.exact("v0.2.0")
+        #expect(r.bestMatch(in: ["v0.1.0", "v0.2.0", "v0.3.0"]) == "v0.2.0")
+        #expect(r.bestMatch(in: ["v0.3.0"]) == nil)
+        #expect(r.exactRevision == "v0.2.0")
+    }
+
+    /// `from` picks the highest tag >= from within the same major (SwiftPM's
+    /// from: semantics): from v0.2.0, the newest v0.x - never v1.0.0, never an
+    /// older v0.1.
+    @Test func fromStaysWithinTheMajor() {
+        let r = RevisionRequirement.from("v0.2.0")
+        #expect(r.bestMatch(in: ["v0.1.0", "v0.2.0", "v0.2.1", "v0.10.0", "v1.0.0"]) == "v0.10.0")
+        #expect(r.bestMatch(in: ["v0.1.0", "v1.0.0"]) == nil)   // nothing in range
+        #expect(r.exactRevision == nil)
+    }
+
+    /// Numeric ordering, not lexicographic: v0.10.0 > v0.9.0.
+    @Test func ordersNumerically() {
+        let r = RevisionRequirement.from("v0.9.0")
+        #expect(r.bestMatch(in: ["v0.9.0", "v0.10.0"]) == "v0.10.0")
+    }
+
+    /// Branches, commits, and prerelease tags never satisfy a range; bare and
+    /// shortened version tags do (v1 == 1.0.0).
+    @Test func onlySemverTagsQualify() {
+        let r = RevisionRequirement.from("1.0.0")
+        #expect(r.bestMatch(in: ["main", "deadbeef", "v1.1.0-rc.1", "v1.1"]) == "v1.1")
+        #expect(SemanticVersion(tag: "main") == nil)
+        #expect(SemanticVersion(tag: "v1.2.3-beta") == nil)
+        #expect(SemanticVersion(tag: "v1") == SemanticVersion(tag: "1.0.0"))
+    }
+}
+
+extension SemanticVersion: Equatable {
+    static func == (a: SemanticVersion, b: SemanticVersion) -> Bool { !(a < b) && !(b < a) }
+}

--- a/mise-tasks/test/swift
+++ b/mise-tasks/test/swift
@@ -12,7 +12,10 @@ dal_start_echo_server 8199
 # Own scratch dir: the Xcode toolchain's artifacts are incompatible with the
 # swift.org toolchain the wasm tasks use, so they must never share one.
 if [ "$(uname)" = Darwin ]; then
-    swift test --scratch-path .build-host
+    # xcrun pins the Xcode toolchain even when a mise-managed swift is on PATH:
+    # older mise ignores the tools os=["linux"] filter above, and the swift.org
+    # toolchain cannot build against the Xcode SDK.
+    xcrun swift test --scratch-path .build-host
 else
     litert=$(dal_litert_dir)
     LD_LIBRARY_PATH="$litert${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \


### PR DESCRIPTION
Adds model-version control to Clear (with the plumbing shared so the
 other model SDKs can adopt it):

 - Pin a version: Clear(revision: .exact("v0.2.0")) — any
   tag/branch/commit, each revision cached separately. Plain-string
   revision: still works.
 - Track compatible updates: .from("v0.2.0") (SwiftPM semantics) resolves
   to the newest published v-tag within the same major at load time, via a
   new ModelTransport.tags seam against the Hub's refs API. Offline it
   falls back to the newest downloaded revision in range, so installed
   devices keep working without network.
 - Introspection: Clear.models() lists downloaded versions in the managed
   cache (manifest-gated, so interrupted downloads don't appear),
   Clear.isDownloaded(variant:revision:) checks one offline, and
   Result.modelRevision reports the concrete revision each run used.
 - Phase-aware load progress: clear.load(progress:) distinguishes
   downloading (bytes-based) from preparing (session build / first-launch
   Core ML compile), so the UI no longer stalls at 100% during compile.
   Existing download(progress:) semantics unchanged.

 New seams: ModelTransport.tags, FileSystem.listDirectory,
 LoadedModel(resolve:isAvailable:) — all defaulted so Android/wasm
 backends conform unchanged. Ranged-selection rules (only v-tags qualify;
 numeric ordering; never crosses a major) are pinned by
 RevisionRequirementTests.