### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,17 +298,51 @@ jobs:
             Vendor/litert
           key: swift-android-6.4.x-2026-07-17-a-ubuntu-22.04-api24-litert-2.1.6
 
+      # Gradle caches (wrapper, dependencies, configuration cache) survive runs.
+      - uses: gradle/actions/setup-gradle@v4
+
       # Cross-compile and package first, outside the emulator's lifetime, so a
       # long native build does not eat the emulator boot timeout.
       - run: mise run build:android
+
+      # Stage the JNI test harness now too, for the same reason. The emulator
+      # is x86_64, so skip the arm64 cross-compile CI would never run.
+      - run: mise run test:android --stage-only
+        env:
+          DAL_ANDROID_ABIS: x86_64
+
+      # A cold boot costs minutes; cache a booted-once AVD snapshot and resume
+      # from it on every later run.
+      - name: AVD cache
+        uses: actions/cache@v6
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-31-x86_64-default
+
+      - name: Create AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 31 # androidtest minSdk (ICU NFKC needs 31+)
+          arch: x86_64
+          target: default # AOSP image: smaller and faster than google_apis, nothing here needs Play Services
+          force-avd-creation: false
+          disable-animations: false
+          emulator-boot-timeout: 900
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          script: echo "Generated AVD snapshot for caching"
 
       - name: On-device tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 31 # androidtest minSdk (ICU NFKC needs 31+)
           arch: x86_64
-          target: google_apis
+          target: default
+          force-avd-creation: false
           disable-animations: true
           emulator-boot-timeout: 900
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot
-          script: mise run test:android
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save
+          script: mise run test:android --no-stage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,12 +301,26 @@ jobs:
       # Gradle caches (wrapper, dependencies, configuration cache) survive runs.
       - uses: gradle/actions/setup-gradle@v4
 
-      # Cross-compile and package first, outside the emulator's lifetime, so a
-      # long native build does not eat the emulator boot timeout.
-      - run: mise run build:android
+      # The Swift cross-compile scratch dir. Restoring it turns the six-way
+      # (models x ABIs) static-stdlib release build into an incremental one;
+      # the source hash keys an exact hit, and restore-keys accept a stale
+      # cache that SwiftPM then patches incrementally.
+      - name: Cache the Android Swift build
+        uses: actions/cache@v6
+        with:
+          path: .build-android
+          key: android-swift-build-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**') }}
+          restore-keys: android-swift-build-
 
-      # Stage the JNI test harness now too, for the same reason. The emulator
-      # is x86_64, so skip the arm64 cross-compile CI would never run.
+      # Cross-compile and package first, outside the emulator's lifetime, so a
+      # long native build does not eat the emulator boot timeout. The emulator
+      # is x86_64, so skip the arm64 cross-compiles CI would never run - that
+      # is half of the Swift build work. The release workflow builds both.
+      - run: mise run build:android
+        env:
+          DAL_ANDROID_ABIS: x86_64
+
+      # Stage the JNI test harness now too, for the same reason.
       - run: mise run test:android --stage-only
         env:
           DAL_ANDROID_ABIS: x86_64
@@ -337,6 +351,10 @@ jobs:
 
       - name: On-device tests
         uses: reactivecircus/android-emulator-runner@v2
+        env:
+          # If Gradle's preBuild re-runs build:android-natives, keep it on the
+          # one ABI this emulator can execute.
+          DAL_ANDROID_ABIS: x86_64
         with:
           api-level: 31 # androidtest minSdk (ICU NFKC needs 31+)
           arch: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,21 @@ jobs:
           key: models-${{ runner.os }}-${{ hashFiles('Sources/*/Catalog.swift') }}
           restore-keys: models-${{ runner.os }}-
 
