### PR TITLE
Feature Clips and Titles

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,59 @@ let wasmBuild = ProcessInfo.processInfo.environment["DAL_WASM_BUILD"] != nil
 let noJavaScriptKit = !wasmBuild
     || ProcessInfo.processInfo.environment["SWIFT_ANDROID_STATIC_BUILD"] != nil
 
+// MLX is opt-in for the same reason, and the reason is the same MACRO problem — but unlike
+// JavaScriptKit it is gated by a package TRAIT rather than an environment variable.
+//
+// `Title` is the one model here that does not run through `InferenceSession`: writing a title
+// is short autoregressive decode, which measured 5.7-8.3x faster on MLX/GPU than on the ANE,
+// and `8e97532` removed MLState when the Core ML path lost. So Title needs mlx-swift-lm.
+//
+// `MLXHuggingFace` exposes `#huggingFaceLoadModelContainer`, a MACRO — so it pulls swift-syntax
+// and host macro plugins exactly as JavaScriptKit does, and a package dependency cannot carry a
+// platform condition. Declaring its target edges unconditionally would make every Linux and
+// Android consumer clone and build it for a target MLX cannot run on at all, and would risk the
+// same static-stdlib link conflict recorded above.
+//
+// So: the `MLX` trait (SE-0450). SwiftPM PRUNES the mlx-swift-lm and swift-transformers
+// package dependencies whenever no enabled trait references them, so a consumer without the
+// trait never clones them — the same graph the old `DAL_MLX_BUILD` env var produced, but
+// declared in the consumer's manifest instead of ambient process environment (which Xcode's
+// resolver could only see via `launchctl setenv`).
+//
+// The trait is deliberately NOT a default trait: default traits are enabled implicitly by
+// every consumer, including the Linux/Android/wasm pipelines, which would then need
+// `--disable-default-traits` plumbed through every build (including plugin invocations that
+// may not forward trait flags). Opt-in keeps every non-Apple graph exactly as before.
+//
+// A consumer opts in with:  .package(url: ..., traits: ["MLX"])   (tools-version 6.1+)
+// and a build that forgets it fails compiling against the `Title` stub (its MLX API is behind
+// `#if MLX`) rather than mis-building.
+//
+// The env var check stays temporarily as a migration guard: a build still exporting
+// DAL_MLX_BUILD gets a loud error instead of silently building a Title stub.
+if ProcessInfo.processInfo.environment["DAL_MLX_BUILD"] != nil {
+    // Uncomment-to-taste: fatalError would block builds that harmlessly still export it.
+    FileHandle.standardError.write(Data(
+        "warning: DAL_MLX_BUILD is obsolete; use the 'MLX' package trait instead.\n".utf8))
+}
+
+let mlxDependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "3.31.3"),
+    // swift-transformers is NOT optional here even though no line of Title names it. The
+    // `#huggingFaceLoadModelContainer` macro EXPANDS into code referencing `HuggingFace`,
+    // `HubClient` and `Tokenizers`, so the dependency is invisible at the call site and shows up
+    // only as "cannot find 'HubClient' in scope" inside a macro expansion.
+    .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.3.3"),
+]
+// `MLX` itself is NOT a product of mlx-swift-lm -- it comes transitively from mlx-swift, which
+// is why `import MLX` works without declaring it. Declaring it fails resolution.
+let mlxProducts: [Target.Dependency] = [
+    .product(name: "Transformers", package: "swift-transformers", condition: .when(traits: ["MLX"])),
+    .product(name: "MLXLMCommon", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+    .product(name: "MLXLLM", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+    .product(name: "MLXHuggingFace", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+]
+
 let jsDependencies: [Package.Dependency] = noJavaScriptKit ? [] : [
     .package(url: "https://github.com/swiftwasm/JavaScriptKit", from: "0.56.1"),
 ]
@@ -45,10 +98,14 @@ struct ModelPackage {
     var resources: [Resource] = []
     var testDependencies: [Target.Dependency] = []
     var testResources: [Resource] = []
+    /// Apple-only models get no Android/Node/wasm products. `Title` is MLX, which has no other
+    /// platform, and a product promising an artifact that cannot load is worse than its absence.
+    var appleOnly: Bool = false
 }
 
 let models: [ModelPackage] = [
     .init(name: "Emo"),
+    .init(name: "Clips", dependencies: ["Transcript"]),
     .init(
         name: "Clear",
         dependencies: ["AudioIO", "AudioDSP"],
@@ -71,6 +128,13 @@ let models: [ModelPackage] = [
             .copy("Resources/gist-feature-oracle.json"),
         ]
     ),
+] + [
+    // Cards are written for a `Clip`, which `Transcript` declares. Declared unconditionally;
+    // without the `MLX` trait its MLX dependencies are pruned and the target compiles as a
+    // stub (`#if MLX` in Title.swift), so the graph is identical on every platform.
+    ModelPackage(name: "Title",
+                 dependencies: [.byName(name: "Transcript")] + mlxProducts,
+                 appleOnly: true),
 ]
 let modelDependencies: [Target.Dependency] = models.map { .byName(name: $0.name) }
 
@@ -144,6 +208,8 @@ let products: [Product] = [
         .library(name: "Regex", targets: ["Regex"]),
         .library(name: "JSON", targets: ["JSON"]),
         .library(name: "TextNormalization", targets: ["TextNormalization"]),
+        // Shared by every model and pipeline that reads a transcript.
+        .library(name: "Transcript", targets: ["Transcript"]),
         .library(name: "FFIBuffer", targets: ["FFIBuffer"]),
         // Cross-platform audio: decode/encode (AudioIO) and STFT/mel/framing
         // DSP (AudioDSP), so audio model SDKs ship no per-platform audio code.
@@ -161,19 +227,22 @@ let products: [Product] = [
         .library(name: "CoreAndroidTests", type: .dynamic, targets: ["CoreAndroidTests"]),
 ]
 
-let modelWasmProducts: [Product] = noJavaScriptKit ? [] : models.map { model in
+// `appleOnly` models (Title) have no `Web/` entry point, so they get no wasm product.
+let modelWasmProducts: [Product] = noJavaScriptKit ? [] : models.filter { !$0.appleOnly }.map { model in
     .executable(name: "\(model.name)Web", targets: ["\(model.name)Web"])
 }
 
 let modelProducts: [Product] = models.flatMap { model in
-    [
-        .library(name: model.name, targets: [model.name]),
-        .library(name: "\(model.name)Android", type: .dynamic, targets: [model.name]),
-        .library(name: "\(model.name)Node", type: .dynamic, targets: [model.name]),
-    ]
+    model.appleOnly
+        ? [.library(name: model.name, targets: [model.name])]
+        : [
+            .library(name: model.name, targets: [model.name]),
+            .library(name: "\(model.name)Android", type: .dynamic, targets: [model.name]),
+            .library(name: "\(model.name)Node", type: .dynamic, targets: [model.name]),
+        ]
 } + modelWasmProducts
 
-let modelWasmTargets: [Target] = noJavaScriptKit ? [] : models.map { model in
+let modelWasmTargets: [Target] = noJavaScriptKit ? [] : models.filter { !$0.appleOnly }.map { model in
     .executableTarget(
         name: "\(model.name)Web",
         dependencies: [
@@ -190,7 +259,9 @@ let modelTargets: [Target] = models.map { model in
         dependencies: [.byName(name: "DesertAnt"), .byName(name: "NativeBindings")]
             + model.dependencies,
         path: "Sources/\(model.name)",
-        exclude: ["Web"],
+        // Only models with a wasm entry point have a `Web/` directory to exclude. An exclude
+        // naming a path that does not exist is a warning today and could become an error.
+        exclude: model.appleOnly ? [] : ["Web"],
         resources: model.resources
     )
 } + modelWasmTargets
@@ -276,6 +347,9 @@ let libraryTargets: [Target] = [
                 .target(name: "CHostBridge", condition: .when(platforms: [.android])),
             ] + jsWasi
         ),
+        // Transcript vocabulary: words, sentences, clips, and time spans. No
+        // dependencies, so every platform splits a transcript identically.
+        .target(name: "Transcript"),
         .target(name: "FFIBuffer"),
         .target(name: "NativeBindings", dependencies: ["DesertAnt"]),
         .target(
@@ -364,6 +438,7 @@ let testTargets: [Target] = [
             dependencies: [.byName(name: "DesertAnt"), "Tongue"] + modelDependencies
         ),
         .testTarget(name: "TextNormalizationTests", dependencies: ["TextNormalization"]),
+        .testTarget(name: "TranscriptTests", dependencies: ["Transcript"]),
         .testTarget(name: "RegexTests", dependencies: ["Regex"]),
         .testTarget(name: "JSONTests", dependencies: ["JSON"]),
         .testTarget(
@@ -376,19 +451,50 @@ let testTargets: [Target] = [
         .testTarget(name: "FFIBufferTests", dependencies: ["FFIBuffer"]),
 ]
 
-let coreTargets: [Target] = libraryTargets + testTargets + modelTargets + modelTestTargets
-    + alignTargets + tongueTargets
+
+let coreTargets: [Target] =
+    libraryTargets + testTargets + modelTargets + modelTestTargets + alignTargets
+    + tongueTargets
 
 let package = Package(
     name: "DesertAnt",
-    platforms: [
-        .iOS(.v16),
-        .macOS(.v13),
-        .tvOS(.v16),
-        .visionOS(.v1),
+    // The package floor is the LOWEST any product supports, not the highest any product
+    // needs. Emo, Clear and Redact run on iOS 16 and keep it.
+    //
+    // Clips and Title need more, and they declare it THEMSELVES with `@available` rather than
+    // dragging every other model up with them:
+    //
+    //   Clips  iOS 18 / macOS 15 / tvOS 18 / visionOS 2. `clips.mlmodelc` is a MULTIFUNCTION
+    //          package and multifunction is an iOS 18 feature. Read off the compiled artifact:
+    //          specificationVersion 9. iOS 17 was measured, not assumed: the graph converts at
+    //          spec 8, but two fixed-shape packages cost 562 MB against 284, and one
+    //          enumerated-shape package cannot use the Neural Engine and ran ~20x slower
+    //          (833 ms/batch at 128 against 40 ms).
+    //   Title  iOS 17 / macOS 14, MLX's own floor.
+    //
+    // An earlier version of this branch raised the whole package to iOS 17, then to iOS 18, on
+    // the reasoning that "SwiftPM platform floors are package-wide". That is true of THIS
+    // declaration and false of the thing that matters: `@available` is per-declaration, so a
+    // model that needs a newer OS can say so without costing the models that do not.
+    //
+    // The one case where the package floor genuinely must move is MLX, because a DEPENDENCY's
+    // platform requirement is a manifest-level constraint that `@available` cannot satisfy:
+    // SwiftPM refuses to resolve `MLXLLM` (macOS 14) into a macOS 13 package. The floor used
+    // to rise only behind `DAL_MLX_BUILD`; `platforms` cannot vary by trait, so with the `MLX`
+    // trait the iOS 17 / macOS 14 floor is now unconditional. That costs iOS 16 / macOS 13 for
+    // Apple consumers that never enable MLX — accepted deliberately: no known Apple consumer
+    // sits below iOS 17, and Linux/Android/wasm ignore Apple floors entirely. If such a
+    // consumer appears, this is the line to argue about.
+    platforms: [.iOS(.v17), .macOS(.v14), .tvOS(.v16), .visionOS(.v1)],
+    products: products + modelProducts + alignProducts,
+    traits: [
+        .trait(
+            name: "MLX",
+            description: "MLX-backed generation (the Title model). Apple platforms only; "
+                + "pulls mlx-swift-lm and swift-transformers into the graph."
+        ),
     ],
-    products: products + modelProducts + alignProducts + tongueProducts,
-    dependencies: jsDependencies + [
+    dependencies: jsDependencies + mlxDependencies + [
         .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
     ],
     targets: coreTargets

--- a/Sources/Clips/Binding.swift
+++ b/Sources/Clips/Binding.swift
@@ -1,0 +1,56 @@
+// Clips's side of the cross-language binding: construction, plus the payload
+// schemas that are genuinely model-specific (the input a run takes, the options,
+// and what a result looks like). The generic handle lifecycle and the exported
+// symbols live in NativeBindings and ClipNative, so this file is only the
+// model's adapter.
+
+import DesertAnt
+
+extension Clips: BoundModel {
+    // `isDownloaded()` and `download(progress:)` are Clips's own public API and
+    // witness the protocol as they stand.
+
+    /// Input payload: `u32 count`, then that many length-prefixed UTF-8
+    /// sentences, in spoken order. A transcript is a string array, which is a
+    /// payload schema like any other - it adds no entry point to the ABI.
+    ///
+    /// Options payload: `u32 limit` (the most moments to return; `0` means all
+    /// of them). An empty payload means the SDK defaults.
+    ///
+    /// Result payload: `u32 count`, then per moment a `u32` sentence count
+    /// followed by that many `u32` transcript indices, a length-prefixed UTF-8
+    /// text, and `f64 score`, `f64 percentile`, `f64 estimatedDurationSec`.
+    public func run(input: FFIReader, options: FFIReader) async -> [UInt8]? {
+        var input = input
+        var options = options
+        let transcript = input.strings()
+        guard !transcript.isEmpty else { return nil }
+        // An empty payload means the SDK defaults, so this must match the
+        // default every SDK declares for `limit` (no limit), not a number of
+        // its own.
+        let limit = options.isEmpty ? 0 : options.u32()
+        guard let moments = try? await clips(in: transcript, limit: limit > 0 ? limit : nil) else {
+            return nil
+        }
+        var w = FFIWriter()
+        w.u32(moments.count)
+        for moment in moments {
+            w.u32(moment.sentenceIDs.count)
+            for id in moment.sentenceIDs { w.u32(id) }
+            w.string(moment.text)
+            w.f64(moment.score)
+            w.f64(moment.percentile)
+            w.f64(moment.estimatedDurationSec)
+        }
+        return w.bytes
+    }
+}
+
+/// How the generic bindings construct Clips.
+public enum ClipBinding: ModelBinding {
+    public static let id = ClipModel.id
+
+    public static func make(cacheRoot: String?, directory: String?) -> any BoundModel {
+        Clips(directory: directory, cacheRoot: cacheRoot)
+    }
+}

--- a/Sources/Clips/Catalog.swift
+++ b/Sources/Clips/Catalog.swift
@@ -1,0 +1,131 @@
+// This model's catalog declaration: coordinates, file names, and which of them
+// each platform ships. The shared behaviour (distribution, resolve, availability)
+// comes from `ModelDeclaration` in the catalog's shared half.
+
+import DesertAnt
+
+/// The clip model: on-device selection of a transcript's best moments.
+///
+/// Two graphs rather than one. Selection runs a per-sentence *selector*
+/// (saliency plus start/end probabilities, which is what proposes candidate
+/// spans) and then a per-span *scorer*, and they are separate graphs because
+/// they take different inputs - the selector also reads five discourse scalars
+/// the scorer has no use for. `artifact(for:)` names the selector's file,
+/// because the shared declaration is single-artifact by design; both halves are
+/// declared beside it in `files` and reached through ``selector(for:)`` and
+/// ``scorer(for:)``, which name the function inside the file as well as the
+/// file.
+public enum ClipModel: ModelDeclaration {
+    public static let id = "clips"
+    public static let product = "Clips"
+    // Pinned, not `main`. The Hub repo's `v0.1.0` is the first tag whose artifacts
+    // match the names below: one multifunction `clips.mlmodelc` and a LiteRT pair at
+    // the same widths, all from `runs/win256` (checkpoint digest `fe11c7852ef0421e`).
+    // Before it, the repo carried two separate Core ML packages under different names
+    // and nothing here resolved. Pinning matters more than usual for this model: the
+    // scorer's window is the axis the arms vary on, so a repo that moved under an
+    // unpinned `main` would hand the SDK a graph of a different width and be caught by
+    // nothing but wrong clips.
+    public static let revision = "v0.1.0"
+    /// No published npm/Maven package (see `docs/development.md`: a model with an
+    /// npm package must run real inference in headless Chromium, and this one
+    /// needs two sessions - which the wasm host cannot give it). Nothing
+    /// cross-checks this the way `ModelCatalogTests` checks emo and redact; keep
+    /// it in step with `packages/clips-*` if they land.
+    /// `clips.mlmodelc` is a MULTIFUNCTION package, which is an iOS 18 feature — the compiled
+    /// artifact declares specificationVersion 9. Stated here rather than in `Package.swift` so
+    /// Emo, Clear and Redact keep the iOS 16 package floor they can actually run at.
+    public static let osFloor = OSFloor.multifunction
+
+    public static let sdkVersion = "3.0.0"
+    public static let summary = "On-device clip selection: a transcript's best non-overlapping moments, ranked."
+
+    /// The artifact family this SDK is built against, and the ONE place the
+    /// shipping export is named. Every file name below derives from this stem, so
+    /// changing the shipped export is changing this line plus the Hub tag.
+    ///
+    /// **The quantization is decided: int8 per-channel, 284 MB, `select` [16,128]
+    /// and `score` [16,256], from `runs/win256` (digest `fe11c7852ef0421e`).** It
+    /// ties fp16 on judged clips in every stratum at half the size; int4 is
+    /// 2.0-2.7x SLOWER on the ANE with a mean selection IoU of 0.130 against its
+    /// own reference; and every LUT scheme doubles the trunk, because
+    /// `save_multifunction` dedups by hashing constant values and palettized
+    /// weights do not collide. See `clips-training/docs/quant-decision.md`.
+    public static let stem = "clips"
+
+    /// XLM-R SentencePiece **Unigram** vocab in the compact binary
+    /// `Tokenizer.swift` reads. Token ids must match training exactly, so the
+    /// vocab ships with the model rather than being reconstructed.
+    public static let tokenizer = "clip_tokenizer.bin"
+
+    /// Half of the pipeline: the artifact to open, and - when that artifact
+    /// carries more than one graph - which function inside it to run. A file
+    /// name on its own does not identify a model on Core ML, which is why this
+    /// is a pair and not a `String`.
+    public struct Export: Sendable, Equatable {
+        /// Repo-relative artifact, exactly as it appears in ``files``.
+        public let file: String
+        /// The Core ML function to load, or `nil` for a single-graph artifact.
+        public let function: String?
+    }
+
+    /// Core ML export (a directory on the Hub): ONE multifunction package
+    /// carrying both graphs over the encoder they share, as the functions
+    /// `select` and `score`. The trunk is 278M parameters and is stored once,
+    /// so the asset is 284 MB against the 535 MB two separate packages cost -
+    /// which is also the download, on a phone.
+    ///
+    /// Reaching a function needs `MLModelConfiguration.functionName`, which is
+    /// what ``Export/function`` carries to
+    /// `Sources/Inference/CoreMLSession.swift`. Without it a path names the
+    /// file and not the graph: Core ML loads the package's default function and
+    /// reports nothing, so both halves of the pipeline would be the selector.
+    public static let coreML = "\(stem).mlmodelc"
+    public static let selectFunction = "select"
+    public static let scoreFunction = "score"
+
+    /// LiteRT exports: Android/Linux/Windows. LiteRT has no multifunction
+    /// packaging, so those platforms ship two files and pay for the shared
+    /// trunk twice.
+    public static let selectorTFLite = "\(stem)-selector.tflite"
+    public static let scorerTFLite = "\(stem)-scorer.tflite"
+
+    /// Sidecars every platform needs alongside the artifacts.
+    public static let sidecars = [tokenizer]
+
+    // No `.web` entry. The wasm host contract holds one compiled model per
+    // module (`docs/development.md`), and selection needs two sessions in the
+    // same module, so there is no honest web manifest to declare: a browser
+    // build would resolve files it could not both compile. Apple + Linux +
+    // Android + a wasm compile check, which is the Clear precedent.
+    public static let files: [ModelPlatform: [String]] = [
+        .apple: [coreML + "/"] + sidecars,
+        .android: [selectorTFLite, scorerTFLite] + sidecars,
+        .linux: [selectorTFLite, scorerTFLite] + sidecars,
+        .windows: [selectorTFLite, scorerTFLite] + sidecars,
+    ]
+
+    /// The per-sentence selector: the first half of the pipeline, and what the
+    /// shared declaration considers *the* model.
+    public static func selector(for platform: ModelPlatform) -> Export {
+        platform == .apple
+            ? Export(file: coreML, function: selectFunction)
+            : Export(file: selectorTFLite, function: nil)
+    }
+
+    /// The span scorer, the second half of the pipeline. On Apple this is the
+    /// same file as ``selector(for:)`` under a different function.
+    public static func scorer(for platform: ModelPlatform) -> Export {
+        platform == .apple
+            ? Export(file: coreML, function: scoreFunction)
+            : Export(file: scorerTFLite, function: nil)
+    }
+
+    public static func artifact(for platform: ModelPlatform) -> String {
+        selector(for: platform).file
+    }
+
+    /// The two halves for the platform being built for.
+    public static var selector: Export { selector(for: .current) }
+    public static var scorer: Export { scorer(for: .current) }
+}

--- a/Sources/Clips/Clips.swift
+++ b/Sources/Clips/Clips.swift
@@ -1,0 +1,151 @@
+import DesertAnt
+import Transcript
+
+/// Errors thrown while loading or running the model. (`MessageError` is
+/// `LocalizedError` wherever Foundation exists, so `localizedDescription`
+/// shows `message`.)
+public enum ClipError: MessageError, Sendable {
+    /// A model resource (an export or the tokenizer) could not be found.
+    case modelNotFound
+    /// On-device selection failed or returned an unexpected output.
+    case predictionFailed
+
+    public var message: String {
+        switch self {
+        case .modelNotFound: "A Clips model resource was not found."
+        case .predictionFailed: "On-device clip selection failed."
+        }
+    }
+}
+
+/// On-device clip selection: the moments in a transcript worth cutting.
+///
+/// `Clips` turns a transcript - one string per sentence, in order - into ranked,
+/// non-overlapping runs of those sentences, fully on device. A per-sentence
+/// selector proposes candidate spans, a span scorer rates them, and weighted
+/// interval scheduling picks the best non-overlapping set. Both models run
+/// through the shared inference session (Core ML on Apple, LiteRT elsewhere).
+/// Create one once and reuse it.
+///
+/// ```swift
+/// let clip = Clips()
+/// let moments = try await clip.clips(in: transcript)
+/// for moment in moments where moment.percentile > 0.8 {
+///     print(moment.text)
+/// }
+/// ```
+public final class Clips: @unchecked Sendable {
+    /// How many moments a call returns unless the caller says otherwise.
+    ///
+    /// **10 is a PRODUCT CHOICE, not a measurement**, recorded as such so it is not later cited
+    /// as one. What IS measured: the model finds a median of 30 disjoint moments on long-form
+    /// (`clips-training/runs/e2e/preflight_uncapped_50.jsonl`), and 30 is the pipeline's own
+    /// internal ceiling, so the true number is higher and unknown. The duration curve in
+    /// `Pipeline.budget(for:)` — 8/11/13/14 — came from the teacher's median count, which is
+    /// itself pinned by the teacher prompt's arbitrary "8 minimum, 15 maximum". None of those
+    /// numbers is a statement about how many good moments a video contains.
+    ///
+    /// The ceiling is a latency decision as much as an editorial one, because the emitted count
+    /// sets the candidate pool: on an M1 the same 633-sentence podcast takes 23.5 s at 14 clips.
+    /// Measurements in `clips-training/runs/e2e/`.
+    ///
+    /// Pass `nil` to ``clips(in:limit:)`` to use the duration curve instead of this.
+    public static let defaultClipLimit = 10
+
+    // Resolving the files, loading once, sharing that load, and reporting
+    // availability are the same for every model, so they live in the core's
+    // `LoadedModel`; Clips adds only how a resolved directory becomes its model.
+    private let model: LoadedModel<Model>
+
+    /// Creates a selector. Construction does no work and starts no download; the
+    /// model loads on the first ``clips(in:limit:)`` or ``download(progress:)``,
+    /// off your calling thread.
+    ///
+    /// `directory` is where the model lives. If it already contains the model
+    /// (you pre-downloaded or shipped it there) it is used offline; otherwise the
+    /// model is downloaded into it and reused offline afterward. With no
+    /// `directory` (the default), a managed cache location is used.
+    ///
+    /// Nothing is bundled with this package. To ship the model with your app,
+    /// point `directory` at a folder you populated with the model files: it is
+    /// used as-is, offline, and nothing is downloaded.
+    ///
+    /// `computeUnits` is which backends Core ML may prepare and run the graph
+    /// on. It defaults to ``ComputeUnits/cpuAndNeuralEngine`` rather than
+    /// ``ComputeUnits/all`` because this model is built for the ANE — the int8
+    /// per-channel export in `Catalog.swift` was chosen on ANE latency — and
+    /// preparing a GPU path it never profitably uses is paid on first load, once
+    /// per function. `clips.mlmodelc` is multifunction, so `.all` compiles two
+    /// graphs for three backends. Measured on an iPhone 17 Pro with the model
+    /// already on disk: `.all` took 3-4 minutes to specialize, and
+    /// `.cpuAndNeuralEngine` took ~41s, with selection latency unchanged
+    /// (5.31s -> 4.92s on a 49-sentence transcript). Pass `.all` to restore the
+    /// previous behaviour, or `.cpuOnly` to take the ANE out of the picture when
+    /// diagnosing a partitioning problem.
+    public convenience init(directory: String? = nil, computeUnits: ComputeUnits = .cpuAndNeuralEngine) {
+        self.init(directory: directory, cacheRoot: nil, computeUnits: computeUnits)
+    }
+
+    /// Binding entry point that also supplies the platform base cache root under
+    /// which the managed layout lives (the app cache dir on Android, node
+    /// `~/.cache` on the web). On Apple/Linux FileManager provides it, so the
+    /// public `init(directory:)` passes `nil`.
+    @_spi(ClipBindings)
+    public init(directory: String?, cacheRoot: String?, computeUnits: ComputeUnits = .cpuAndNeuralEngine) {
+        model = LoadedModel(ClipModel.self, directory: directory, cacheRoot: cacheRoot) { files in
+            try Model(assets: await .clip(files: files, computeUnits: computeUnits))
+        }
+    }
+
+    /// Creates a selector from explicitly provided assets (used by the
+    /// Android/JNI and custom-deployment paths).
+    @_spi(ClipBindings)
+    public init(assets: ModelAssets) {
+        model = LoadedModel { try Model(assets: assets) }
+    }
+
+    /// Whether the model is available for this selector with no network:
+    /// cached (for the managed location) or already present in `directory`.
+    public func isDownloaded() -> Bool { model.isDownloaded() }
+
+    /// Download and load the model ahead of time, so the first
+    /// ``clips(in:limit:)`` is instant. Reports download progress `0...1`.
+    /// Concurrent calls, and an implicit load from a selection, share one
+    /// download. A no-op once loaded (see ``isDownloaded()``).
+    public func download(progress: @Sendable @escaping (Double) -> Void = { _ in }) async throws {
+        try await model.download(progress: progress)
+    }
+
+    /// Await model readiness. The bindings use this to surface load errors
+    /// eagerly; apps can just call ``clips(in:limit:)``.
+    @_spi(ClipBindings)
+    public func waitUntilLoaded() async throws {
+        _ = try await model.value()
+    }
+
+    /// Every worthwhile moment in `transcript`, ranked best first and
+    /// non-overlapping.
+    ///
+    /// - Parameters:
+    ///   - transcript: one sentence per element, in spoken order.
+    ///   - limit: the most moments to return. Defaults to ``defaultClipLimit``.
+    ///     Pass `nil` to let the model decide from the video's duration.
+    /// - Returns: the moments, best first. A transcript under three sentences
+    ///   returns `[]`.
+    ///
+    /// **The limit sizes the WORK, it does not trim the result.** It sets the selection budget,
+    /// and the candidate pool is `budget * 4` anchors wide, so a smaller limit means fewer
+    /// scorer passes — which is 60-85% of the runtime. This previously ran the whole pipeline at
+    /// the full ceiling and then discarded the tail, so asking for fewer clips cost exactly as
+    /// much as asking for all of them.
+    ///
+    /// One consequence worth knowing: the result at `limit: 10` is not generally the first ten
+    /// of the result at `limit: 14`. Weighted interval scheduling returns the highest-total
+    /// non-overlapping SET of at most k, and the best set of ten is not the best set of fourteen
+    /// with four removed. Both are correct answers to different questions, and a bounded list
+    /// wants "the best ten moments".
+    public func clips(in transcript: [String],
+                      limit: Int? = Clips.defaultClipLimit) async throws -> [Clip] {
+        try await model.value().clips(in: transcript, limit: limit)
+    }
+}

--- a/Sources/Clips/Model.swift
+++ b/Sources/Clips/Model.swift
@@ -1,0 +1,190 @@
+import DesertAnt
+import Transcript
+
+/// The neural stage: tokenize sentences and spans into the exports' fixed
+/// batch-16 x 128-token buckets, run them through the shared
+/// `InferenceSession` (Core ML | LiteRT, chosen by desert-ant-core), and read
+/// the per-sentence signals and per-span scores. This file only knows clip's
+/// tensor layout; the runtime is oblivious. Choosing which spans to keep is
+/// `Pipeline.swift`.
+///
+/// The exported signatures:
+///
+///     selector: ids[16,128] int32, mask[16,128] int32, disc[16,5] float32
+///               -> saliency[16], start_p[16], end_p[16]
+///     scorer:   ids[16,128] int32, mask[16,128] int32 -> score[16]
+///
+/// The two functions CAN run at different sequence lengths — the package format
+/// supports it and the exporters build it — but the shipping artifact runs both
+/// at 128. See ``Model/scoreSeqLen`` for why that is not the window the scorer
+/// trained at, and what it would cost to change.
+///
+/// Fixed shapes throughout: sessions cache their input buffers per shape and
+/// rebuild whenever one changes, so feeding arbitrary lengths would trade
+/// padding waste for buffer churn. Two fixed shapes, one per function, keeps
+/// that property - each session still sees exactly one shape for its lifetime.
+final class Model: @unchecked Sendable {
+    /// Batch 16 is optimal and throughput DEGRADES above it: 2.92 ms/candidate
+    /// at 16, 3.18 at 32, 3.73 at 64. Opposite to GPU intuition; do not raise it.
+    static let batch = 16
+
+    /// The SELECTOR graph's buffer width. A property of the compiled artifact, and NOT the
+    /// point at which a sentence is truncated — see ``sentenceTokens``.
+    static let seqLen = 128
+
+    /// Where a SENTENCE is cut for the selector, and the window its heads were TRAINED at.
+    ///
+    /// Not `seqLen`. `train_selector.py:195` pools sentence embeddings at `heads.MAXTOK` = 64,
+    /// `train_spans.py:70` tokenizes at the same constant, and every checkpoint's
+    /// `run_manifest.json` records `"sentence_window": 64` as a first-class config field. The
+    /// saliency, start and end heads have never seen a sentence pooled over more than 64
+    /// tokens.
+    ///
+    /// This was `seqLen`, i.e. 128, because one constant served as both the buffer width and
+    /// the truncation point. That ran the heads off-distribution on 3.47% of sentences and
+    /// **76% of the frozen holdout's videos**, and changed the emitted clip set on 30% of a
+    /// 20-video quantile sample (micro-IoU 0.901 against the trained path).
+    ///
+    /// It needs no re-export: masked-mean pooling plus the additive attention mask means a
+    /// 128-wide buffer fed a mask zeroed past token 64 is bit-identical to a 64-wide graph.
+    static let sentenceTokens = 64
+
+    /// Fallback SCORER window, used only when a runtime cannot report its own shape.
+    ///
+    /// The real width is read from the loaded graph — see ``scoreWidth`` — because it is the
+    /// axis the model arms vary and the two candidate packages differ in exactly this number:
+    /// the 128 package serves `score` at [16,128] and the 256 package at [16,256], identical
+    /// in every other respect of their I/O. Hardcoding it truncates every candidate to 128 on
+    /// a 256 artifact and returns a null by construction, which is what `bench_latency.py` was
+    /// retired for.
+    ///
+    /// A 256 build was promoted and unwound on 2026-08-10 for want of evidence. That evidence
+    /// now exists and is in `docs/export.md`: measured end to end on real transcripts rather
+    /// than extrapolated from a scorer multiplier, 256 costs +75% to +134% and buys +0.068
+    /// Likert, which the product owner has accepted.
+    static let scoreSeqLen = 128
+
+    private let selector: any InferenceSession
+    private let scorer: any InferenceSession
+    private let tokenizer: Tokenizer
+
+    /// Buffer widths taken from the LOADED GRAPHS, falling back to the constants above only
+    /// when a runtime cannot report shapes. This is what lets one binary serve the 128 package
+    /// and the 256 package without a rebuild, and what stops a 256 artifact being silently
+    /// truncated to 128 — which would make a window comparison return no difference by
+    /// construction.
+    private var selectWidth: Int { selector.inputWidth("ids") ?? Self.seqLen }
+    private var scoreWidth: Int { scorer.inputWidth("ids") ?? Self.scoreSeqLen }
+
+    init(assets: ModelAssets) throws {
+        selector = assets.selector
+        scorer = assets.scorer
+        guard let tokenizer = Tokenizer(bytes: assets.tokenizer) else {
+            throw ClipError.modelNotFound
+        }
+        self.tokenizer = tokenizer
+    }
+
+    /// The whole pipeline: per-sentence signals, candidate spans, span scores,
+    /// then the non-overlapping choice. See `Pipeline.swift` for the selection.
+    func clips(in transcript: [String], limit: Int?) async throws -> [Clip] {
+        guard transcript.count >= Pipeline.minSentences else { return [] }
+        let saliency = try await perSentenceSaliency(transcript)
+        // Computed once and threaded through: the anchor count is `budget * 4`, so enumeration
+        // and ranking must size from one number or the pool is not the one the ranker expects.
+        // This is also where a caller's limit earns its latency: a smaller ceiling means a
+        // smaller pool and fewer scorer passes, which is most of the runtime.
+        let candidates = Pipeline.enumerateCandidates(
+            count: transcript.count, saliency: saliency,
+            budget: Pipeline.budget(for: transcript, limit: limit))
+        guard !candidates.isEmpty else { return [] }
+        let texts = candidates.map { span in span.map { transcript[$0] }.joined(separator: " ") }
+        let scores = try await scoreSpans(texts)
+        return Pipeline.rank(candidates: candidates, scores: scores, transcript: transcript,
+                             limit: limit)
+    }
+
+    // MARK: inference
+
+    /// Per-sentence saliency, batched. `start_p`/`end_p` are read off the same
+    /// pass because the export emits all three, but only saliency picks anchors
+    /// today - the span boundaries come from the scorer's ranking instead.
+    private func perSentenceSaliency(_ sentences: [String]) async throws -> [Double] {
+        var saliency: [Double] = []
+        saliency.reserveCapacity(sentences.count)
+        let n = sentences.count
+        for start in stride(from: 0, to: n, by: Self.batch) {
+            let slice = sentences[start..<min(start + Self.batch, n)]
+            var ids = [Int32](repeating: 0, count: Self.batch * selectWidth)
+            var mask = [Int32](repeating: 0, count: Self.batch * selectWidth)
+            var disc = [Float](repeating: 0, count: Self.batch * 5)
+            for (r, sentence) in slice.enumerated() {
+                write(sentence, row: r, ids: &ids, mask: &mask, width: selectWidth,
+                      truncateAt: Self.sentenceTokens)
+                // The 5 discourse scalars the heads were trained with. Passed in
+                // rather than derived in-graph: deriving from shapes is what
+                // emits aten::Int and breaks conversion.
+                let features = Pipeline.discourseFeatures(
+                    sentence, position: Double(start + r) / Double(max(n, 1)))
+                for (c, value) in features.enumerated() { disc[r * 5 + c] = value }
+            }
+            let out = try await selector.run(
+                inputs: ["ids": Tensor(int32: ids, shape: [Self.batch, selectWidth]),
+                         "mask": Tensor(int32: mask, shape: [Self.batch, selectWidth]),
+                         "disc": Tensor(float32: disc, shape: [Self.batch, 5])],
+                outputs: ["saliency", "start_p", "end_p"])
+            guard out.count == 3, let values = out[0].float32Values, values.count >= slice.count else {
+                throw ClipError.predictionFailed
+            }
+            for r in 0..<slice.count { saliency.append(Double(values[r])) }
+        }
+        return saliency
+    }
+
+    /// Per-span quality, batched.
+    private func scoreSpans(_ texts: [String]) async throws -> [Double] {
+        var scores: [Double] = []
+        scores.reserveCapacity(texts.count)
+        for start in stride(from: 0, to: texts.count, by: Self.batch) {
+            let slice = texts[start..<min(start + Self.batch, texts.count)]
+            var ids = [Int32](repeating: 0, count: Self.batch * scoreWidth)
+            var mask = [Int32](repeating: 0, count: Self.batch * scoreWidth)
+            for (r, text) in slice.enumerated() {
+                write(text, row: r, ids: &ids, mask: &mask, width: scoreWidth)
+            }
+            let out = try await scorer.run(
+                inputs: ["ids": Tensor(int32: ids, shape: [Self.batch, scoreWidth]),
+                         "mask": Tensor(int32: mask, shape: [Self.batch, scoreWidth])],
+                outputs: ["score"])
+            guard let values = out.first?.float32Values, values.count >= slice.count else {
+                throw ClipError.predictionFailed
+            }
+            for r in 0..<slice.count { scores.append(Double(values[r])) }
+        }
+        return scores
+    }
+
+    /// Tokenize `text` into row `r` of a batch `width` tokens wide, setting the
+    /// attention mask for exactly the tokens written. Rows past the end of a short
+    /// final batch stay all-zero, and are dropped by the caller rather than read
+    /// back.
+    ///
+    /// `width` is the buffer STRIDE and is a parameter rather than a constant because the two
+    /// graphs run at different lengths. Truncating to one width and indexing with another
+    /// silently interleaves rows - every row after the first lands at the wrong offset, the
+    /// mask stops matching the ids, and the model returns finite numbers for a scrambled batch.
+    ///
+    /// `truncateAt` is where the TEXT is cut, and it defaults to the stride because for the
+    /// scorer the two are the same number. For the selector they are not: the buffer is the
+    /// graph's 128 and the cut is the heads' trained 64. Keeping them as one parameter is what
+    /// ran the selector off-distribution on 76% of holdout videos, so they are two parameters
+    /// now and the caller states both.
+    private func write(_ text: String, row r: Int, ids: inout [Int32], mask: inout [Int32],
+                       width: Int = Model.seqLen, truncateAt: Int? = nil) {
+        let cut = min(truncateAt ?? width, width)
+        for (c, token) in tokenizer.encode(text, maxLength: cut).enumerated() where c < cut {
+            ids[r * width + c] = token
+            mask[r * width + c] = 1
+        }
+    }
+}

--- a/Sources/Clips/ModelLoading.swift
+++ b/Sources/Clips/ModelLoading.swift
@@ -1,0 +1,80 @@
+// How Clips obtains and shapes its models: the file manifest, the
+// download/adopt sources, and the `ModelAssets` the pipeline consumes.
+// (Running them is `Model.swift`.) All platform variation is data here (which
+// exports ship where, declared in `Catalog.swift`); building the platform's
+// session is DesertAnt's `inferenceSession` factory.
+import DesertAnt
+
+// The SDK's usage identity (`ClipModel.sdkInfo`) is derived from the catalog
+// declaration's `product` + `sdkVersion`, so it cannot drift from the published
+// package version or be forgotten on a session.
+
+/// Loaded model inputs: the tokenizer vocab and one ready session per export.
+/// Also the entry point for the cross-language bindings and custom deployments
+/// (not part of the Swift SDK's public API, which loads assets for you).
+///
+/// Two sessions, not one: selection is a per-sentence pass through the selector
+/// and then a per-span pass through the scorer, and they are separate graphs
+/// with different inputs. On Apple those two graphs live in one multifunction
+/// asset, so the sessions share a file and are told apart by function name.
+@_spi(ClipBindings)
+public struct ModelAssets: Sendable {
+    /// Contents of `clip_tokenizer.bin` (the XLM-R unigram vocab).
+    public let tokenizer: [UInt8]
+    /// Per-sentence saliency + start/end probabilities.
+    let selector: any InferenceSession
+    /// Per-span quality score.
+    let scorer: any InferenceSession
+
+    /// Bindings entry point: build from already-constructed sessions plus the
+    /// sidecar.
+    @_spi(ClipBindings)
+    public init(tokenizer: [UInt8], selector: any InferenceSession, scorer: any InferenceSession) {
+        self.tokenizer = tokenizer
+        self.selector = selector
+        self.scorer = scorer
+    }
+
+    /// Build from a resolved model directory: read the sidecar and let the core
+    /// pick this platform's session for each export.
+    static func clip(files: StoredModel, computeUnits: ComputeUnits) async throws -> ModelAssets {
+        ModelAssets(
+            tokenizer: try files.read(ClipModel.tokenizer),
+            selector: try await files.session(ClipModel.selector, computeUnits: computeUnits),
+            scorer: try await files.session(ClipModel.scorer, computeUnits: computeUnits))
+    }
+}
+
+extension StoredModel {
+    /// Open one half of the pipeline: the file, and the function inside it when
+    /// the artifact carries more than one.
+    ///
+    /// The function name is the easy part to drop, and Core ML raises nothing
+    /// when it is missing: it loads the package's default function, so both
+    /// halves of the pipeline become the selector. Here that surfaces later as
+    /// a prediction failure about a missing `score`, which points at the model
+    /// rather than at the load that never addressed a graph. On Apple the two
+    /// halves are one asset (``ClipModel/coreML``); everywhere else the name is
+    /// `nil` and this is an ordinary per-file load.
+    func session(_ export: ClipModel.Export,
+                 computeUnits: ComputeUnits) async throws -> any InferenceSession {
+        try await inferenceSession(model: export.file, computeUnits: computeUnits,
+                                   functionName: export.function, sdk: ClipModel.sdkInfo)
+    }
+}
+
+public extension Clips {
+    /// The published model repository.
+    static var modelRepo: String { ClipModel.repo }
+    /// The model revision this SDK is built against (pinned; not configurable).
+    static var modelRevision: String { ClipModel.revision }
+}
+
+// MARK: shipping the model with your app
+
+// This package bundles no model artifact and has no resource bundle to load
+// one from. The model is downloaded on demand: to a managed cache location by
+// default, or to the `directory` you pass. Shipping the model with your app is
+// therefore just pointing `directory` at a folder that already holds this
+// platform's exports plus the tokenizer - it is then used offline, with no
+// download. (Android's equivalent is classpath resources.)

--- a/Sources/Clips/Native.swift
+++ b/Sources/Clips/Native.swift
@@ -1,0 +1,60 @@
+// Clips's exported entry points. Everything behind them is model-agnostic and
+// lives in NativeBindings; this file only names the symbols, because symbol
+// names are the one thing that cannot be shared: `@_cdecl` takes a string
+// literal and JNI derives its name from the Kotlin class.
+//
+// The names are model-scoped (`clips_create`, `Java_ai_desertant_clip_...`)
+// rather than generic, so two models can be linked into one binary - which is
+// what lets a model be a single target instead of a separate native one.
+
+#if !os(WASI)
+import DesertAnt
+import NativeBindings
+#if os(Android)
+import Android
+#endif
+
+#if !os(Android)
+@_cdecl("clips_create")
+public func clips_create(_ modelId: UnsafePointer<CChar>?, _ cacheRoot: UnsafePointer<CChar>?,
+                        _ directory: UnsafePointer<CChar>?) -> UnsafeMutableRawPointer? {
+    nativeCreate(binding: ClipBinding.self, modelId: modelId,
+                 cacheRoot: cacheRoot, directory: directory)
+}
+#endif
+
+#if os(Android)
+@_cdecl("Java_ai_desertant_clip_ClipNative_create")
+public func androidCreateClip(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                              _ modelId: jbyteArray?, _ cacheRoot: jbyteArray?,
+                              _ directory: jbyteArray?) -> jlong {
+    androidCreate(ClipBinding.self, env: env, cls: cls, modelId: modelId,
+                  cacheRoot: cacheRoot, directory: directory)
+}
+
+@_cdecl("Java_ai_desertant_clip_ClipNative_destroy")
+public func androidDestroyClip(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                               _ handle: jlong) {
+    nativeDestroy(androidPointer(handle))
+}
+
+@_cdecl("Java_ai_desertant_clip_ClipNative_isDownloaded")
+public func androidIsDownloadedClip(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                                    _ handle: jlong) -> jint {
+    androidIsDownloaded(env, cls, handle)
+}
+
+@_cdecl("Java_ai_desertant_clip_ClipNative_download")
+public func androidDownloadClip(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                                _ handle: jlong) -> jint {
+    androidDownload(env, cls, handle)
+}
+
+@_cdecl("Java_ai_desertant_clip_ClipNative_run")
+public func androidRunClip(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                           _ handle: jlong, _ input: jbyteArray?,
+                           _ options: jbyteArray?) -> jbyteArray? {
+    androidRun(env, cls, handle, input, options)
+}
+#endif
+#endif

--- a/Sources/Clips/Pipeline.swift
+++ b/Sources/Clips/Pipeline.swift
@@ -1,0 +1,240 @@
+import DesertAnt
+import Transcript
+
+/// Choosing which moments to keep: the discourse features the selector is fed,
+/// candidate enumeration around saliency anchors, weighted interval scheduling
+/// over the scored spans, and the near-duplicate cut. No model runs here - this
+/// is the half of selection that would be identical on any runtime.
+enum Pipeline {
+    static let lookback = 8
+    static let lookahead = 14
+    static let minSentences = 3
+    static let maxSentences = 10
+    /// Drop a clip that repeats an already-kept one. Readers punish duplicates
+    /// hard: the first search build shipped the same moment 2-3 times and lost
+    /// ship-rank despite better individual clips.
+    static let jaccardMax = 0.5
+
+    /// Words per second, for turning a transcript into a duration. The corpus carries no
+    /// timestamps, so this proxy is the only duration the pipeline has. Matches
+    /// `python/construct.py`'s `WPS`.
+    static let wordsPerSecond = 2.5
+
+    /// An UPPER LIMIT on emitted moments, set by the video's DURATION. Never a quota: a
+    /// transcript that supports fewer good moments emits fewer, and that is correct.
+    ///
+    /// **This is one definition shared with `python/construct.py`'s `clip_budget`, and it
+    /// replaces a rule that disagreed with it.** The offline path capped at a literal 6 --
+    /// which bound on 79% of the frozen holdout and on 98-99% of long and podcast, so every
+    /// evaluated clip count was the ceiling rather than the model -- while this file capped at
+    /// `max(min(n / 4, 12), 2)` and carried a comment claiming the two matched. They never did:
+    /// identical input produced different clip counts on the two paths, and only one of them
+    /// was ever evaluated.
+    ///
+    /// The numbers are measured, not chosen. Median Shorts the teacher emits, over 1,216 corpus
+    /// videos: 8 under 5 minutes, 11 to 10, 13 to 30, 14 beyond. That curve is itself censored
+    /// from above by the teacher prompt's own "Create 8 Shorts minimum and 15 Shorts maximum",
+    /// so read the top of it as a property of the prompt as much as of the content.
+    ///
+    /// DURATION, not sentence count, because sentences per minute varies -- the same `n` is a
+    /// different video at different speaking rates, and the measurement above is by duration.
+    /// The old `n / 4` rule also floored at 2, which on a short video capped output at 2 clips
+    /// where the pipeline could support about 3.
+    static func budget(for transcript: [String]) -> Int {
+        let words = transcript.reduce(0) { $0 + max(1, $1.split(separator: " ").count) }
+        let minutes = Double(words) / wordsPerSecond / 60
+        if minutes < 5 { return 8 }
+        if minutes < 10 { return 11 }
+        if minutes < 30 { return 13 }
+        return 14
+    }
+
+    /// The effective ceiling: a caller's `limit` when given, otherwise the duration curve.
+    ///
+    /// **A limit set here is not the same as trimming the returned list, and the difference is
+    /// both latency and content.** The anchor count is `budget * 4`, so the ceiling sizes the
+    /// candidate pool and therefore the number of scorer passes — most of the runtime. Trimming
+    /// afterwards pays for every clip and then discards some, which is what `Clips.clips(in:
+    /// limit:)` used to do.
+    ///
+    /// The content differs too: weighted interval scheduling at budget k returns the
+    /// highest-total NON-OVERLAPPING SET of size <= k, which is not generally the top k of the
+    /// set it would return at a larger budget. Neither is wrong; they answer different
+    /// questions. This one answers "the best k moments", which is what a bounded list wants.
+    static func budget(for transcript: [String], limit: Int?) -> Int {
+        guard let limit else { return budget(for: transcript) }
+        return max(1, limit)
+    }
+
+    /// Every span worth scoring: around each of the most salient sentences, all
+    /// runs of 3...10 sentences that contain it, starting up to 8 sentences
+    /// before it and ending up to 14 after.
+    ///
+    /// `budget` is passed in rather than recomputed. It used to be derived here from `n` and
+    /// again in `rank`, and the anchor count is `budget * 4`, so two derivations that ever
+    /// disagreed would enumerate a pool the ranker never sized for.
+    static func enumerateCandidates(count n: Int, saliency: [Double], budget: Int) -> [[Int]] {
+        let anchors = saliency.enumerated().sorted { $0.element > $1.element }
+            .prefix(max(budget * 4, 12)).map(\.offset)
+        var seen = Set<[Int]>()
+        for a in anchors where a < n {
+            for lo in max(0, a - lookback)...a {
+                for hi in a..<min(n, a + lookahead + 1)
+                where (hi - lo + 1) >= minSentences && (hi - lo + 1) <= maxSentences {
+                    seen.insert(Array(lo...hi))
+                }
+            }
+        }
+        return seen.sorted { ($0.first!, $0.last!) < ($1.first!, $1.last!) }
+    }
+
+    /// Scored candidates in, ranked non-overlapping moments out.
+    static func rank(candidates: [[Int]], scores: [Double], transcript: [String],
+                     limit: Int?) -> [Clip] {
+        let spans = candidates.enumerated().map { (i, span) in (span.first!, span.last!, scores[i]) }
+        let chosen = dedupe(
+            selectNonOverlapping(spans, budget: budget(for: transcript, limit: limit)),
+            transcript: transcript)
+        let ranked = chosen.sorted { $0.2 > $1.2 }
+        return ranked.enumerated().map { (i, span) in
+            let ids = Array(span.0...span.1)
+            let words = ids.reduce(0) { $0 + transcript[$1].split(separator: " ").count }
+            return Clip(
+                id: i,
+                sentenceIDs: ids,
+                text: ids.map { transcript[$0] }.joined(separator: " "),
+                score: span.2,
+                percentile: ranked.count > 1 ? 1.0 - Double(i) / Double(ranked.count - 1) : 1.0,
+                estimatedDurationSec: Double(words) / 2.5)
+        }
+    }
+
+    /// Weighted interval scheduling: choose the highest-scoring non-overlapping
+    /// set of at most `budget` spans. Replaces claim-order greedy, under which a
+    /// video's 4th-best moment could be truncated because the 1st-best anchor
+    /// already took the sentence its hook needed.
+    ///
+    /// Near-ties are broken deterministically rather than on float noise, and that is
+    /// load-bearing rather than tidy. The pool holds overlapping windows around one
+    /// anchor, and the encoder truncates a span to a fixed token count, so two
+    /// candidates differing only in trailing sentences can receive a bit-identical
+    /// input and therefore an identical score. Measured on the frozen holdout, 27% of
+    /// emitted clips had an exactly-tied rival. Under a bare `use > skip` over a sort
+    /// on `hi` alone, which one a user sees turned on the last bit of a float: two
+    /// numerically equivalent runs returned different clips, and a Core ML GPU run and
+    /// an ANE run agreed on only 85% of spans in one stratum.
+    ///
+    /// Three things make it deterministic: a total order on `(hi, lo)` rather than `hi`
+    /// alone, an epsilon so an equal score never displaces the incumbent, and preferring
+    /// the smallest clip count among totals within that epsilon. The Python reference
+    /// `clips-training/python/dp_select.py` does the same three and they must stay in
+    /// step, or Swift and Python disagree on exactly these near-ties.
+    static func selectNonOverlapping(_ spans: [(Int, Int, Double)], budget: Int)
+        -> [(Int, Int, Double)] {
+        let sorted = spans.sorted { $0.1 != $1.1 ? $0.1 < $1.1 : $0.0 < $1.0 }
+        let eps = 1e-6
+        guard !sorted.isEmpty, budget > 0 else { return [] }
+        var prev = [Int](repeating: -1, count: sorted.count)
+        for i in 0..<sorted.count {
+            var j = i - 1
+            while j >= 0 && sorted[j].1 >= sorted[i].0 { j -= 1 }
+            prev[i] = j
+        }
+        let neg = -Double.greatestFiniteMagnitude
+        var dp = [[Double]](repeating: [Double](repeating: neg, count: budget + 1),
+                            count: sorted.count + 1)
+        var take = [[Bool]](repeating: [Bool](repeating: false, count: budget + 1),
+                            count: sorted.count + 1)
+        for k in 0...budget { dp[0][k] = 0 }
+        for i in 1...sorted.count {
+            let p = prev[i - 1] + 1
+            for k in 0...budget {
+                let skip = dp[i - 1][k]
+                let use = (k >= 1 && dp[p][k - 1] > neg / 2) ? dp[p][k - 1] + sorted[i - 1].2 : neg
+                if use > skip + eps { dp[i][k] = use; take[i][k] = true } else { dp[i][k] = skip }
+            }
+        }
+        // Smallest clip count whose total is within eps of the best: a tie between
+        // k and k+1 clips means the extra clip earned nothing, so do not emit it.
+        //
+        // The maximum is taken first, deliberately. Advancing a running best only on
+        // a jump greater than eps is NOT equivalent: several consecutive increments
+        // can each fall under eps while summing to more than it, and the two rules
+        // then differ by a clip. For totals [0, 1.0, 1.0000009, 1.0000018] the
+        // running form yields k=3 where this yields k=2. That needs consecutive
+        // candidates scoring under 1e-6, which this pool is now known to produce.
+        let totals = dp[sorted.count]
+        let best = totals.max() ?? 0
+        let bestK = (0...budget).first { totals[$0] >= best - eps } ?? 0
+        var out: [(Int, Int, Double)] = []
+        var i = sorted.count, k = bestK
+        while i > 0 && k > 0 {
+            if take[i][k] { out.append(sorted[i - 1]); k -= 1; i = prev[i - 1] + 1 } else { i -= 1 }
+        }
+        return out.reversed()
+    }
+
+    /// Cut spans whose words repeat an already-kept span's past ``jaccardMax``.
+    static func dedupe(_ spans: [(Int, Int, Double)], transcript: [String])
+        -> [(Int, Int, Double)] {
+        var kept: [(Int, Int, Double)] = []
+        for s in spans {
+            let a = Set(Array(s.0...s.1).flatMap { transcript[$0].split(separator: " ") })
+            let clash = kept.contains { k in
+                let b = Set(Array(k.0...k.1).flatMap { transcript[$0].split(separator: " ") })
+                return Double(a.intersection(b).count) / Double(max(a.union(b).count, 1)) > jaccardMax
+            }
+            if !clash { kept.append(s) }
+        }
+        return kept
+    }
+
+    // MARK: discourse features
+
+    /// EXACT port of `train_gen1.disc_feats`. Order and semantics must match
+    /// training or the heads receive garbage in 5 of their 773 input dimensions:
+    ///   [position, hookPatternCount, payoffPatternCount, endsWithQuestion, digitRatio]
+    /// Note these are pattern COUNTS (how many of the list matched), not
+    /// booleans, and the position comes FIRST - an earlier hand-written version
+    /// had all five wrong.
+    static let hookPatterns: [Pattern] = compile([
+        "\\bhere'?s\\b", "nobody", "most people",
+        "the (mistake|secret|truth|problem|reason)", "\\bwhat if\\b", "\\bwhy\\b",
+        "\\bhow (to|i|we|you)\\b", "\\?",
+        "\\b(never|always|everyone|no one|nobody)\\b",
+        "\\b(biggest|worst|best|craziest|first|only|most)\\b",
+    ])
+    static let payoffPatterns: [Pattern] = compile([
+        "\\bso\\b", "that'?s why", "the point", "which means", "turns out", "the result",
+    ])
+
+    private static func compile(_ patterns: [String]) -> [Pattern] {
+        patterns.compactMap { try? Pattern($0).ignoresCase() }
+    }
+
+    static func discourseFeatures(_ sentence: String, position: Double) -> [Float] {
+        let t = sentence.lowercased()
+        func count(_ patterns: [Pattern]) -> Float {
+            Float(patterns.reduce(0) { $0 + ($1.contains(in: t) ? 1 : 0) })
+        }
+        let endsQ: Float = t.trimmedWhitespace.hasSuffix("?") ? 1 : 0
+        let digits = t.filter(\.isNumber).count
+        let digitRatio = Float(digits) / Float(t.count + 1)
+        return [Float(position), count(hookPatterns), count(payoffPatterns), endsQ, digitRatio]
+    }
+}
+
+private extension String {
+    /// Trim ASCII/Unicode whitespace without Foundation (absent on Android).
+    var trimmedWhitespace: String {
+        let scalars = unicodeScalars
+        var start = scalars.startIndex
+        var end = scalars.endIndex
+        while start < end, scalars[start].properties.isWhitespace { start = scalars.index(after: start) }
+        while end > start {
+            let prev = scalars.index(before: end)
+            if scalars[prev].properties.isWhitespace { end = prev } else { break }
+        }
+        return String(String.UnicodeScalarView(scalars[start..<end]))
+    }
+}

--- a/Sources/Clips/Tokenizer.swift
+++ b/Sources/Clips/Tokenizer.swift
@@ -1,0 +1,306 @@
+import DesertAnt
+
+/// XLM-R SentencePiece **Unigram** tokenizer, in pure Swift: NFKC
+/// normalization, no lowercasing, `▁` metaspace, Viterbi over the vocab with a
+/// `min_score − 10` unknown penalty. Backed by a compact `clip_tokenizer.bin`.
+///
+/// Token ids MUST match training exactly. A stand-in tokenizer produces
+/// plausible latency and meaningless clips, because the encoder sees words it
+/// was never trained on.
+///
+/// This is a port of the same container format and Viterbi decoder Redact
+/// reads, because both models were trained on the same xlm-roberta-base vocab.
+/// It is duplicated rather than shared because `check:isolation` forbids one
+/// model's Swift graph from containing another; the natural home is a shared
+/// capability module beside `TextNormalization`, which is a core-wide decision
+/// rather than something a new model gets to make.
+struct Tokenizer {
+    let bosID: Int
+    let eosID: Int
+    let unkID: Int
+
+    private let scores: [Float]
+    private let vocab: VocabIndex
+    private let unkPenalty: Double
+    private let maxLen: Int
+
+    init?(bytes: [UInt8]) {
+        // "RDTK": the container tag the vocab builder emits, not a model name.
+        guard bytes.count >= 21, bytes.count <= Int(Int32.max),
+              bytes.starts(with: [0x52, 0x44, 0x54, 0x4B]) else { return nil }
+        var offset = 5
+
+        func readU16() -> Int? {
+            guard offset <= bytes.count - 2 else { return nil }
+            defer { offset += 2 }
+            return Int(bytes[offset]) | Int(bytes[offset + 1]) << 8
+        }
+        func readU32() -> UInt32? {
+            guard offset <= bytes.count - 4 else { return nil }
+            defer { offset += 4 }
+            return UInt32(bytes[offset])
+                | UInt32(bytes[offset + 1]) << 8
+                | UInt32(bytes[offset + 2]) << 16
+                | UInt32(bytes[offset + 3]) << 24
+        }
+        func readInt() -> Int? { readU32().map { Int(Int32(bitPattern: $0)) } }
+
+        guard let unk = readInt(), let bos = readInt(), let eos = readInt(),
+              let count = readInt(), count > 0,
+              count <= (bytes.count - offset) / 6 else { return nil }
+
+        var parsedScores: [Float] = []
+        parsedScores.reserveCapacity(count)
+        for _ in 0..<count {
+            guard let bits = readU32() else { return nil }
+            parsedScores.append(Float(bitPattern: bits))
+        }
+
+        var lengths: [Int] = []
+        lengths.reserveCapacity(count)
+        for _ in 0..<count {
+            guard let length = readU16() else { return nil }
+            lengths.append(length)
+        }
+
+        // Pieces are stored back to back to the end of the container, so the
+        // index borrows `bytes` as its byte image and records where each piece
+        // begins; nothing is copied and no piece becomes a `String`.
+        var bounds: [Int32] = []
+        bounds.reserveCapacity(count + 1)
+        var maximumLength = 1
+        for length in lengths {
+            guard length <= bytes.count - offset else { return nil }
+            bounds.append(Int32(offset))
+            // Measured in scalars, because the Viterbi window below is.
+            var scalars = 0
+            for byte in bytes[offset..<(offset + length)] where byte & 0xC0 != 0x80 {
+                scalars += 1
+            }
+            maximumLength = max(maximumLength, scalars)
+            offset += length
+        }
+        bounds.append(Int32(offset))
+        guard offset == bytes.count,
+              let index = VocabIndex(image: bytes, bounds: bounds),
+              (0..<count).contains(unk), (0..<count).contains(bos), (0..<count).contains(eos)
+        else { return nil }
+
+        unkID = unk
+        bosID = bos
+        eosID = eos
+        scores = parsedScores
+        vocab = index
+        maxLen = min(maximumLength, 32)
+        unkPenalty = Double(parsedScores.min() ?? 0) - 10.0
+    }
+
+    /// Encode `text` the way the exports were fed in training: `<s>`, the
+    /// content pieces, `</s>`, truncated to `maxLength`.
+    ///
+    /// Truncation follows HuggingFace's `truncation=True, max_length=`: it KEEPS
+    /// the eos. A plain `prefix(maxLength)` drops `</s>` and substitutes one
+    /// more content token, so every span longer than the bucket is scored on
+    /// input the model never saw in training. Measured Aug 2026: that alone
+    /// accounted for the Swift port's divergence from the Python reference on
+    /// long transcripts, and cost 3.7% of total scorer mass - its worst clip
+    /// scored 0.466 where the reference's worst scored 0.537. Only spans over
+    /// the limit were affected, which is why short transcripts looked perfect
+    /// and hid it.
+    func encode(_ text: String, maxLength: Int) -> [Int32] {
+        guard maxLength > 0 else { return [] }
+        var ids = [Int32(bosID)]
+        ids.append(contentsOf: tokenize(text).map { Int32($0) })
+        ids.append(Int32(eosID))
+        guard ids.count > maxLength else { return ids }
+        return Array(ids.prefix(maxLength - 1)) + [Int32(eosID)]
+    }
+
+    /// Tokenize `text` into content sub-word ids (no `<s>` / `</s>`),
+    /// Viterbi-optimal over the unigram vocabulary.
+    func tokenize(_ text: String) -> [Int] {
+        let nfkc = text.nfkc
+        // SentencePiece's `remove_extra_whitespaces`: trim and collapse space
+        // runs, like the training tokenizer.
+        var squeezed = [Unicode.Scalar]()
+        squeezed.reserveCapacity(nfkc.unicodeScalars.count)
+        var lastWasSpace = true  // trims leading spaces
+        for scalar in nfkc.unicodeScalars {
+            if scalar == " " {
+                if lastWasSpace { continue }
+                lastWasSpace = true
+            } else {
+                lastWasSpace = false
+            }
+            squeezed.append(scalar)
+        }
+        if squeezed.last == " " { squeezed.removeLast() }
+        let normalized = "\u{2581}" + String(String.UnicodeScalarView(
+            squeezed.map { $0 == " " ? "\u{2581}" : $0 }))
+        // The lattice is indexed by scalar, the vocab is keyed by byte, so carry
+        // the text as UTF-8 plus the byte offset each scalar starts at. Built
+        // once per call; the O(n × maxLen) inner loop then slices it for free.
+        let s = Array(normalized.unicodeScalars)
+        let n = s.count
+        if n == 0 { return [] }
+        let utf8 = Array(normalized.utf8)
+        var span = [Int](repeating: 0, count: n + 1)
+        for (i, scalar) in s.enumerated() { span[i + 1] = span[i] + utf8Width(scalar) }
+
+        return utf8.withUnsafeBufferPointer { text -> [Int] in
+            vocab.withLookup { lookup -> [Int] in
+                let neg = -1e18
+                var best = [Double](repeating: neg, count: n + 1); best[0] = 0
+                var backPos = [Int](repeating: -1, count: n + 1)
+                var backID = [Int](repeating: -1, count: n + 1)
+                for i in 1...n {
+                    let lo = max(0, i - maxLen)
+                    for j in lo..<i {
+                        let query = UnsafeBufferPointer(rebasing: text[span[j]..<span[i]])
+                        if let tid = lookup.id(of: query) {
+                            let sc = best[j] + Double(scores[tid])
+                            if sc > best[i] { best[i] = sc; backPos[i] = j; backID[i] = tid }
+                        }
+                    }
+                    let cand = best[i - 1] + unkPenalty
+                    if cand > best[i] { best[i] = cand; backPos[i] = i - 1; backID[i] = unkID }
+                }
+
+                var ids: [Int] = []
+                var i = n
+                while i > 0 {
+                    let j = backPos[i]
+                    ids.append(backID[i])
+                    i = j
+                }
+                return ids.reversed()
+            }
+        }
+    }
+}
+
+/// How many UTF-8 bytes a scalar occupies, without building a `String` for it.
+@inline(__always)
+private func utf8Width(_ scalar: Unicode.Scalar) -> Int {
+    switch scalar.value {
+    case ..<0x80: 1
+    case ..<0x800: 2
+    case ..<0x1_0000: 3
+    default: 4
+    }
+}
+
+/// The vocabulary, keyed on a piece's UTF-8 **bytes**.
+///
+/// Swift compares and hashes `String` by Unicode *canonical equivalence*, not by
+/// bytes, so in a `[String: Int]` vocab two byte-distinct pieces that differ only
+/// in composition or in combining-mark order are ONE key, and the later id
+/// silently evicts the earlier. xlm-roberta-base's 250,002 pieces hold 29 such
+/// pairs - Burmese `င့်` sign orderings, Arabic shadda before or after its vowel,
+/// Hebrew dagesh, precomposed Kannada `ೋ` against its decomposition. In 16 of the
+/// 29 the evicted id is the one the Python reference emits, so that input
+/// tokenized differently on device than in training.
+///
+/// And it is worse than 29 wrong tokens. The loader's own
+/// `parsedIndex.count == count` check cannot hold when 29 keys collapse, so a
+/// `String`-keyed index REJECTS the published vocab outright from `init?` and
+/// every `Clips` load throws `modelNotFound`. Checked against the file on the
+/// Hub, which is byte-identical to the one the export builds.
+///
+/// Bytes are what the container stores and what training matched, so bytes are
+/// the key. This is open addressing over the container's own byte image rather
+/// than a `[[UInt8]: Int]` dictionary because the decoder probes the vocab
+/// O(scalars × maxLen) times per sentence over 400-sentence transcripts, and an
+/// `Array` key would heap-allocate on every probe.
+struct VocabIndex {
+    /// The whole container, borrowed. Piece `id` is `image[bounds[id]..<bounds[id + 1]]`,
+    /// so the pieces cost no storage beyond the bytes already read from disk.
+    private let image: [UInt8]
+    private let bounds: [Int32]
+    /// Open addressing, power-of-two, `-1` where empty; the value is a piece id.
+    private let table: [Int32]
+    private let mask: Int
+
+    /// Fails when two pieces carry identical bytes, which is a malformed
+    /// container rather than a Unicode subtlety.
+    init?(image: [UInt8], bounds: [Int32]) {
+        let count = bounds.count - 1
+        guard count > 0 else { return nil }
+        var capacity = 16
+        while capacity < count * 2 { capacity <<= 1 }
+        var slots = [Int32](repeating: -1, count: capacity)
+        let m = capacity - 1
+
+        let duplicate = image.withUnsafeBufferPointer { bytes -> Bool in
+            for id in 0..<count {
+                let lo = Int(bounds[id]), hi = Int(bounds[id + 1])
+                let piece = UnsafeBufferPointer(rebasing: bytes[lo..<hi])
+                var slot = VocabIndex.hash(piece) & m
+                while slots[slot] >= 0 {
+                    let other = Int(slots[slot])
+                    let range = Int(bounds[other])..<Int(bounds[other + 1])
+                    if range.count == piece.count,
+                       UnsafeBufferPointer(rebasing: bytes[range]).elementsEqual(piece) {
+                        return true
+                    }
+                    slot = (slot + 1) & m
+                }
+                slots[slot] = Int32(id)
+            }
+            return false
+        }
+        guard !duplicate else { return nil }
+
+        self.image = image
+        self.bounds = bounds
+        table = slots
+        mask = m
+    }
+
+    /// Borrow the index for the length of one tokenization. Everything the inner
+    /// loop touches is resolved to a pointer once, so a probe is a hash, a
+    /// length compare, and a byte compare - no allocation, no retain.
+    func withLookup<R>(_ body: (Lookup) -> R) -> R {
+        image.withUnsafeBufferPointer { image in
+            bounds.withUnsafeBufferPointer { bounds in
+                table.withUnsafeBufferPointer { table in
+                    body(Lookup(image: image, bounds: bounds, table: table, mask: mask))
+                }
+            }
+        }
+    }
+
+    struct Lookup {
+        fileprivate let image: UnsafeBufferPointer<UInt8>
+        fileprivate let bounds: UnsafeBufferPointer<Int32>
+        fileprivate let table: UnsafeBufferPointer<Int32>
+        fileprivate let mask: Int
+
+        /// The id of the piece whose UTF-8 is exactly `query`, or nil.
+        func id(of query: UnsafeBufferPointer<UInt8>) -> Int? {
+            var slot = VocabIndex.hash(query) & mask
+            while true {
+                let id = Int(table[slot])
+                if id < 0 { return nil }
+                let lo = Int(bounds[id]), hi = Int(bounds[id + 1])
+                if hi - lo == query.count,
+                   UnsafeBufferPointer(rebasing: image[lo..<hi]).elementsEqual(query) {
+                    return id
+                }
+                slot = (slot + 1) & mask
+            }
+        }
+    }
+
+    /// FNV-1a, which is what the container's own tooling hashes with and is
+    /// cheap enough to run on every probe.
+    @inline(__always)
+    fileprivate static func hash(_ bytes: UnsafeBufferPointer<UInt8>) -> Int {
+        var h: UInt64 = 0xCBF2_9CE4_8422_2325
+        for byte in bytes {
+            h ^= UInt64(byte)
+            h = h &* 0x0000_0100_0000_01B3
+        }
+        return Int(truncatingIfNeeded: h) & Int.max
+    }
+}

--- a/Sources/Clips/Web/main.swift
+++ b/Sources/Clips/Web/main.swift
@@ -1,0 +1,31 @@
+#if os(WASI)
+import DesertAnt
+import WasmBindings
+@_spi(ClipBindings) import Clips
+
+// Clips's WebAssembly entry point.
+//
+// The exported surface is the shared, model-agnostic one in `WasmBindings`
+// (`Exports.swift`, generated into typed JS by BridgeJS), the wasm twin of the
+// `dal_*` C ABI: the transcript, the options and the result cross as the FFI
+// payloads `Clips/Binding.swift` already encodes, so nothing model-specific is
+// repeated here.
+//
+// Clips ships no npm package, so this is a compile check today - and it is the
+// honest state of the model on the web rather than an oversight. The wasm host
+// contract holds ONE compiled model per module (`docs/development.md`), and
+// selection needs two sessions in the same module: a per-sentence selector and
+// a per-span scorer, two separate exports with different inputs. So
+// `ClipModel.files` declares no `.web` manifest, and the self-hosted path -
+// where the JS host fetched the files and compiled the model itself - has only
+// one of the two sessions to hand over and says so rather than half-building a
+// model that would score every span against the wrong graph.
+//
+// Lifting this is the same cross-language decision `docs/development.md`
+// already frames for Clear: it is a host-contract change (more than one
+// compiled model per module), not a patch to this file.
+installWasmModel(
+    WasmModel(ClipModel.self, binding: ClipBinding.self) { _, _ in
+        throw ClipError.modelNotFound
+    })
+#endif

--- a/Sources/Inference/CoreMLSession.swift
+++ b/Sources/Inference/CoreMLSession.swift
@@ -24,9 +24,31 @@ final class CoreMLSession: InferenceSession, @unchecked Sendable {
     /// Load a compiled model. `computeUnits` is what the model SDK asks for
     /// (Core ML's `MLComputeUnits`); the environment and the simulator can
     /// override it - see ``configuration(for:)``.
-    init(modelPath: String, computeUnits: ComputeUnits = .all) throws {
+    /// - Parameter functionName: which function of a multifunction model to run. One
+    ///   `.mlmodelc` can carry several graphs - a selector and a scorer sharing an encoder,
+    ///   say - and shipping them as one asset stores the shared weights once rather than
+    ///   twice. `nil` uses the model's default function, which is every single-function
+    ///   model.
+    init(modelPath: String, computeUnits: ComputeUnits = .all,
+         functionName: String? = nil) throws {
+        let configuration = CoreMLSession.configuration(for: computeUnits)
+        if let functionName {
+            // watchOS 11.0 belongs here even though this package declares no watchOS platform.
+            // `MLModelConfiguration.functionName` is annotated watchOS 11.0+ in the Core ML
+            // header, and a platform left out of an `#available` list falls to `*` — which
+            // matches every watchOS version, so the guard PASSES and the line below then fails
+            // to COMPILE against the watchOS SDK. An omission here is a build error rather
+            // than a runtime fallback, and `ModelPlatform.current` does route watchOS to
+            // `.apple`.
+            guard #available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+            else {
+                throw InferenceError.sessionUnavailable(
+                    "multifunction models need iOS 18 / macOS 15; '\(functionName)' is unreachable here")
+            }
+            configuration.functionName = functionName
+        }
         model = try MLModel(contentsOf: URL(fileURLWithPath: modelPath),
-                            configuration: CoreMLSession.configuration(for: computeUnits))
+                            configuration: configuration)
     }
 
     /// The configuration to load with, in precedence order:
@@ -53,6 +75,16 @@ final class CoreMLSession: InferenceSession, @unchecked Sendable {
             #endif
         }
         return configuration
+    }
+
+    /// Read off the declared constraint. On a multifunction package `modelDescription` reflects
+    /// the function this session was configured with, so `select` and `score` report their own
+    /// widths from two sessions over the same file.
+    func inputWidth(_ name: String) -> Int? {
+        guard let shape = model.modelDescription
+            .inputDescriptionsByName[name]?.multiArrayConstraint?.shape,
+              let last = shape.last?.intValue, last > 0 else { return nil }
+        return last
     }
 
     func run(inputs: [String: Tensor], outputs: [String], deviceId: String?) throws -> [Tensor] {

--- a/Sources/Inference/InferenceSession.swift
+++ b/Sources/Inference/InferenceSession.swift
@@ -37,9 +37,24 @@ public protocol InferenceSession: Sendable {
     /// concrete backends ignore it — only the usage-tracking wrapper uses it.
     /// Most callers use the two-argument convenience below.
     func run(inputs: [String: Tensor], outputs: [String], deviceId: String?) async throws -> [Tensor]
+
+    /// The last-dimension extent this graph was compiled at for a named input — its sequence
+    /// width — or `nil` when the runtime cannot report shapes.
+    ///
+    /// Exists so a caller can size buffers from the ARTIFACT rather than from a constant. The
+    /// clips scorer forced it: two candidate packages differ in exactly this number (`score` at
+    /// [16,128] against [16,256]) and in nothing else about their I/O, so a hardcoded width
+    /// silently truncates every candidate on the wider one and reports no difference between
+    /// them — a null by construction rather than a measurement.
+    func inputWidth(_ name: String) -> Int?
 }
 
 public extension InferenceSession {
+    /// Runtimes that cannot introspect their own shapes report nothing, and callers fall back
+    /// to their own default. Returning `nil` rather than a guess keeps "I don't know" distinct
+    /// from "it is 128".
+    func inputWidth(_ name: String) -> Int? { nil }
+
     /// Run, resolving the device id for usage attribution without the SDK having
     /// to pass one. Precedence:
     ///   1. `InferenceContext.deviceId` — a per-call task-local the host binds

--- a/Sources/Inference/SessionFactory.swift
+++ b/Sources/Inference/SessionFactory.swift
@@ -12,9 +12,11 @@ import Usage
 /// `computeUnits` is a Core ML concern (LiteRT picks its own delegates), and the
 /// environment can still override it - see `CoreMLSession.configuration(for:)`.
 public func inferenceSession(modelPath: String, computeUnits: ComputeUnits = .all,
+                             functionName: String? = nil,
                              sdk: SDKInfo = SDKInfo()) throws -> any InferenceSession {
     #if canImport(CoreML)
-    return tracked(try CoreMLSession(modelPath: modelPath, computeUnits: computeUnits), sdk: sdk)
+    return tracked(try CoreMLSession(modelPath: modelPath, computeUnits: computeUnits,
+                                     functionName: functionName), sdk: sdk)
     #elseif canImport(CLiteRt)
     return tracked(try LiteRTSession(modelPath: modelPath), sdk: sdk)
     #else
@@ -50,12 +52,14 @@ public extension StoredModel {
     /// the typed contract in `Sources/JSHost/Host.swift`. This is the one call a
     /// model SDK makes to go from resolved files to a runnable session.
     func inferenceSession(model: String, computeUnits: ComputeUnits = .all,
+                          functionName: String? = nil,
                           sdk: SDKInfo = SDKInfo()) async throws -> any InferenceSession {
         #if os(WASI)
         try await createJavaScriptSession(modelFile: model)
         return tracked(JSInferenceSession(), sdk: sdk)
         #else
-        return try Inference.inferenceSession(modelPath: path(model), computeUnits: computeUnits, sdk: sdk)  // already tracked
+        return try Inference.inferenceSession(modelPath: path(model), computeUnits: computeUnits,
+                                              functionName: functionName, sdk: sdk)  // already tracked
         #endif
     }
 }

--- a/Sources/Inference/UsageTracking.swift
+++ b/Sources/Inference/UsageTracking.swift
@@ -26,6 +26,17 @@ func tracked(_ session: any InferenceSession, sdk: SDKInfo = SDKInfo()) -> any I
 /// while awaiting the wrapped session, so concurrent runs still run concurrently.
 actor TrackedSession: InferenceSession {
     private let wrapped: any InferenceSession
+
+    /// Forwarded, `nonisolated` so it satisfies the synchronous protocol requirement.
+    ///
+    /// Without this the wrapper silently inherits the protocol's `nil` default and every caller
+    /// falls back to its own constant — not a compile error, not a warning, just a wrong buffer
+    /// width. It cost a run: the clips scorer asked a 256-wide graph for its width, got `nil`
+    /// through this wrapper, sized buffers at the fallback 128, and Core ML rejected the batch.
+    /// A wrapper that drops an introspection method is the same defect class as one that drops
+    /// an error.
+    nonisolated func inputWidth(_ name: String) -> Int? { wrapped.inputWidth(name) }
+
     private let storage: UsageStorage
     private let makeDeviceClient: (String) -> UsageClient
     private let debounceNanos: UInt64

--- a/Sources/ModelCatalog/ModelDeclaration.swift
+++ b/Sources/ModelCatalog/ModelDeclaration.swift
@@ -8,6 +8,7 @@
 // Each model contributes its own module (`Sources/Emo`, `Sources/Redact`, ...)
 // holding only that model's data, so adding a model changes nothing shared.
 
+import Foundation
 import ModelStore
 import Usage
 
@@ -31,6 +32,12 @@ public protocol ModelDeclaration: Sendable {
     /// Repo-relative entries each platform needs. Directory artifacts (e.g. a
     /// Core ML `.mlmodelc`) end in `/`. A platform absent here is unsupported.
     static var files: [ModelPlatform: [String]] { get }
+
+    /// The oldest OS this model's ARTIFACT runs on. Defaults to the package floor, so a model
+    /// whose artifact imposes nothing extra says nothing. Override when the artifact does —
+    /// and `ModelCatalogTests` checks the value against the compiled package rather than
+    /// trusting it.
+    static var osFloor: OSFloor { get }
     /// The runnable artifact for `platform` — the file the inference session is
     /// built from, as opposed to the sidecars around it.
     static func artifact(for platform: ModelPlatform) -> String
@@ -40,6 +47,8 @@ public extension ModelDeclaration {
     /// Hugging Face repo id, e.g. `"desert-ant-labs/redact"`. Uniform across the
     /// catalog, so it is derived rather than declared per model.
     static var repo: String { "desert-ant-labs/\(id)" }
+
+    static var osFloor: OSFloor { .packageFloor }
 
     /// This SDK's usage identity, attached to every emitted telemetry body's
     /// `sdk` field so usage attributes to this model rather than to the core it
@@ -72,5 +81,69 @@ public extension ModelDeclaration {
     /// Whether the model is usable offline for `directory`.
     static func isAvailable(directory: String? = nil, cacheRoot: String? = nil) -> Bool {
         distribution.isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot)
+    }
+}
+
+/// The oldest OS each Apple platform needs to run a model's artifact.
+///
+/// Data, not a comment. A model's OS requirement comes from the artifact it ships — a Core ML
+/// package records `specificationVersion` and an availability map, and refusing to load below
+/// it is the runtime's behaviour whatever the SDK claims. Declaring it here means the catalog
+/// can be checked against the artifact instead of against somebody's memory.
+///
+/// **This does NOT gate compilation.** Swift's `@available` is a compile-time attribute and
+/// cannot be computed from a value, so a model that must not COMPILE below some version still
+/// annotates its own declarations. What this gives is the other three things:
+/// a runtime refusal with a legible reason, a catalog test that every model states a floor,
+/// and one place to read when writing the README — instead of three that drift apart, which is
+/// how the manifest came to declare iOS 16 while the README promised iOS 18.
+public struct OSFloor: Sendable, Equatable {
+    public let iOS: Int
+    public let macOS: Int
+    public let tvOS: Int
+    public let visionOS: Int
+    public let watchOS: Int
+
+    public init(iOS: Int, macOS: Int, tvOS: Int, visionOS: Int, watchOS: Int) {
+        self.iOS = iOS; self.macOS = macOS; self.tvOS = tvOS
+        self.visionOS = visionOS; self.watchOS = watchOS
+    }
+
+    /// What the SDK itself supports: nothing in the model is holding it back.
+    public static let packageFloor = OSFloor(iOS: 16, macOS: 13, tvOS: 16, visionOS: 1, watchOS: 9)
+
+    /// A Core ML **multifunction** package. Two graphs over one stored copy of a shared trunk,
+    /// which is an iOS 18 feature; such an artifact reports `specificationVersion` 9.
+    public static let multifunction = OSFloor(iOS: 18, macOS: 15, tvOS: 18, visionOS: 2, watchOS: 11)
+
+    /// MLX, which has no build below this.
+    public static let mlx = OSFloor(iOS: 17, macOS: 14, tvOS: 17, visionOS: 1, watchOS: 11)
+
+    /// Is the OS running this code new enough?
+    public var isSatisfiedHere: Bool {
+        #if os(iOS)
+        return ProcessInfo.processInfo.isOperatingSystemAtLeast(
+            .init(majorVersion: iOS, minorVersion: 0, patchVersion: 0))
+        #elseif os(macOS)
+        return ProcessInfo.processInfo.isOperatingSystemAtLeast(
+            .init(majorVersion: macOS, minorVersion: 0, patchVersion: 0))
+        #elseif os(tvOS)
+        return ProcessInfo.processInfo.isOperatingSystemAtLeast(
+            .init(majorVersion: tvOS, minorVersion: 0, patchVersion: 0))
+        #elseif os(visionOS)
+        return ProcessInfo.processInfo.isOperatingSystemAtLeast(
+            .init(majorVersion: visionOS, minorVersion: 0, patchVersion: 0))
+        #elseif os(watchOS)
+        return ProcessInfo.processInfo.isOperatingSystemAtLeast(
+            .init(majorVersion: watchOS, minorVersion: 0, patchVersion: 0))
+        #else
+        return true          // non-Apple platforms do not run Core ML and are not gated by it
+        #endif
+    }
+
+    /// A sentence a developer can act on, or nil when the OS is new enough.
+    public func unmetReason(_ model: String) -> String? {
+        isSatisfiedHere ? nil : "\(model) needs iOS \(iOS) / macOS \(macOS) / tvOS \(tvOS) / "
+            + "visionOS \(visionOS) / watchOS \(watchOS); this system is older"
     }
 }

--- a/Sources/ModelStore/FoundationBackend.swift
+++ b/Sources/ModelStore/FoundationBackend.swift
@@ -65,6 +65,7 @@ public struct FoundationTransport: ModelTransport {
         let onBytes: @Sendable (Int64) -> Void
         var continuation: CheckedContinuation<HTTPURLResponse?, Error>?
         private var moveError: Error?
+        private var lastReportedBytes: Int64 = 0
 
         init(destination: URL, onBytes: @escaping @Sendable (Int64) -> Void) {
             self.destination = destination; self.onBytes = onBytes
@@ -73,6 +74,18 @@ public struct FoundationTransport: ModelTransport {
         func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
                         didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
                         totalBytesExpectedToWrite: Int64) {
+            // URLSession reports every received chunk — tens of thousands for a
+            // large weight file — and each report fans out through an actor hop
+            // downstream (`LazyLoader` spawns a Task per callback), which floods
+            // the actor badly enough that observers see only 0% and 100%.
+            // 512 KB steps keep progress sub-percent-smooth for anything over
+            // ~50 MB at a few hundred callbacks per file. The final bytes of a
+            // file always report (completion also reports via the store's
+            // per-file accounting), so nothing is lost for small files.
+            // Serial: URLSession calls the delegate on one queue.
+            guard totalBytesWritten - lastReportedBytes >= 512 * 1024
+                || totalBytesWritten == totalBytesExpectedToWrite else { return }
+            lastReportedBytes = totalBytesWritten
             onBytes(totalBytesWritten)
         }
 

--- a/Sources/Title/Catalog.swift
+++ b/Sources/Title/Catalog.swift
@@ -1,0 +1,84 @@
+// This model's catalog declaration: coordinates, file names, and which of them
+// each platform ships. The shared behaviour (distribution, resolve, availability)
+// comes from `ModelDeclaration` in the catalog's shared half.
+
+import DesertAnt
+
+/// The title model: a short factual title and a one- to two-sentence description
+/// for a passage of text.
+///
+/// **The only MLX model in this package, and the only Apple-exclusive one.** Every other
+/// model here runs through `InferenceSession` — Core ML on Apple, LiteRT elsewhere. This one
+/// does not, and the reason is measured rather than architectural: writing a title is short
+/// autoregressive decode, which the Neural Engine is bandwidth-bound for. Commit `8e97532`
+/// benchmarked the Core ML path and removed `MLState` when it lost — `CPU_AND_NE` could not
+/// build an execution plan from `model.mil` at all (error -14), and Core ML's best showing was
+/// its CPU one at 213 ms to first token against MLX's 55 ms, 86 tok/s against 447, and 1921 MB
+/// resident against 635.
+///
+/// `title-training/release/` still carries `title-coreml/`, `title-coreai/` and `title-onnx/`.
+/// Those are the losing exports kept as evidence, not pending candidates. Do not read their
+/// existence as a Core ML path waiting to be wired up.
+///
+/// **Consequences of being MLX, stated here so they are not rediscovered:**
+///
+///   * `Title` is a SEPARATE product. A consumer that only selects clips must not pay for an
+///     MLX build, which is the same reasoning that keeps JavaScriptKit off every non-wasm
+///     graph in `Package.swift`.
+///   * There is no `.android`, `.linux`, `.windows` or `.web` entry in ``files``. MLX is Apple
+///     only. `supports(_:)` therefore returns false for them, which is the honest answer
+///     rather than a manifest promising files that cannot run.
+///   * The artifact is an MLX model FOLDER (`config.json`, `model.safetensors`,
+///     `tokenizer.json`), not a compiled graph, so it does not follow the
+///     `<model>.mlmodelc` / `<model>.tflite` shape the other models share.
+public enum TitleModel: ModelDeclaration {
+    public static let id = "title"
+    public static let product = "Title"
+    /// Pinned. The exception this used to claim — "the published repo carries
+    /// `title-mlx-6bit.*`, and the file names below do not match it" — expired when the repo
+    /// was republished: all seven names in ``files`` exist at `v0.1.0`, checked against the
+    /// Hub listing.
+    ///
+    /// A justification that outlives the condition it describes is worse than none, because it
+    /// reads as a decision somebody made rather than a state nobody rechecked. `ModelCatalogTests`
+    /// permits `main` only as a documented exception, and Title is absent from that test's
+    /// catalog list, so nothing here would have caught the staleness.
+    public static let revision = "v0.1.0"
+    /// MLX has no build below macOS 14 / iOS 17. Unlike Clips this is a DEPENDENCY floor, not
+    /// an artifact one, so `Package.swift` must also rise when the MLX dependency is pulled in
+    /// — SwiftPM resolves platforms at manifest level and no declaration here can satisfy it.
+    public static let osFloor = OSFloor.mlx
+
+    public static let sdkVersion = "3.0.0"
+    public static let summary =
+        "On-device titles and descriptions: a short factual title and a one- to two-sentence "
+        + "description for any passage of text."
+
+    /// The MLX weights. 6-bit quantized Granite at roughly 280 MB — produced by
+    /// `title-training/python/quantize_mlx.py` and packaged by its `package.py`.
+    public static let weights = "model.safetensors"
+    /// Shard index. Present even for a single shard, because `ModelConfiguration` reads it.
+    public static let weightsIndex = "model.safetensors.index.json"
+    /// Architecture and quantization config. MLX reads this to build the graph.
+    public static let config = "config.json"
+    /// Decode defaults. Read by MLX, not by this SDK.
+    public static let generationConfig = "generation_config.json"
+    /// Byte-level BPE with merges — the `TTOK` family, NOT interchangeable with the `RDTK`
+    /// tokenizer `Clips` uses. Both are "a tokenizer binary" and they are different formats.
+    public static let tokenizer = "tokenizer.json"
+    public static let tokenizerConfig = "tokenizer_config.json"
+    /// The chat template the fine-tune was trained against. `MLXLMCommon` applies it, and a
+    /// different template is a different task to the model.
+    public static let chatTemplate = "chat_template.jinja"
+
+    /// APPLE ONLY. See the type's note: MLX has no other platform, and declaring a file list
+    /// for one would promise an artifact that cannot load.
+    public static let files: [ModelPlatform: [String]] = [
+        .apple: [weights, weightsIndex, config, generationConfig,
+                 tokenizer, tokenizerConfig, chatTemplate],
+    ]
+
+    /// The weights are what the shared declaration considers *the* model, though MLX loads the
+    /// whole directory rather than one file.
+    public static func artifact(for platform: ModelPlatform) -> String { weights }
+}

--- a/Sources/Title/Title.swift
+++ b/Sources/Title/Title.swift
@@ -1,0 +1,185 @@
+import DesertAnt
+import Foundation
+import Transcript
+
+// Everything MLX-backed is behind `#if MLX`, the compilation condition SwiftPM defines for the
+// `MLX` package trait (see Package.swift). Without the trait this module still compiles —
+// `Card`, the prompt, and `parse` are portable and tested everywhere — but generation is
+// absent: `Titles` has no public initializer, so a consumer that forgot the trait fails at
+// compile time instead of mis-building.
+#if MLX
+// `HuggingFace` and `Tokenizers` are imported for the MACRO, not for this file's own code:
+// `#huggingFaceLoadModelContainer` expands into references to `HubClient` and `Tokenizers`.
+// Removing them as "unused" breaks the build inside a macro expansion, where the error names
+// symbols that appear nowhere in this source.
+import HuggingFace
+import MLX
+import MLXHuggingFace
+import MLXLLM
+import MLXLMCommon
+import Tokenizers
+#endif
+
+/// A title and a description for a passage of text.
+///
+/// Owned by `Title`, deliberately, and NOT a field on ``Transcript/Clip``. Selection and card
+/// writing are separate stages on separate silicon, and a `card` property hanging off every
+/// `Clip` would be permanently nil for the many consumers that never call this module — the
+/// same reasoning that keeps `Title` a separate product. Pair them with ``Titles/cards(for:)``
+/// when you want both.
+public struct Card: Sendable, Codable, Equatable {
+    public let title: String
+    public let description: String
+
+    public init(title: String, description: String) {
+        self.title = title
+        self.description = description
+    }
+
+    /// True when the model returned neither a title nor a description. Parsing is deliberately
+    /// tolerant (see ``Titles/parse(_:)``), so an empty card is the only failure signal a
+    /// caller gets, and it should be treated as "no card" rather than as an error.
+    public var isEmpty: Bool { title.isEmpty && description.isEmpty }
+}
+
+/// Writes titles and descriptions on device.
+///
+/// **Not clip-specific.** The model was fine-tuned on transcript clips, but the task it learned
+/// is general. Measured Aug 2026 on the 6-bit Granite against a transcript clip, a news
+/// paragraph, a product description and an internal email: all four produced accurate,
+/// specific, correctly-registered cards. One slip in four — an email saying "moving the review
+/// from Tuesday to Thursday" was described as running "from Tuesday to Thursday" — so treat it
+/// as capable on general prose, not infallible on it.
+///
+/// Loading is expensive and generation is cheap: build one and reuse it. An `actor` because MLX
+/// state is not safe to drive from several tasks at once.
+///
+/// This type does NOT go through `InferenceSession`. It is the one model in this package that
+/// runs on MLX, for reasons recorded on ``TitleModel``.
+public actor Titles {
+
+    /// The prompt the model is fine-tuned against, byte for byte.
+    ///
+    /// The single definition is `title-training/python/student_prompt.py`, which `train.py`
+    /// imports to build every training example and which `tests/test_prompt_parity.py` compares
+    /// against THIS string. If they drift, that test fails.
+    ///
+    /// **The previous version of this property was a different string from the one training
+    /// used**, and the divergence was invisible from either side. Training used a short
+    /// instruction; this sent a long RULES block whose docstring sourced it to a
+    /// `gen_factual_batch.py` that does not exist. So the shipped model was served an unseen
+    /// prompt on every call, and the rule this block spent four lines on —
+    /// `NEVER begin with "The video", "This clip", "The speaker"` — had never appeared in a
+    /// training example and could not have been learned. The model went on producing those
+    /// openers at roughly the rate its TARGETS contained them, which is where the fix belongs.
+    ///
+    /// It says "passage" rather than "video clip" because the model is not clip-specific and
+    /// the old wording made every non-video caller send instructions about a video.
+    ///
+    /// No RULES block. Rules shape the TEACHER's output and therefore the targets; a student
+    /// that has learned the mapping does not need them recited, and reciting them costs prompt
+    /// tokens on every call. The teacher's prompt lives in `title-training/python/gen_cards.py`.
+    static let prompt = """
+        Write a factual title (3-8 words) and a 1-2 sentence description for this passage.\
+        Be specific enough to identify this passage. No emoji, no hashtags, no hype.\
+        Write in the same language as the passage.
+
+        PASSAGE:
+        {clip}
+        """
+
+    #if MLX
+    private let model: ModelContainer
+    private let maxTokens: Int
+
+    /// - Parameters:
+    ///   - directory: an MLX model folder — the files ``TitleModel/files`` declares. Nothing is
+    ///     bundled with this package and nothing is downloaded here; point this at a folder you
+    ///     populated.
+    ///   - maxTokens: two short lines. The cap stops a degenerate run decoding forever, which
+    ///     is a real failure mode for a small instruct model given unusual input.
+    public init(directory: URL, maxTokens: Int = 96) async throws {
+        self.model = try await #huggingFaceLoadModelContainer(
+            configuration: ModelConfiguration(directory: directory))
+        self.maxTokens = maxTokens
+    }
+
+    /// A title and description for any passage of text.
+    public func describe(_ text: String) async throws -> Card {
+        Self.parse(try await generate(
+            Self.prompt.replacingOccurrences(of: "{clip}", with: text)))
+    }
+
+    /// A card for one clip.
+    public func card(for clip: Clip) async throws -> Card {
+        try await describe(clip.text)
+    }
+
+    /// Cards for many clips, index-aligned with the input.
+    ///
+    /// Returns a parallel array rather than mutating `Clip`, so `Clips` stays unaware that this
+    /// module exists. Zip them if you want pairs.
+    ///
+    /// Sequential on purpose. Decode is already GPU-bound, so overlapping generations contend
+    /// for the same device rather than adding throughput, and on a phone it adds thermal
+    /// pressure that shows up as throttling partway through a long video.
+    public func cards(for clips: [Clip]) async throws -> [Card] {
+        var out: [Card] = []
+        out.reserveCapacity(clips.count)
+        for clip in clips {
+            out.append(try await card(for: clip))
+        }
+        return out
+    }
+
+    private func generate(_ prompt: String) async throws -> String {
+        try await model.perform { context in
+            let input = try await context.processor.prepare(
+                input: UserInput(messages: [["role": "user", "content": prompt]]))
+            // The AsyncStream `generate` — the callback variants are deprecated. The token cap
+            // moved into `GenerateParameters.maxTokens`, which stops the iterator itself; the
+            // old visitor returned `.stop` at the same count.
+            var text = ""
+            let stream = try MLXLMCommon.generate(
+                input: input,
+                parameters: GenerateParameters(
+                    maxTokens: self.maxTokens,
+                    temperature: 0.0    // deterministic cards
+                ),
+                context: context
+            )
+            for await generation in stream {
+                if case let .chunk(chunk) = generation {
+                    text += chunk
+                }
+            }
+            return text
+        }
+    }
+    #endif
+
+    /// Pull TITLE/DESC out of the reply.
+    ///
+    /// Tolerant by design: a card model that drifts off format should degrade to a usable title
+    /// rather than throw, because the clip itself is still good and selection is what ships.
+    /// `DESC` and `DESCRIPTION` are both accepted — the training data uses `DESC`, but
+    /// base-model habits leak the longer spelling through.
+    static func parse(_ raw: String) -> Card {
+        var title = "", description = ""
+        for line in raw.split(separator: "\n", omittingEmptySubsequences: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let upper = trimmed.uppercased()
+            if upper.hasPrefix("TITLE:") {
+                title = String(trimmed.dropFirst(6)).trimmingCharacters(in: .whitespaces)
+            } else if upper.hasPrefix("DESCRIPTION:") {
+                description = String(trimmed.dropFirst(12)).trimmingCharacters(in: .whitespaces)
+            } else if upper.hasPrefix("DESC:") {
+                description = String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+            } else if title.isEmpty && !trimmed.isEmpty {
+                // No label at all: take the first real line as the title rather than nothing.
+                title = trimmed
+            }
+        }
+        return Card(title: title, description: description)
+    }
+}

--- a/Sources/Transcript/Clip.swift
+++ b/Sources/Transcript/Clip.swift
@@ -1,0 +1,129 @@
+/// A span of a recording, in seconds.
+public struct TimeRange: Sendable, Equatable {
+    /// The time the span begins, in seconds from the start of the recording.
+    public let start: Double
+
+    /// The time the span ends, in seconds from the start of the recording.
+    public let end: Double
+
+    /// The length of the span, in seconds.
+    public var duration: Double { end - start }
+
+    /// Creates a span between the given times.
+    ///
+    /// - Parameters:
+    ///   - start: The start time, in seconds.
+    ///   - end: The end time, in seconds. Clamped to no earlier than `start`.
+    public init(start: Double, end: Double) {
+        self.start = start
+        self.end = max(start, end)
+    }
+}
+
+/// A set of transcript sentences selected as a moment worth publishing.
+///
+/// Selection returns clips in descending order of `score`, and no two clips
+/// share a sentence.
+public struct Clip: Identifiable, Sendable, Equatable {
+    /// The clip's rank in the selected set, where `0` is the highest scoring.
+    public let id: Int
+
+    /// The positions of the sentences that make up the clip, in ascending order.
+    public let sentenceIDs: [Int]
+
+    /// The clip's sentences, joined with spaces.
+    public let text: String
+
+    /// The score the model gave the clip.
+    ///
+    /// Comparable only among clips selected from the same transcript. Use
+    /// `percentile` to compare across transcripts or to apply a threshold.
+    public let score: Double
+
+    /// The clip's rank within its transcript, from `0` to `1`.
+    public let percentile: Double
+
+    /// The estimated spoken length of `text`, in seconds.
+    ///
+    /// Estimated from word count. For the length the clip plays for, call
+    /// `duration(in:padding:)`.
+    public let estimatedDurationSec: Double
+
+    /// Creates a clip.
+    ///
+    /// - Parameters:
+    ///   - id: The clip's rank in the selected set.
+    ///   - sentenceIDs: The positions of the sentences the clip contains.
+    ///   - text: The clip's sentences, joined with spaces.
+    ///   - score: The score the model gave the clip.
+    ///   - percentile: The clip's rank within its transcript, from `0` to `1`.
+    ///   - estimatedDurationSec: The estimated spoken length of `text`.
+    public init(id: Int, sentenceIDs: [Int], text: String, score: Double,
+                percentile: Double, estimatedDurationSec: Double) {
+        self.id = id
+        self.sentenceIDs = sentenceIDs
+        self.text = text
+        self.score = score
+        self.percentile = percentile
+        self.estimatedDurationSec = estimatedDurationSec
+    }
+}
+
+public extension Clip {
+    /// Returns the spans of the recording the clip plays.
+    ///
+    /// Sentences spoken without a gap between them produce a single span, and
+    /// sentences separated by a pause produce one span each, so that the pause
+    /// is cut rather than played. Spans that overlap once padded are combined.
+    ///
+    /// Each end is padded by half the silence before the neighbouring sentence,
+    /// up to `padding`. Speech that runs straight into the next sentence takes
+    /// none, so a cut never reaches into a neighbouring word, while word
+    /// boundaries accurate only to tens of milliseconds are still covered
+    /// wherever there is room.
+    ///
+    /// Sentence positions absent from `transcript` are ignored.
+    ///
+    /// - Parameters:
+    ///   - transcript: The sentences the clip was selected from.
+    ///   - padding: The greatest time to add to either end of a span, in
+    ///     seconds.
+    /// - Returns: The spans to play, in ascending order of `start`.
+    func ranges(in transcript: [Sentence], padding: Double = 0.15) -> [TimeRange] {
+        let byID = Dictionary(transcript.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
+        let spans = sentenceIDs.sorted().compactMap { id -> TimeRange? in
+            guard let sentence = byID[id] else { return nil }
+            let before = byID[id - 1].map { sentence.start - $0.end } ?? sentence.start
+            let after = byID[id + 1].map { $0.start - sentence.end } ?? .infinity
+            return TimeRange(start: max(0, sentence.start - Self.share(of: before, upTo: padding)),
+                             end: sentence.end + Self.share(of: after, upTo: padding))
+        }
+
+        return spans.reduce(into: []) { merged, span in
+            guard let last = merged.last, span.start <= last.end else {
+                merged.append(span)
+                return
+            }
+            merged[merged.count - 1] = TimeRange(start: last.start, end: max(last.end, span.end))
+        }
+    }
+
+    /// Half of a silence, up to `limit`. Zero where neighbouring speech runs
+    /// straight in, and the full `limit` where nothing follows.
+    private static func share(of gap: Double, upTo limit: Double) -> Double {
+        guard gap > 0 else { return 0 }
+        return gap.isFinite ? min(limit, gap / 2) : limit
+    }
+
+    /// Returns the length the clip plays for, in seconds.
+    ///
+    /// The total of the clip's spans, excluding any pauses cut between them.
+    ///
+    /// - Parameters:
+    ///   - transcript: The sentences the clip was selected from.
+    ///   - padding: Time added to both ends of every span, in seconds.
+    func duration(in transcript: [Sentence], padding: Double = 0.15) -> Double {
+        ranges(in: transcript, padding: padding).reduce(0) { $0 + $1.duration }
+    }
+}

--- a/Sources/Transcript/Sentence.swift
+++ b/Sources/Transcript/Sentence.swift
@@ -1,0 +1,107 @@
+/// A sentence of transcribed speech, and the span of the recording it occupies.
+public struct Sentence: Identifiable, Sendable, Equatable {
+    /// The sentence's position in the transcript, numbered from zero.
+    ///
+    /// Clip selection identifies sentences by this index, so a transcript
+    /// reordered or renumbered after selection resolves to different audio.
+    public let id: Int
+
+    /// The sentence text, with leading and trailing whitespace removed.
+    public let text: String
+
+    /// The time the sentence begins, in seconds from the start of the recording.
+    public let start: Double
+
+    /// The time the sentence ends, in seconds from the start of the recording.
+    public let end: Double
+
+    /// The length of the sentence, in seconds.
+    public var duration: Double { end - start }
+
+    /// Creates a sentence spanning the given times.
+    ///
+    /// - Parameters:
+    ///   - id: The sentence's position in the transcript.
+    ///   - text: The sentence text.
+    ///   - start: The start time, in seconds.
+    ///   - end: The end time, in seconds. Clamped to no earlier than `start`.
+    public init(id: Int, text: String, start: Double, end: Double) {
+        self.id = id
+        self.text = text
+        self.start = start
+        self.end = max(start, end)
+    }
+}
+
+public extension Sentence {
+    /// Groups a recognizer's timed words into sentences.
+    ///
+    /// A sentence ends at terminal punctuation. Speech transcribed without
+    /// punctuation is broken at `runOnLimit` characters instead, so that a
+    /// transcript always presents more than one sentence to choose between.
+    ///
+    /// Each sentence spans from the start of its first placed word to the end
+    /// of its last. Words the recognizer could not place contribute their text
+    /// but not their times.
+    ///
+    /// - Parameters:
+    ///   - words: The recognized words, in the order they were spoken.
+    ///   - runOnLimit: The character count at which unpunctuated speech is
+    ///     broken into a new sentence.
+    /// - Returns: The sentences, numbered from zero. Empty if `words` contains
+    ///   no text.
+    static func sentences(from words: [TimedWord], runOnLimit: Int = 320) -> [Sentence] {
+        var sentences: [Sentence] = []
+        var pending = Pending(runOnLimit: runOnLimit)
+
+        for word in words {
+            if pending.isEmpty, word.text.allSatisfy(\.isWhitespace) { continue }
+
+            pending.append(word)
+            guard pending.closesSentence else { continue }
+            if let sentence = pending.take(id: sentences.count) { sentences.append(sentence) }
+        }
+
+        if let sentence = pending.take(id: sentences.count) { sentences.append(sentence) }
+        return sentences
+    }
+}
+
+/// Accumulates words until they make a sentence.
+private struct Pending {
+    let runOnLimit: Int
+    private var text = ""
+    private var start: Double?
+    private var end = 0.0
+
+    init(runOnLimit: Int) { self.runOnLimit = runOnLimit }
+
+    var isEmpty: Bool { start == nil }
+
+    var closesSentence: Bool {
+        let trimmed = text.trimmed
+        guard let last = trimmed.last else { return false }
+        // A lone terminator is punctuation the recognizer emitted as its own word.
+        return ".!?…".contains(last) ? trimmed.count > 1 : trimmed.count >= runOnLimit
+    }
+
+    mutating func append(_ word: TimedWord) {
+        text += word.text
+        guard word.isTimed else { return }
+        if start == nil { start = word.start }
+        end = word.end
+    }
+
+    mutating func take(id: Int) -> Sentence? {
+        defer { self = Pending(runOnLimit: runOnLimit) }
+        let trimmed = text.trimmed
+        guard !trimmed.isEmpty, let start else { return nil }
+        return Sentence(id: id, text: trimmed, start: start, end: end)
+    }
+}
+
+private extension String {
+    var trimmed: String {
+        String(drop(while: \.isWhitespace).reversed().drop(while: \.isWhitespace).reversed())
+    }
+}

--- a/Sources/Transcript/TimedWord.swift
+++ b/Sources/Transcript/TimedWord.swift
@@ -1,0 +1,37 @@
+/// A word recognized in audio, and the span of the recording it occupies.
+///
+/// Times are in seconds from the start of the recording. `text` is preserved
+/// exactly as the recognizer emitted it, including any leading whitespace.
+public struct TimedWord: Sendable, Equatable {
+    /// The recognized text, including surrounding whitespace.
+    public let text: String
+
+    /// The time the word begins, in seconds from the start of the recording.
+    public let start: Double
+
+    /// The time the word ends, in seconds from the start of the recording.
+    ///
+    /// Never earlier than `start`.
+    public let end: Double
+
+    /// The length of the word, in seconds.
+    public var duration: Double { end - start }
+
+    /// Creates a word spanning the given times.
+    ///
+    /// - Parameters:
+    ///   - text: The recognized text.
+    ///   - start: The start time, in seconds.
+    ///   - end: The end time, in seconds. Clamped to no earlier than `start`.
+    public init(text: String, start: Double, end: Double) {
+        self.text = text
+        self.start = start
+        self.end = max(start, end)
+    }
+
+    /// A Boolean value indicating whether the word carries a usable time.
+    ///
+    /// Recognizers report a word they could not place with a negative or
+    /// non-finite time.
+    var isTimed: Bool { start.isFinite && end.isFinite && start >= 0 }
+}

--- a/Tests/ClipsTests/ClipTests.swift
+++ b/Tests/ClipsTests/ClipTests.swift
@@ -1,0 +1,303 @@
+import Foundation
+import Testing
+import DesertAnt
+@testable import Clips
+
+/// Selection's non-model half: the discourse features the selector is fed, the
+/// candidate spans, the non-overlapping choice, and the near-duplicate cut.
+///
+/// These run everywhere and need no artifact, which is the point: every one of
+/// them guards a constant that has to agree with training (`budget`, the
+/// feature order, the span bounds) or a rule a reader notices immediately
+/// (duplicates). The model-backed end-to-end suite arrives with the published
+/// Hub artifacts; `HubDownloadTests` is the network-gated half that exists today.
+struct ClipPipelineTests {
+    /// The budget is an UPPER LIMIT set by DURATION, and it is the same rule
+    /// `python/construct.py`'s `clip_budget` applies: 8 under 5 minutes, 11 to 10,
+    /// 13 to 30, 14 beyond, at 2.5 words per second.
+    ///
+    /// This test previously asserted `n // 4` capped at 12 and called it "the same
+    /// number train and eval use". It never was: the offline path capped at a literal
+    /// 6, which bound on 79% of the frozen holdout. The two paths emitted different
+    /// clip counts from identical input and only one of them was ever evaluated.
+    @Test func budgetIsTheDurationCeilingSharedWithTrainEval() {
+        // 2.5 words/sec => 150 words per minute.
+        func transcript(minutes: Double) -> [String] {
+            let words = Int(minutes * 60 * 2.5)
+            return (0..<(words / 5)).map { _ in "one two three four five" }
+        }
+        #expect(Pipeline.budget(for: transcript(minutes: 1)) == 8)
+        #expect(Pipeline.budget(for: transcript(minutes: 4.9)) == 8)
+        #expect(Pipeline.budget(for: transcript(minutes: 7)) == 11)
+        #expect(Pipeline.budget(for: transcript(minutes: 20)) == 13)
+        #expect(Pipeline.budget(for: transcript(minutes: 45)) == 14)
+        #expect(Pipeline.budget(for: transcript(minutes: 300)) == 14, "14 is the ceiling")
+        // An empty transcript must not divide by zero or return something enormous.
+        #expect(Pipeline.budget(for: []) == 8)
+    }
+
+    /// A limit SIZES the selection, it does not trim the result — and the two differ in
+    /// content, not just in cost. The best set of two is not the best set of three minus one.
+    @Test func aLimitSizesTheSelectionRatherThanTrimmingIt() {
+        // Three disjoint spans. At budget 3 the DP takes all three; at budget 2 it takes the
+        // two highest-scoring, which is NOT "the first two of the three by score" in general —
+        // here it is, because they are disjoint, so the sharper check is on the BUDGET path.
+        let transcript = (0..<12).map { "sentence number \($0) with distinct words \($0)" }
+        let candidates = [Array(0...2), Array(4...6), Array(8...10)]
+        let all = Pipeline.rank(candidates: candidates, scores: [0.2, 0.9, 0.5],
+                                transcript: transcript, limit: nil)
+        let two = Pipeline.rank(candidates: candidates, scores: [0.2, 0.9, 0.5],
+                                transcript: transcript, limit: 2)
+        #expect(all.count == 3)
+        #expect(two.count == 2, "the limit bounds the emitted set")
+        #expect(two.map(\.score) == [0.9, 0.5], "and it keeps the best, not the first")
+        // The ceiling reaches the POOL, which is where the latency lives.
+        #expect(Pipeline.budget(for: transcript, limit: 2) == 2)
+        #expect(Pipeline.budget(for: transcript, limit: nil) == Pipeline.budget(for: transcript))
+        #expect(Pipeline.budget(for: transcript, limit: 0) == 1, "a zero limit is floored at 1")
+    }
+
+    /// Weighted interval scheduling takes the best-scoring compatible set, not
+    /// the greedy claim order: two good spans beat one better one.
+    @Test func selectionPrefersTheBestCompatibleSet() {
+        let chosen = Pipeline.selectNonOverlapping(
+            [(0, 9, 10.0), (0, 3, 6.0), (5, 9, 6.0)], budget: 4)
+        #expect(chosen.map { [$0.0, $0.1] } == [[0, 3], [5, 9]])
+    }
+
+    @Test func selectionNeverOverlaps() {
+        let spans: [(Int, Int, Double)] = [(0, 4, 5), (3, 7, 9), (6, 10, 4), (8, 12, 7)]
+        let chosen = Pipeline.selectNonOverlapping(spans, budget: 3).sorted { $0.0 < $1.0 }
+        for (a, b) in zip(chosen, chosen.dropFirst()) {
+            #expect(a.1 < b.0, "spans \(a) and \(b) overlap")
+        }
+    }
+
+    @Test func selectionRespectsTheBudget() {
+        let spans = (0..<20).map { (i: Int) in (i * 2, i * 2 + 1, Double(i)) }
+        #expect(Pipeline.selectNonOverlapping(spans, budget: 3).count == 3)
+        #expect(Pipeline.selectNonOverlapping(spans, budget: 0).isEmpty)
+    }
+
+    /// Readers punish duplicates hard, so a span repeating a kept one goes.
+    @Test func dedupeDropsNearDuplicates() {
+        let transcript = ["alpha beta gamma", "delta epsilon zeta", "eta theta iota"]
+        let kept = Pipeline.dedupe([(0, 1, 9.0), (0, 1, 8.0), (2, 2, 7.0)], transcript: transcript)
+        #expect(kept.count == 2)
+        #expect(kept.map(\.2) == [9.0, 7.0], "the first (higher) of a duplicate pair is kept")
+    }
+
+    @Test func dedupeKeepsDistinctMoments() {
+        let transcript = ["alpha beta", "gamma delta", "epsilon zeta", "eta theta"]
+        let kept = Pipeline.dedupe([(0, 1, 9.0), (2, 3, 8.0)], transcript: transcript)
+        #expect(kept.count == 2)
+    }
+
+    /// Candidates stay inside the trained span length and the anchor window.
+    @Test func candidatesRespectTheSpanBounds() {
+        let saliency = (0..<40).map { Double(40 - $0) }
+        let candidates = Pipeline.enumerateCandidates(count: 40, saliency: saliency, budget: 10)
+        #expect(!candidates.isEmpty)
+        for span in candidates {
+            #expect(span.count >= Pipeline.minSentences && span.count <= Pipeline.maxSentences)
+            #expect(span == Array(span.first!...span.last!), "candidates are contiguous runs")
+            #expect(span.first! >= 0 && span.last! < 40)
+        }
+        #expect(Set(candidates).count == candidates.count, "candidates are deduplicated")
+    }
+
+    @Test func candidatesAreEmptyForATranscriptShorterThanASpan() {
+        #expect(Pipeline.enumerateCandidates(count: 2, saliency: [1, 0], budget: 8).isEmpty)
+    }
+
+    /// The 5 scalars the heads were trained with, in order:
+    /// [position, hookCount, payoffCount, endsWithQuestion, digitRatio].
+    /// Position FIRST, and the middle two are COUNTS of matching patterns, not
+    /// booleans - an earlier hand-written version had all five wrong.
+    @Test func discourseFeaturesAreOrderedAsInTraining() {
+        let plain = Pipeline.discourseFeatures("the cat sat on the mat", position: 0.25)
+        #expect(plain.count == 5)
+        #expect(plain[0] == 0.25, "position comes first")
+        #expect(plain[1] == 0 && plain[2] == 0)
+        #expect(plain[3] == 0)
+        #expect(plain[4] == 0)
+    }
+
+    @Test func discourseFeaturesCountPatternsRatherThanFlagThem() {
+        // "Here's why nobody ever..." matches \bhere'?s\b, \bwhy\b, nobody, and
+        // \b(never|always|everyone|no one|nobody)\b: four hook patterns, so the
+        // feature is 4 and not 1.
+        let many = Pipeline.discourseFeatures("Here's why nobody ever wins", position: 0)
+        #expect(many[1] == 4, "hook features are a count of matching patterns, got \(many[1])")
+    }
+
+    @Test func discourseFeaturesDetectQuestionsAndDigits() {
+        let question = Pipeline.discourseFeatures("what if it is true?  ", position: 0)
+        #expect(question[3] == 1, "trailing whitespace must not hide the question mark")
+        let digits = Pipeline.discourseFeatures("1234", position: 0)
+        #expect(abs(digits[4] - 4.0 / 5.0) < 1e-6, "digits over character count plus one")
+    }
+
+    @Test func rankingIsBestFirstWithPercentileSpanningTheList() {
+        let transcript = (0..<12).map { "sentence number \($0) with distinct words \($0)" }
+        let candidates = [Array(0...2), Array(4...6), Array(8...10)]
+        let moments = Pipeline.rank(
+            candidates: candidates, scores: [0.2, 0.9, 0.5], transcript: transcript, limit: nil)
+        #expect(moments.map(\.score) == [0.9, 0.5, 0.2], "best first")
+        #expect(moments.map(\.id) == [0, 1, 2])
+        #expect(moments.first?.percentile == 1.0)
+        #expect(moments.last?.percentile == 0.0)
+        #expect(moments.allSatisfy { (0...1).contains($0.percentile) })
+        #expect(moments.first?.sentenceIDs == [4, 5, 6])
+        #expect(moments.first?.text == candidates[1].map { transcript[$0] }.joined(separator: " "))
+    }
+
+    @Test func aSingleMomentIsTheTopPercentile() {
+        let transcript = (0..<6).map { "word\($0) alpha\($0) beta\($0)" }
+        let moments = Pipeline.rank(
+            candidates: [Array(0...2)], scores: [0.4], transcript: transcript, limit: nil)
+        #expect(moments.count == 1)
+        #expect(moments[0].percentile == 1.0, "one moment must not divide by zero")
+    }
+}
+
+/// The tokenizer's truncation contract, over a synthetic vocab so it needs no
+/// download. This is the invariant that cost real quality: HuggingFace's
+/// `truncation=True, max_length=` KEEPS the eos, and a plain `prefix(maxLength)`
+/// silently replaces it with one more content token, so every span longer than
+/// the bucket is scored on input the model never saw in training.
+struct ClipTokenizerTests {
+    @Test func truncationKeepsTheEndOfSequenceToken() throws {
+        let tokenizer = try #require(Tokenizer(bytes: syntheticVocab()))
+        let long = String(repeating: "a b c ", count: 20)
+        let ids = tokenizer.encode(long, maxLength: 8)
+        #expect(ids.count == 8)
+        #expect(ids.first == Int32(tokenizer.bosID))
+        #expect(ids.last == Int32(tokenizer.eosID), "truncation must keep </s>, not drop it")
+    }
+
+    @Test func shortInputIsNotTruncated() throws {
+        let tokenizer = try #require(Tokenizer(bytes: syntheticVocab()))
+        let ids = tokenizer.encode("a b", maxLength: 128)
+        #expect(ids.first == Int32(tokenizer.bosID))
+        #expect(ids.last == Int32(tokenizer.eosID))
+        #expect(ids.count == 4, "<s> ▁a ▁b </s>")
+    }
+
+    @Test func aMalformedVocabIsRejectedRatherThanGuessed() {
+        #expect(Tokenizer(bytes: [0x00, 0x01, 0x02, 0x03, 0x04]) == nil)
+        #expect(Tokenizer(bytes: Array(syntheticVocab().dropLast(4))) == nil)
+    }
+
+    /// Two vocab pieces that are byte-distinct but *canonically equivalent* must
+    /// stay two pieces. Swift's `String` equality is canonical equivalence, so a
+    /// `[String: Int]` vocab merges them into one key and the later id evicts the
+    /// earlier - after which nothing can ever produce it, and the loader's own
+    /// "every piece landed in the index" check fails, which is why a `String`-keyed
+    /// index cannot load the real 250,002-piece vocab at all.
+    @Test func canonicallyEquivalentPiecesStayDistinct() throws {
+        // ▁ + Kannada VOWEL SIGN OO, then ▁ + the VOWEL SIGN O and LENGTH MARK it
+        // decomposes to. The same pair, in the same order, as ids 9440 and 80321
+        // in xlm-roberta-base.
+        let precomposed = "\u{2581}\u{0CCB}"
+        let decomposed = "\u{2581}\u{0CCA}\u{0CD5}"
+        #expect(precomposed == decomposed, "the premise: Swift calls these equal")
+        #expect(Array(precomposed.utf8) != Array(decomposed.utf8), "but they are not the same bytes")
+
+        let vocab = vocabBytes(
+            pieces: ["<s>", "<pad>", "</s>", "<unk>", precomposed, decomposed],
+            scores: [0, 0, 0, 0, -1, -1])
+        let tokenizer = try #require(Tokenizer(bytes: vocab), "a colliding vocab must still load")
+        // The reachable piece is the earlier id, so `String` keying evicts exactly
+        // the one the input needs and this comes back as `<unk>`.
+        #expect(tokenizer.encode("\u{0CCB}", maxLength: 128) == [0, 4, 2])
+    }
+
+}
+
+/// A minimal vocab in the compact container `Tokenizer` reads: `<s>`, `<pad>`,
+/// `</s>`, `<unk>` at the xlm-roberta ids, then `▁a`, `▁b`, `▁c`.
+func syntheticVocab() -> [UInt8] {
+    vocabBytes(
+        pieces: ["<s>", "<pad>", "</s>", "<unk>", "\u{2581}a", "\u{2581}b", "\u{2581}c"],
+        scores: [0, 0, 0, 0, -1, -1, -1])
+}
+
+/// The compact container, written the way `build_tokenizer_bin.py` writes it, so
+/// a test can state a vocab as pieces rather than as a byte literal. `<unk>`,
+/// `<s>` and `</s>` are at the xlm-roberta ids 3, 0 and 2.
+func vocabBytes(pieces: [String], scores: [Float]) -> [UInt8] {
+    var bytes: [UInt8] = [0x52, 0x44, 0x54, 0x4B, 0x01]  // "RDTK" + version
+    func int32(_ value: Int) {
+        let bits = UInt32(bitPattern: Int32(value))
+        bytes.append(contentsOf: (0..<4).map { UInt8((bits >> (8 * $0)) & 0xFF) })
+    }
+    int32(3)  // unk
+    int32(0)  // bos
+    int32(2)  // eos
+    int32(pieces.count)
+    for score in scores {
+        let bits = score.bitPattern
+        bytes.append(contentsOf: (0..<4).map { UInt8((bits >> (8 * $0)) & 0xFF) })
+    }
+    for piece in pieces {
+        let length = Array(piece.utf8).count
+        bytes.append(UInt8(length & 0xFF))
+        bytes.append(UInt8((length >> 8) & 0xFF))
+    }
+    for piece in pieces { bytes.append(contentsOf: Array(piece.utf8)) }
+    return bytes
+}
+
+/// The catalog declaration, which is the model's whole contract with tooling.
+struct ClipCatalogTests {
+    /// Selection runs two graphs, and both must be in the platform manifest -
+    /// the shared `manifestsContainTheirArtifact` only proves the first.
+    @Test func everyPlatformShipsBothHalvesAndTheTokenizer() {
+        for (platform, files) in ClipModel.files {
+            let selector = ClipModel.selector(for: platform)
+            let scorer = ClipModel.scorer(for: platform)
+            #expect(selector != scorer,
+                    "\(platform.rawValue): the two halves must be addressable apart")
+            for export in [selector, scorer] {
+                #expect(files.contains(export.file) || files.contains(export.file + "/"),
+                        "\(platform.rawValue): manifest is missing \(export.file)")
+            }
+            #expect(files.contains(ClipModel.tokenizer),
+                    "\(platform.rawValue): manifest is missing the tokenizer")
+        }
+    }
+
+    /// Apple ships ONE asset carrying both graphs over the encoder they share -
+    /// 281 MB rather than the 535 MB two packages cost - so there the file name
+    /// cannot tell the halves apart and the function name is what does. A path
+    /// with no function is not a model: Core ML loads the package's default and
+    /// says nothing, which would run the selector for both halves.
+    ///
+    /// LiteRT has no multifunction packaging, so everywhere else the halves are
+    /// two files and name no function.
+    @Test func appleAddressesOneAssetByFunctionAndEveryoneElseByFile() {
+        let selector = ClipModel.selector(for: .apple)
+        let scorer = ClipModel.scorer(for: .apple)
+        #expect(selector.file == ClipModel.coreML && scorer.file == ClipModel.coreML)
+        #expect(selector.function == "select" && scorer.function == "score")
+        #expect(ClipModel.artifact(for: .apple) == ClipModel.coreML)
+        #expect(ClipModel.files[.apple] == [ClipModel.coreML + "/", ClipModel.tokenizer])
+
+        for platform in [ModelPlatform.linux, .android, .windows] {
+            let selector = ClipModel.selector(for: platform)
+            let scorer = ClipModel.scorer(for: platform)
+            #expect(selector.file != scorer.file, "\(platform.rawValue): two files, not one")
+            #expect(selector.function == nil && scorer.function == nil,
+                    "\(platform.rawValue): LiteRT has no function to name")
+        }
+    }
+
+    /// No `.web` manifest: the wasm host holds one compiled model per module and
+    /// selection needs two sessions. Declaring web files would resolve artifacts
+    /// the browser could not both compile.
+    @Test func webIsNotClaimed() {
+        #expect(!ClipModel.supports(.web))
+        #expect(ClipModel.supports(.apple) && ClipModel.supports(.linux) && ClipModel.supports(.android))
+    }
+}

--- a/Tests/ClipsTests/HubDownloadTests.swift
+++ b/Tests/ClipsTests/HubDownloadTests.swift
@@ -1,0 +1,46 @@
+#if !os(WASI)
+import XCTest
+import TestSupport
+@testable import Clips
+
+/// The Hub integration path, shared with every other model SDK and gated on
+/// `HF_INTEGRATION=1` so a normal run needs no network.
+///
+/// This is the only end-to-end test Clips has today, and it is skipped by
+/// default: the published repo carries no tag whose file names match
+/// `ClipModel` yet (see the `revision` note there), so there is nothing to
+/// download. The selection logic that does not need an artifact is covered
+/// unconditionally in `ClipTests.swift`.
+final class HubDownloadTests: XCTestCase {
+    func testDownloadThenSelect() async throws {
+        try await HubDownloadScenario.run(
+            ClipModel.self,
+            make: { Clips(directory: $0) },
+            isDownloaded: { $0.isDownloaded() },
+            download: { try await $0.download(progress: $1) }
+        ) { clip, cached in
+            let transcript = [
+                "Here's the mistake almost everyone makes with their first rental.",
+                "They price it at what they need to cover the mortgage.",
+                "The market does not care what your mortgage is.",
+                "So the unit sits empty for two months.",
+                "That's why an empty month costs more than a lower rent.",
+                "Price it to fill, then raise it at renewal.",
+                "The second year is where the return actually shows up.",
+                "Most people quit before they get there.",
+            ]
+            let moments = try await clip.clips(in: transcript)
+            XCTAssertFalse(moments.isEmpty)
+            XCTAssertEqual(moments.map(\.score), moments.map(\.score).sorted(by: >))
+            XCTAssertTrue(moments.allSatisfy { (0...1).contains($0.percentile) })
+            for moment in moments {
+                XCTAssertEqual(moment.sentenceIDs, Array(moment.sentenceIDs.sorted()))
+                XCTAssertTrue(moment.sentenceIDs.allSatisfy { transcript.indices.contains($0) })
+            }
+
+            let limited = try await cached.clips(in: transcript, limit: 1)
+            XCTAssertLessThanOrEqual(limited.count, 1)
+        }
+    }
+}
+#endif

--- a/Tests/ClipsTests/ShippingArtifactTests.swift
+++ b/Tests/ClipsTests/ShippingArtifactTests.swift
@@ -1,0 +1,116 @@
+#if canImport(CoreML) && !os(WASI)
+import Foundation
+import Testing
+import DesertAnt
+@_spi(ClipBindings) @testable import Clips
+
+/// CLAUDE.md rule 11, as a test: decode real output from the artifact that
+/// ships, through the consumer surface, before anything is pushed.
+///
+/// The rest of `ClipsTests` runs against a 24 KB weightless fixture. That is the
+/// right shape for testing the loading contract - it proves a path names the
+/// file and not the graph - but it deliberately does not carry weights, so a
+/// green run of that suite says nothing about whether the shipping 281 MB
+/// package produces clips a reader would accept. The distinction is the one
+/// rule 11 exists for: a prompt-identity check validates the prompt, not the
+/// parser, and a fixture check validates the loader, not the model.
+///
+/// Opt in by pointing these at a resolved model directory and the reference
+/// transcripts, because the assets are 268 MB and not in the repo:
+///
+///     DAL_CLIP_REAL_MODEL_DIR=<dir with clips.mlmodelc + clip_tokenizer.bin> \
+///     DAL_CLIP_REAL_TRANSCRIPTS=<clips-training/release/clip/test_transcripts.json> \
+///     swift test --filter ShippingArtifact
+///
+/// Build the two assets with:
+///
+///     python python/build_tokenizer_bin.py release/clip/tokenizer/tokenizer.json \
+///            -o <dir>/clip_tokenizer.bin
+///     xcrun coremlcompiler compile \
+///            release/clip-mf/mf/int8_linear_perchannel.mlpackage <dir>
+///     mv <dir>/int8_linear_perchannel.mlmodelc <dir>/clips.mlmodelc
+@Suite(.enabled(if: realAssetsPresent, "set DAL_CLIP_REAL_MODEL_DIR + DAL_CLIP_REAL_TRANSCRIPTS"))
+struct ShippingArtifactTests {
+
+    /// Real weights, real vocab, real transcripts, through `Model.clips(in:)`.
+    ///
+    /// The assertions are the ones a consumer's correctness depends on, not a
+    /// quality bar: quality is settled by blind reads, and no test can stand in
+    /// for one. What this pins is that the shipping bytes produce *decodable*
+    /// clips - indices addressable in the caller's own array, text that is not
+    /// empty, an ordering the API promises, and no overlap between moments.
+    /// Every one of those has been wrong at some point in this model's history
+    /// while a numeric gate stayed green.
+    @Test func theShippingPackageProducesDecodableClips() async throws {
+        let model = try Model(assets: await ModelAssets.clip(files: try realModelDirectory(), computeUnits: .cpuAndNeuralEngine))
+        var totalClips = 0
+
+        for sample in try referenceTranscripts() {
+            let transcript = sample.sentences
+            // `limit: nil` = the duration curve, i.e. what the model itself would emit. Rule 11 is
+            // about whether the shipping bytes decode, so it should not be measured through a
+            // product ceiling that a host can change.
+            let moments = try await model.clips(in: transcript, limit: nil)
+
+            #expect(!moments.isEmpty,
+                    "\(sample.stratum)/\(transcript.count) sentences returned no clips at all")
+            totalClips += moments.count
+
+            for moment in moments {
+                #expect(!moment.sentenceIDs.isEmpty, "a clip with no sentences is not decodable")
+                #expect(moment.sentenceIDs.allSatisfy { transcript.indices.contains($0) },
+                        "sentence id outside the caller's transcript: \(moment.sentenceIDs)")
+                #expect(moment.sentenceIDs == Array(moment.sentenceIDs.sorted()),
+                        "sentence ids must be ascending to slice a transcript with")
+                #expect(!moment.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                        "empty clip text decodes to nothing a user can watch")
+                #expect(moment.estimatedDurationSec > 0)
+                #expect(moment.score.isFinite, "a NaN score would sort arbitrarily")
+            }
+
+            // Rank order is part of the API: callers take the first N.
+            #expect(moments.map(\.score) == moments.map(\.score).sorted(by: >),
+                    "\(sample.stratum): clips must come back best-first")
+
+            // Non-overlapping is the product promise the DP exists to keep.
+            let spans = moments.map { ($0.sentenceIDs.first!, $0.sentenceIDs.last!) }
+                .sorted { $0.0 < $1.0 }
+            for (earlier, later) in zip(spans, spans.dropFirst()) {
+                #expect(earlier.1 < later.0,
+                        "\(sample.stratum): clips overlap at \(earlier) / \(later)")
+            }
+        }
+
+        #expect(totalClips > 0)
+    }
+
+    // MARK: assets
+
+    private struct Sample: Decodable {
+        let stratum: String
+        let sentences: [String]
+    }
+
+    private func referenceTranscripts() throws -> [Sample] {
+        let path = try #require(ProcessInfo.processInfo.environment["DAL_CLIP_REAL_TRANSCRIPTS"])
+        return try JSONDecoder().decode([Sample].self,
+                                        from: Data(contentsOf: URL(fileURLWithPath: path)))
+    }
+
+    private func realModelDirectory() throws -> StoredModel {
+        let root = try #require(ProcessInfo.processInfo.environment["DAL_CLIP_REAL_MODEL_DIR"])
+        for asset in [ClipModel.coreML, ClipModel.tokenizer] {
+            #expect(FileManager.default.fileExists(atPath: root + "/" + asset),
+                    "\(asset) missing from \(root); see this file's header for how to build it")
+        }
+        return try StoredModel.platformLocal(rootPath: root)
+    }
+}
+
+private let realAssetsPresent: Bool = {
+    let env = ProcessInfo.processInfo.environment
+    guard let dir = env["DAL_CLIP_REAL_MODEL_DIR"], env["DAL_CLIP_REAL_TRANSCRIPTS"] != nil
+    else { return false }
+    return FileManager.default.fileExists(atPath: dir + "/" + ClipModel.coreML)
+}()
+#endif

--- a/Tests/ModelCatalogTests/ModelCatalogTests.swift
+++ b/Tests/ModelCatalogTests/ModelCatalogTests.swift
@@ -7,6 +7,7 @@ import DesertAnt
 @testable import Uhm
 @testable import Gist
 @testable import Tongue
+@testable import Clips
 
 /// Every model in the monorepo. The list lives here rather than beside the
 /// `ModelDeclaration` protocol because each model's module depends on the
@@ -19,6 +20,7 @@ let catalog: [any ModelDeclaration.Type] = [
     UhmModel.self,
     GistModel.self,
     TongueModel.self,
+    ClipModel.self,
 ]
 
 /// Invariants every catalog entry must hold, so a malformed declaration fails
@@ -164,4 +166,59 @@ private func firstSemanticVersion(in line: Substring) -> String? {
         i = j + 1
     }
     return nil
+}
+
+/// The declared OS floor must match the artifact, not somebody's memory.
+///
+/// This is the check that makes `osFloor` worth having. A comment saying "needs iOS 18" rots
+/// silently; a value the catalog states and a test reads off the COMPILED PACKAGE cannot. The
+/// defect it exists to catch already happened twice on this repo: `Package.swift` declared
+/// iOS 16 while `README.md` promised iOS 18, and `ClipModel.revision` carried a justification
+/// that had stopped being true.
+@Suite("Model OS floors")
+struct ModelOSFloorTests {
+
+    /// A Core ML package states its own availability. Read it and compare.
+    ///
+    /// Skips loudly rather than passing when the artifact is absent — the packages are ~284 MB
+    /// and are not in the repository, so a green tick here with nothing checked would be worse
+    /// than no test.
+    @Test("A model's declared floor matches its compiled artifact")
+    func declaredFloorMatchesArtifact() throws {
+        let root = ProcessInfo.processInfo.environment["DAL_CLIP_REAL_MODEL_DIR"]
+        guard let root else {
+            print("SKIP: set DAL_CLIP_REAL_MODEL_DIR to check the floor against the artifact. "
+                  + "NOT PASSING — nothing was compared.")
+            return
+        }
+        let metadata = URL(fileURLWithPath: root)
+            .appending(path: ClipModel.coreML).appending(path: "metadata.json")
+        guard let data = try? Data(contentsOf: metadata),
+              let parsed = try? JSONSerialization.jsonObject(with: data) else {
+            Issue.record("could not read \(metadata.path)"); return
+        }
+        let entry = (parsed as? [Any])?.first as? [String: Any] ?? parsed as? [String: Any]
+        let availability = entry?["availability"] as? [String: String] ?? [:]
+        #expect(!availability.isEmpty, "the artifact records no availability map")
+        // The artifact speaks in "18.0"; the declaration in 18.
+        for (key, declared) in [("iOS", ClipModel.osFloor.iOS), ("macOS", ClipModel.osFloor.macOS),
+                                ("tvOS", ClipModel.osFloor.tvOS)] {
+            guard let stated = availability[key], let major = Int(stated.split(separator: ".")[0])
+            else { continue }
+            #expect(declared == major,
+                    "\(key): ClipModel.osFloor says \(declared), the artifact says \(major)")
+        }
+    }
+
+    /// Every model states a floor, and none states one BELOW what the package supports.
+    @Test("Declared floors are coherent with the package")
+    func floorsAreCoherent() {
+        for model in catalog {
+            let f = model.osFloor
+            #expect(f.iOS >= OSFloor.packageFloor.iOS,
+                    "\(model.id) claims an iOS floor below the package's")
+            #expect(f.macOS >= OSFloor.packageFloor.macOS,
+                    "\(model.id) claims a macOS floor below the package's")
+        }
+    }
 }

--- a/Tests/TitleTests/TitleTests.swift
+++ b/Tests/TitleTests/TitleTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import Title
+
+/// Parsing the model's reply, which is the part that fails quietly.
+///
+/// Generation needs a ~280 MB MLX folder and a GPU, so it is not tested here. `parse` is pure
+/// and is where a format drift shows up, so it is where the tests are. The design rule being
+/// pinned: **a card model that drifts off format must degrade to a usable title rather than
+/// throw**, because the clip is still good and selection is what ships.
+@Suite struct TitleParsingTests {
+
+    @Test func theTrainedFormatParses() {
+        let card = Titles.parse("TITLE: Cold plunges and cortisol\nDESC: A physiologist explains why.")
+        #expect(card.title == "Cold plunges and cortisol")
+        #expect(card.description == "A physiologist explains why.")
+        #expect(!card.isEmpty)
+    }
+
+    /// The training data uses `DESC`, but base-model habits leak `DESCRIPTION` through. Both
+    /// are accepted, and that is a deliberate tolerance rather than an oversight.
+    @Test func bothSpellingsOfDescriptionAreAccepted() {
+        let short = Titles.parse("TITLE: A\nDESC: one")
+        let long = Titles.parse("TITLE: A\nDESCRIPTION: one")
+        #expect(short.description == "one")
+        #expect(long.description == "one", "base models leak the longer spelling")
+    }
+
+    /// Labels are case-insensitive because a small instruct model lowercases them under
+    /// unusual input, and losing a good title to that would be absurd.
+    @Test func labelsAreCaseInsensitive() {
+        let card = Titles.parse("title: Lowercase label\ndesc: still parsed")
+        #expect(card.title == "Lowercase label")
+        #expect(card.description == "still parsed")
+    }
+
+    /// No labels at all: take the first real line as the title rather than returning nothing.
+    /// This is the degradation path, and it is the reason `parse` does not throw.
+    @Test func anUnlabelledReplyStillYieldsATitle() {
+        let card = Titles.parse("Cold plunges and cortisol\n")
+        #expect(card.title == "Cold plunges and cortisol")
+        #expect(card.description.isEmpty)
+        #expect(!card.isEmpty, "a title alone is still a usable card")
+    }
+
+    /// Empty is the ONLY failure signal a caller gets, so it must be reachable and honest.
+    @Test func anEmptyReplyIsAnEmptyCard() {
+        #expect(Titles.parse("").isEmpty)
+        #expect(Titles.parse("\n   \n").isEmpty)
+    }
+
+    /// Whitespace around the label and the value is stripped, including a leading blank line,
+    /// which the model emits often enough to matter.
+    @Test func surroundingWhitespaceIsStripped() {
+        let card = Titles.parse("\n  TITLE:   Spaced out  \n  DESC:   and trimmed  \n")
+        #expect(card.title == "Spaced out")
+        #expect(card.description == "and trimmed")
+    }
+
+    /// A colon inside the value must survive: titles legitimately contain them, and splitting
+    /// on the first colon rather than the label prefix would truncate them.
+    @Test func aColonInsideTheValueSurvives() {
+        let card = Titles.parse("TITLE: Sleep: the short version\nDESC: Ten minutes on it.")
+        #expect(card.title == "Sleep: the short version")
+    }
+
+    /// The prompt is the trained wording and a paraphrase is a different task to the model, so
+    /// its load-bearing parts are pinned. See the doc comment on `Titles.prompt` for why there
+    /// is no RULES block and why it says "passage" rather than "video clip".
+    @Test func thePromptKeepsTheClausesTheModelWasTrainedWith() {
+        let p = Titles.prompt
+        #expect(p.contains("{clip}"), "the substitution point must survive edits")
+        #expect(p.contains("Be specific enough to identify this passage"))
+        #expect(p.contains("same language as the passage"))
+        #expect(p.contains("PASSAGE:"), "the label the training pairs used")
+        #expect(!p.contains("video"), "non-video callers must not send video instructions")
+    }
+}

--- a/Tests/TranscriptTests/ClipTests.swift
+++ b/Tests/TranscriptTests/ClipTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Transcript
+
+struct ClipRanges {
+    /// Two sentences spoken back to back, then a long pause, then a third.
+    private let transcript = [
+        Sentence(id: 0, text: "Zero.", start: 0, end: 1),
+        Sentence(id: 1, text: "One.", start: 1, end: 2),
+        Sentence(id: 2, text: "Two.", start: 30, end: 31),
+    ]
+
+    private func clip(_ ids: [Int]) -> Clip {
+        Clip(id: 0, sentenceIDs: ids, text: "", score: 0, percentile: 0, estimatedDurationSec: 0)
+    }
+
+    @Test func contiguousSentencesMerge() {
+        let ranges = clip([0, 1]).ranges(in: transcript, padding: 0)
+
+        #expect(ranges.count == 1)
+        #expect(ranges[0].start == 0)
+        #expect(ranges[0].end == 2)
+    }
+
+    @Test func pausesAreCut() {
+        let ranges = clip([1, 2]).ranges(in: transcript, padding: 0)
+
+        #expect(ranges.count == 2)
+        #expect(ranges[1].start == 30)
+    }
+
+    @Test func paddingStopsAtZero() {
+        #expect(clip([0]).ranges(in: transcript, padding: 5).first?.start == 0)
+    }
+
+    @Test func overlappingPaddingMerges() {
+        #expect(clip([0, 1]).ranges(in: transcript, padding: 2).count == 1)
+    }
+
+    @Test func noPaddingWithoutSilence() {
+        // Sentence 0 ends exactly where 1 begins, so there is no silence to take.
+        #expect(clip([1]).ranges(in: transcript, padding: 5)[0].start == 1)
+    }
+
+    @Test func paddingIsHalfTheSilence() {
+        let close = [Sentence(id: 0, text: "A.", start: 0, end: 1),
+                     Sentence(id: 1, text: "B.", start: 1.25, end: 2)]
+        // A quarter-second gap gives an eighth of a second, not the full limit.
+        #expect(clip([0]).ranges(in: close, padding: 5)[0].end == 1.125)
+        // A long silence is capped rather than halved.
+        #expect(clip([1]).ranges(in: transcript, padding: 0.15)[0].end == 2.15)
+    }
+
+    @Test func paddingAtTheEnd() {
+        #expect(clip([2]).ranges(in: transcript, padding: 0.15)[0].end == 31.15)
+    }
+
+    @Test func unknownIdsAreSkipped() {
+        // Selection addresses the array it was given; an id outside it means a
+        // different transcript than the one selected from.
+        #expect(clip([0, 99]).ranges(in: transcript, padding: 0).count == 1)
+    }
+
+    @Test func rangesAreOrdered() {
+        #expect(clip([2, 0]).ranges(in: transcript, padding: 0).map(\.start) == [0, 30])
+    }
+
+    @Test func durationSumsSpans() {
+        #expect(clip([0, 1]).duration(in: transcript, padding: 0) == 2)
+        #expect(clip([1, 2]).duration(in: transcript, padding: 0) == 2)
+    }
+}

--- a/Tests/TranscriptTests/SentenceTests.swift
+++ b/Tests/TranscriptTests/SentenceTests.swift
@@ -1,0 +1,69 @@
+import Testing
+import Transcript
+
+/// Words with the spacing a recognizer leaves on them, one word per half second.
+func words(_ text: String, from start: Double = 0, step: Double = 0.5) -> [TimedWord] {
+    text.split(separator: " ", omittingEmptySubsequences: false).enumerated().map { index, word in
+        TimedWord(text: index == 0 ? String(word) : " " + word,
+                  start: start + Double(index) * step,
+                  end: start + Double(index + 1) * step)
+    }
+}
+
+struct SentenceSplitting {
+    @Test func splitsOnTerminalPunctuation() {
+        let sentences = Sentence.sentences(from: words("One two. Three four!"))
+
+        #expect(sentences.count == 2)
+        #expect(sentences[0].text == "One two.")
+        #expect(sentences[0].start == 0)
+        #expect(sentences[0].end == 1.0)
+        #expect(sentences[1].text == "Three four!")
+        #expect(sentences[1].start == 1.0)
+        #expect(sentences[1].end == 2.0)
+    }
+
+    @Test func idsAreTranscriptPositions() {
+        // Selection returns these numbers and nothing else.
+        #expect(Sentence.sentences(from: words("A. B. C.")).map(\.id) == [0, 1, 2])
+    }
+
+    @Test func leadingSilence() {
+        #expect(Sentence.sentences(from: words("Hello there.", from: 10)).first?.start == 10)
+    }
+
+    @Test func unpunctuatedTail() {
+        let sentences = Sentence.sentences(from: words("Done. And then this"))
+        #expect(sentences.count == 2)
+        #expect(sentences[1].text == "And then this")
+    }
+
+    @Test func runOnIsBrokenUp() {
+        #expect(Sentence.sentences(from: words(String(repeating: "word ", count: 200))).count > 1)
+    }
+
+    @Test func noSpeech() {
+        #expect(Sentence.sentences(from: []).isEmpty)
+        #expect(Sentence.sentences(from: words("   ")).isEmpty)
+    }
+
+    @Test func loneTerminator() {
+        // Recognizers split punctuation off often enough that closing on it
+        // would emit "." as an entry the model then has to score.
+        let split = [TimedWord(text: "Hello", start: 0, end: 1),
+                     TimedWord(text: ".", start: 1, end: 1.1),
+                     TimedWord(text: " Bye.", start: 1.2, end: 2)]
+        #expect(Sentence.sentences(from: split).map(\.text) == ["Hello.", "Bye."])
+    }
+
+    @Test func untimedWords() {
+        let mixed = [TimedWord(text: "Placed", start: 5, end: 6),
+                     TimedWord(text: " unplaced", start: -1, end: -1),
+                     TimedWord(text: " end.", start: 6, end: 7)]
+        let sentences = Sentence.sentences(from: mixed)
+
+        #expect(sentences.count == 1)
+        #expect(sentences[0].start == 5)
+        #expect(sentences[0].end == 7)
+    }
+}

--- a/mise-tasks/build/swift
+++ b/mise-tasks/build/swift
@@ -18,8 +18,16 @@ for model in $(dal_select "${usage_model:-all}"); do
     # `--target`, not `--product`: the model libraries are automatic products,
     # which SwiftPM refuses to select and then silently builds everything.
     if [ "$(uname)" = Darwin ]; then
-        swift build --scratch-path .build-host --target "$product"
+        # `Title` is MLX and its generation half only compiles behind the `MLX`
+        # package trait (see Package.swift). Scoped to Title so the other models
+        # keep proving they build against a graph without mlx-swift-lm.
+        traits=(); [ "$product" = Title ] && traits=(--traits MLX)
+        # `${traits[@]+...}`: bash 3.2 + `set -u` treats expanding an empty
+        # array as an unbound variable; this expands to nothing instead.
+        swift build --scratch-path .build-host ${traits[@]+"${traits[@]}"} --target "$product"
     else
+        # MLX has no Linux port; `Title` never enters the graph here.
+        [ "$product" = Title ] && { echo "skip: MLX is Apple-only"; continue; }
         swift build --scratch-path .build-host --target "$product" -Xlinker "-L$litert"
     fi
 done

--- a/mise-tasks/check/isolation
+++ b/mise-tasks/check/isolation
@@ -18,6 +18,9 @@ for model in $models; do
     grep -rq '^import Audio' "Sources/$product" && audio_users="$audio_users $product"
 done
 
+# `Title` is declared unconditionally since the `MLX` trait replaced
+# DAL_MLX_BUILD (see Package.swift): its MLX edges are trait-conditional and
+# pruned here, so no flag is needed for the target to appear in the graph.
 swift package describe --type json \
     | MODELS="$(for m in $models; do dal_product "$m"; done | tr '\n' ' ')" AUDIO_USERS="$audio_users" node -e '
 let raw = "";


### PR DESCRIPTION
Add Clips and Title to the core SDK

 Brings the video-highlight pipeline into desert-ant-core: select the strongest clips from a caller-supplied
 transcript and title them.

 ### New modules

 - Transcript — portable transcript primitives: TimedWord, Sentence, Clip (with Clip.ranges(in:padding:) for cut
   spans)
 - Clips — clip selection model: catalog, tokenizer, inference pipeline, native + web (wasm) entry points
 - Title — generates title cards for selected clips

 ### Supporting changes

 - Inference — session usage tracking, CoreML session and factory extensions
 - ModelCatalog / ModelStore — model declarations and Foundation-backend support for the new models
 - Package.swift — new targets/products wired in; AutoEdit module removed (nothing imported it; transcription and
   cutting happen outside the SDK, and clip selection now lives in Clips)

 ### Tests

 Coverage for clip selection, sentence segmentation, tokenizer, Hub download, shipping artifacts, model catalog,
 and titles (~700 lines of tests).