+      # The iOS simulator build compiles swift-syntax (via JavaScriptKit's
+      # macro plugin) from source, which dominates the job. test:ios pins
+      # DerivedData and the SPM clones to .build/ when $CI is set, so this
+      # cache turns that into an incremental build. Package.resolved keys the
+      # dependency graph; restore-keys accept a stale cache, which xcodebuild
+      # then patches incrementally.
+      - name: Cache iOS DerivedData and SPM clones
+        uses: actions/cache@v6
+        with:
+          path: |
+            .build/ios-deriveddata
+            .build/ios-packages
+          key: ios-deriveddata-${{ runner.os }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: ios-deriveddata-${{ runner.os }}-
+
       - run: mise run build:swift
       - run: mise run test:swift
       - run: mise run test:ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,40 @@ jobs:
             ~/.config/swiftpm/swift-sdks
           key: swift-wasm-sdk-6.3.3
 
+      # The three Swift builds this job runs from scratch otherwise: the wasm
+      # test build (test:wasi) and the wasm release builds (build:wasm) share
+      # the default .build - which also holds the swift-syntax macro host build
+      # JavaScriptKit's BridgeJS plugin needs, minutes on its own - and
+      # build:node-native uses .build-host. The source hash keys an exact hit;
+      # restore-keys accept a stale cache SwiftPM then patches incrementally.
+      - name: Cache the Swift builds (wasm + native)
+        uses: actions/cache@v6
+        with:
+          path: |
+            .build
+            .build-host
+          key: js-swift-build-${{ runner.os }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**') }}
+          restore-keys: js-swift-build-${{ runner.os }}-
+
+      # test:browser fetches Chromium (~130 MB) through Playwright on every
+      # cold run; the lockfile pins the Playwright version, which decides the
+      # browser build it wants.
+      - name: Cache Playwright's Chromium
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+
+      # npm ci runs several times (workspace install, test:bundles' packed
+      # installs); a warm ~/.npm turns those into cache reads.
+      - name: Cache the npm store
+        uses: actions/cache@v6
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-
+
       # The node package suites download the pinned model revision too: into the
       # suite-local .model-cache (an explicit `directory`), and the managed store
       # for anything resolving by default. Cache both for the same reason as the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,16 +335,21 @@ jobs:
       # Gradle caches (wrapper, dependencies, configuration cache) survive runs.
       - uses: gradle/actions/setup-gradle@v4
 
-      # The Swift cross-compile scratch dir. Restoring it turns the six-way
-      # (models x ABIs) static-stdlib release build into an incremental one;
-      # the source hash keys an exact hit, and restore-keys accept a stale
-      # cache that SwiftPM then patches incrementally.
-      - name: Cache the Android Swift build
+      # The Swift cross-compile scratch dirs. Restoring them turns the
+      # static-stdlib release builds into incremental ones; the source hash
+      # keys an exact hit, and restore-keys accept a stale cache that SwiftPM
+      # then patches incrementally. Two dirs, one per toolchain: .build-android
+      # belongs to the 6.4.x snapshot (build:android-natives), .build-androidtest
+      # to the pinned release toolchain (test:android). Sharing one dir poisoned
+      # the restored state across toolchains (CHostBridge: stdlib.h not found).
+      - name: Cache the Android Swift builds
         uses: actions/cache@v6
         with:
-          path: .build-android
-          key: android-swift-build-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**') }}
-          restore-keys: android-swift-build-
+          path: |
+            .build-android
+            .build-androidtest
+          key: android-swift-build-v2-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**') }}
+          restore-keys: android-swift-build-v2-
 
       # Cross-compile and package first, outside the emulator's lifetime, so a
       # long native build does not eat the emulator boot timeout. The emulator

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ mise.local.toml
 .build/
 .build-host/
 .build-android/
+.build-androidtest/
 .swiftpm/
 Package.resolved
 Vendor/

--- a/docs/development.md
+++ b/docs/development.md
@@ -167,7 +167,8 @@ directory, because their artifacts are mutually incompatible:
 | Toolchain | Used by | Scratch |
 |---|---|---|
 | Xcode / the system toolchain | `test:swift`, `build:swift`, `build:node-native` | `.build-host` |
-| pinned swift.org release | `test:wasi`, `build:wasm`, `test:android` | `.build` (the js plugin requires the default) |
+| pinned swift.org release | `test:wasi`, `build:wasm` | `.build` (the js plugin requires the default) |
+| pinned swift.org release | `test:android` | `.build-androidtest` |
 | swift.org 6.4 snapshot | `build:android-natives` | `.build-android` |
 
 mise provisions the pinned toolchains, the JDK, Node, and wasm-opt. The Android

--- a/mise-tasks/build/android
+++ b/mise-tasks/build/android
@@ -46,7 +46,9 @@ for model in $models; do
         echo "error: the $model AAR duplicates a runtime that ai.desertant:core owns" >&2
         exit 1
     }
-    for abi in arm64-v8a x86_64; do
+    # The core AAR always carries both LiteRT ABIs (prebuilt, cheap); only the
+    # Swift cross-compile honors DAL_ANDROID_ABIS, so check what was built.
+    for abi in ${DAL_ANDROID_ABIS:-arm64-v8a x86_64}; do
         unzip -Z1 "$aar" | grep -qx "jni/$abi/lib${product}Android.so" \
             || { echo "error: the $model AAR is missing jni/$abi/lib${product}Android.so" >&2; exit 1; }
     done

--- a/mise-tasks/build/android-natives
+++ b/mise-tasks/build/android-natives
@@ -20,6 +20,18 @@ source "$MISE_PROJECT_ROOT/Tools/dal.sh"
 api="${DAL_ANDROID_API:-24}"
 export SWIFT_ANDROID_STATIC_BUILD=1
 
+# Which ABIs to build. Ships both by default; CI's emulator is x86_64 only, so
+# it sets DAL_ANDROID_ABIS=x86_64 to skip the arm64 half it would never run.
+# The release workflow leaves this unset and builds everything.
+abi_pairs=""
+for abi in ${DAL_ANDROID_ABIS:-arm64-v8a x86_64}; do
+    case "$abi" in
+        arm64-v8a) abi_pairs="$abi_pairs arm64-v8a:aarch64" ;;
+        x86_64) abi_pairs="$abi_pairs x86_64:x86_64" ;;
+        *) echo "error: unknown ABI '$abi' in DAL_ANDROID_ABIS" >&2; exit 1 ;;
+    esac
+done
+
 # Build against the official Swift Android SDK. Stable releases floor at API 28
 # (Bionic gained posix_spawn there), but the 6.4.x snapshots support API 23+, so
 # this keeps minSdk 24 on first-party tooling. The host toolchain and the SDK
@@ -118,7 +130,7 @@ for model in $(dal_select "${usage_model:-all}" kotlin); do
     product=$(dal_product "$model")
     jni_libs="packages/$model-kotlin/src/main/jniLibs"
 
-    for pair in arm64-v8a:aarch64 x86_64:x86_64; do
+    for pair in $abi_pairs; do
         abi=${pair%:*} arch=${pair#*:}
         echo "== $product $abi ($arch) =="
 

--- a/mise-tasks/build/wasm
+++ b/mise-tasks/build/wasm
@@ -22,6 +22,11 @@ sdk=$(dal_wasm_sdk)
 # can have a working wasm core before it ships a package (Clear does today), and
 # a *Web product that stops compiling should fail here rather than the first time
 # someone packages it.
+# Three phases rather than one loop: the Swift builds must run serially (the js
+# plugin needs the one default scratch path), but the wasm-opt passes are
+# independent single-threaded jobs of about a minute each, so they run in
+# parallel once every binary exists.
+built=""
 for model in $(dal_select "${usage_model:-all}"); do
     product=$(dal_product "$model")
     [ -d "Sources/$product/Web" ] || { echo "== $product has no wasm entry, skipping =="; continue; }
@@ -35,14 +40,27 @@ for model in $(dal_select "${usage_model:-all}"); do
     # which SwiftPM's plugin sandbox blocks on macOS without it.
     swift package -Xswiftc -Osize --swift-sdk "$sdk" --allow-writing-to-package-directory \
         js --product "${product}Web" -c release --output "$out"
+    built="$built $model"
+done
 
-    if command -v wasm-opt > /dev/null; then
+if command -v wasm-opt > /dev/null; then
+    pids=()
+    for model in $built; do
+        product=$(dal_product "$model")
+        out=.build/wasm-package/$product
         wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int \
             --enable-sign-ext --enable-reference-types --strip-debug --strip-producers \
-            "$out/${product}Web.wasm" -o "$out/${product}Web.wasm"
-    else
-        echo "warning: wasm-opt not found; shipping unoptimized wasm (~3x larger)" >&2
-    fi
+            "$out/${product}Web.wasm" -o "$out/${product}Web.wasm" &
+        pids+=($!)
+    done
+    for pid in ${pids[@]+"${pids[@]}"}; do wait "$pid"; done
+else
+    echo "warning: wasm-opt not found; shipping unoptimized wasm (~3x larger)" >&2
+fi
+
+for model in $built; do
+    product=$(dal_product "$model")
+    out=.build/wasm-package/$product
 
     # Models without an npm package are a compile check only; there is nowhere
     # to stage the artifact.

--- a/mise-tasks/test/android
+++ b/mise-tasks/test/android
@@ -16,7 +16,10 @@ source "$MISE_PROJECT_ROOT/Tools/dal.sh"
 # runs it on a device, then runs each model AAR's own instrumented suite.
 #
 # A pinned swift.org toolchain: the Android cross-compilation SDK only exists for
-# released Swift versions. Own scratch dir so toolchains never share one.
+# released Swift versions. Own scratch dir (.build-androidtest) so toolchains
+# never share one: build:android-natives owns .build-android with a 6.4.x
+# snapshot toolchain, and reusing its scratch state from this release toolchain
+# breaks the C targets' header search (stdlib.h not found).
 api="${DAL_ANDROID_API:-31}"
 ndk_version=r27d
 export SWIFT_ANDROID_STATIC_BUILD=1 # drops JavaScriptKit (host macros) from the graph
@@ -68,8 +71,11 @@ fi
 [ -n "$bundle" ] || { echo "error: the Swift Android SDK was not found after install" >&2; exit 1; }
 
 # The SDK needs an Android NDK (r27d+); install it into the bundle once and run
-# its setup script. Marker: a populated ndk-sysroot. Large one-time download.
-if ! find -L "$bundle/swift-android/ndk-sysroot" -name libc++_shared.so 2> /dev/null | grep -q .; then
+# its setup script. Marker: a populated ndk-sysroot whose symlinked headers and
+# libraries both resolve (a restored cache can leave dangling links behind).
+# Large one-time download.
+if ! [ -e "$bundle/swift-android/ndk-sysroot/usr/include/stdlib.h" ] \
+    || ! find -L "$bundle/swift-android/ndk-sysroot" -name libc++_shared.so 2> /dev/null | grep -q .; then
     echo "Installing the Android NDK $ndk_version and configuring the SDK (one-time, large download)..."
     (
         cd "$bundle/swift-android"
@@ -92,11 +98,11 @@ for abi in $abis; do
         *) echo "error: unknown ABI '$abi' in DAL_ANDROID_ABIS" >&2; exit 1 ;;
     esac
     resources="$bundle/swift-android/swift-resources/usr/lib/swift_static-$arch"
-    swift build --scratch-path .build-android -c release --product CoreAndroidTests \
+    swift build --scratch-path .build-androidtest -c release --product CoreAndroidTests \
         --swift-sdk "$arch-unknown-linux-android$api" \
         -Xswiftc -static-stdlib -Xswiftc -resource-dir -Xswiftc "$resources"
     mkdir -p "$jni/$abi"
-    cp ".build-android/$arch-unknown-linux-android$api/release/libCoreAndroidTests.so" "$jni/$abi/"
+    cp ".build-androidtest/$arch-unknown-linux-android$api/release/libCoreAndroidTests.so" "$jni/$abi/"
     cxx=$(find -L "$bundle/swift-android/ndk-sysroot/usr/lib" -path "*$arch*" -name libc++_shared.so 2> /dev/null | head -1)
     [ -z "$cxx" ] || cp "$cxx" "$jni/$abi/"
 done

--- a/mise-tasks/test/android
+++ b/mise-tasks/test/android
@@ -5,6 +5,8 @@
 #MISE tools={swift="6.3.3", java="temurin-21"}
 #USAGE arg "<model>" help="Also run this model AAR's instrumented tests, or 'all'" default="all"
 #USAGE flag "--core-only" help="Only run the core host-bridge harness, no model AARs"
+#USAGE flag "--stage-only" help="Only cross-compile and stage the JNI harness, no device needed"
+#USAGE flag "--no-stage" help="Skip staging; run against jniLibs a prior --stage-only produced"
 source "$MISE_PROJECT_ROOT/Tools/dal.sh"
 
 # Android is the one platform `swift test` cannot cover: there the JSON, Regex,
@@ -19,15 +21,29 @@ api="${DAL_ANDROID_API:-31}"
 ndk_version=r27d
 export SWIFT_ANDROID_STATIC_BUILD=1 # drops JavaScriptKit (host macros) from the graph
 
-adb="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}/platform-tools/adb"
-[ -x "$adb" ] || adb=adb
-"$adb" devices 2> /dev/null | sed 1d | grep -qw device || {
-    echo "error: no Android device or emulator is connected." >&2
-    echo "       Start one (Android Studio, or 'emulator -avd <name>'); CI uses" >&2
-    echo "       reactivecircus/android-emulator-runner." >&2
-    exit 1
-}
+# Which ABIs to stage. Devices are arm64, emulators x86_64; CI sets
+# DAL_ANDROID_ABIS=x86_64 to skip the cross-compile it will never run.
+abis="${DAL_ANDROID_ABIS:-arm64-v8a x86_64}"
 
+if [ -z "${usage_stage_only:-}" ]; then
+    adb="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}/platform-tools/adb"
+    [ -x "$adb" ] || adb=adb
+    "$adb" devices 2> /dev/null | sed 1d | grep -qw device || {
+        echo "error: no Android device or emulator is connected." >&2
+        echo "       Start one (Android Studio, or 'emulator -avd <name>'); CI uses" >&2
+        echo "       reactivecircus/android-emulator-runner." >&2
+        exit 1
+    }
+fi
+
+jni=androidtest/src/main/jniLibs
+if [ -n "${usage_no_stage:-}" ]; then
+    find "$jni" -name libCoreAndroidTests.so 2> /dev/null | grep -q . || {
+        echo "error: --no-stage, but nothing is staged in $jni. Run" >&2
+        echo "       'mise run test:android --stage-only' first." >&2
+        exit 1
+    }
+else
 # Match the Android SDK bundle to the toolchain version, installing from the
 # downloaded file so no per-version checksum has to be pinned here.
 swift_version=$(dal_swift_version)
@@ -65,13 +81,16 @@ if ! find -L "$bundle/swift-android/ndk-sysroot" -name libc++_shared.so 2> /dev/
     )
 fi
 
-# Cross-compile the JNI harness for both ABIs and stage it (plus the NDK's
+# Cross-compile the JNI harness per ABI and stage it (plus the NDK's
 # libc++_shared.so) into the Gradle module's jniLibs. A static stdlib bundles the
 # Swift runtime into the .so, matching how a shipping Android artifact looks.
-jni=androidtest/src/main/jniLibs
 rm -rf "$jni"
-for pair in arm64-v8a:aarch64 x86_64:x86_64; do
-    abi=${pair%%:*} arch=${pair##*:}
+for abi in $abis; do
+    case "$abi" in
+        arm64-v8a) arch=aarch64 ;;
+        x86_64) arch=x86_64 ;;
+        *) echo "error: unknown ABI '$abi' in DAL_ANDROID_ABIS" >&2; exit 1 ;;
+    esac
     resources="$bundle/swift-android/swift-resources/usr/lib/swift_static-$arch"
     swift build --scratch-path .build-android -c release --product CoreAndroidTests \
         --swift-sdk "$arch-unknown-linux-android$api" \
@@ -81,13 +100,19 @@ for pair in arm64-v8a:aarch64 x86_64:x86_64; do
     cxx=$(find -L "$bundle/swift-android/ndk-sysroot/usr/lib" -path "*$arch*" -name libc++_shared.so 2> /dev/null | head -1)
     [ -z "$cxx" ] || cp "$cxx" "$jni/$abi/"
 done
+fi # end of staging
+
+[ -n "${usage_stage_only:-}" ] && exit 0
 
 ./gradlew --no-daemon -p androidtest connectedAndroidTest
 
-# Each model AAR's own instrumented suite, on the same booted device. Gradle
-# builds the model natives first (preBuild -> build:android-natives), so run
+# Each model AAR's own instrumented suite, on the same booted device, in one
+# Gradle invocation so the JVM/configuration cost is paid once. Gradle builds
+# the model natives first (preBuild -> build:android-natives), so run
 # `mise run build:android` before this if you want the two costs separated.
 [ -n "${usage_core_only:-}" ] && exit 0
+tasks=()
 for model in $(dal_select "${usage_model:-all}" kotlin); do
-    ./gradlew --no-daemon ":$model:connectedDebugAndroidTest"
+    tasks+=(":$model:connectedDebugAndroidTest")
 done
+[ ${#tasks[@]} -eq 0 ] || ./gradlew --no-daemon "${tasks[@]}"

--- a/mise-tasks/test/ios
+++ b/mise-tasks/test/ios
@@ -9,7 +9,21 @@ source "$MISE_PROJECT_ROOT/Tools/dal.sh"
 # Newest available iPhone simulator.
 device=$(xcrun simctl list devices available | grep -oE 'iPhone [0-9]+( Pro)?( Max)?' | tail -1)
 echo "Using simulator: ${device:?no iPhone simulator is available}"
+
+# On CI, pin DerivedData and the SPM clone dir to repo-local paths so
+# actions/cache can persist them across runs; locally, leave Xcode's defaults
+# (and your existing DerivedData) untouched.
+ci_flags=()
+if [[ -n "${CI:-}" ]]; then
+    ci_flags=(
+        -derivedDataPath .build/ios-deriveddata
+        -clonedSourcePackagesDirPath .build/ios-packages
+        -skipPackageUpdates
+    )
+fi
+
 xcodebuild test \
     -scheme DesertAnt-Package \
     -destination "platform=iOS Simulator,name=$device" \
-    -skipMacroValidation
+    -skipMacroValidation \
+    ${ci_flags[@]+"${ci_flags[@]}"}

--- a/mise.toml
+++ b/mise.toml
@@ -33,7 +33,8 @@
 # wasm and Android tasks pin a swift.org toolchain, because they need its clang
 # and a matching cross-compilation SDK, which only exist for released versions.
 # Each toolchain gets its own SwiftPM scratch directory (.build-host,
-# .build-android, .build for wasm) so their artifacts never collide.
+# .build-android for the snapshot natives, .build-androidtest for the on-device
+# harness, .build for wasm) so their artifacts never collide.
 
 [env]
 # Non-empty also vendors the LiteRT GPU accelerator sibling on Linux.


### PR DESCRIPTION
test:ios rebuilt everything - including swift-syntax, pulled in by JavaScriptKit's macro plugin - from scratch on every CI run, which dominated the job's ~5 minutes. When $CI is set, the task now pins DerivedData and the SPM clone dir to repo-local .build/ paths and skips package update checks, and the apple job caches those paths keyed on the dependency graph. Warm runs get an incremental build.

Locally nothing changes: without $CI the task keeps Xcode's default DerivedData location untouched. The empty-array expansion is guarded because macOS ships bash 3.2 and dal.sh sets -u.