### PR TITLE
clear: pin the published v0.3.0 tag, not a commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 |---|---|---|---|---|---|
 | **Emo** | Multilingual emoji suggestion from short text, 23 languages | `Emo` | `ai.desertant:emo` | `@desert-ant-labs/emo` | [Hugging Face](https://huggingface.co/desert-ant-labs/emo) |
 | **Redact** | PII detection and reversible redaction, 27 languages | `Redact` | `ai.desertant:redact` | `@desert-ant-labs/redact` | [Hugging Face](https://huggingface.co/desert-ant-labs/redact) |
-| **Clear** | Speech enhancement: denoise, dereverb, podcast-ready 48 kHz | `Clear` | soon | soon | [Hugging Face](https://huggingface.co/desert-ant-labs/clear) |
+| **Clear** | Speech enhancement: denoise, dereverb, podcast-ready 48 kHz | `Clear` | `ai.desertant:clear` | `@desert-ant-labs/clear` | [Hugging Face](https://huggingface.co/desert-ant-labs/clear) |
 | **Align** | Word-timestamp refinement for Apple's `SpeechAnalyzer` pipeline, 9 languages | `Align` | Apple-only | Apple-only | [Hugging Face](https://huggingface.co/desert-ant-labs/align) |
 
 Each model behaves the same on every platform, so you can build a feature once

--- a/Sources/Clear/Catalog.swift
+++ b/Sources/Clear/Catalog.swift
@@ -8,12 +8,7 @@ import DesertAnt
 public enum ClearModel: ModelDeclaration {
     public static let id = "clear"
     public static let product = "Clear"
-    // Not the v0.2.0 tag: that tag's Core ML export predates the ANE-shaped
-    // batch-4 layout the enhancer now feeds (Enhancer.batchSize), so Apple
-    // would fail with a shape mismatch on every run. This commit of `main`
-    // carries the re-shaped .mlmodelc alongside the LiteRT exports; becomes
-    // the next `v`-tag once one is cut with it.
-    public static let revision = "1d8810fa86077c319952ffc2080b31bab86a2ad7"
+    public static let revision = "v0.3.0"
     /// Matches packages/clear-node/package.json and packages/clear-kotlin/build.gradle.kts
     /// (ModelCatalogTests enforces it).
     public static let sdkVersion = "1.1.0"

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -194,7 +194,7 @@ struct ClearTests {
     /// once per process and every test here reuses it.
     private func enhancer() async throws -> Clear {
         let files = try await ModelFixture.files(ClearModel.self)
-        return try Clear(modelPath: files.path(ClearModel.artifact), revision: "1d8810f")
+        return try Clear(modelPath: files.path(ClearModel.artifact), revision: ClearModel.revision)
     }
 
     @Test func enhanceEndToEnd() async throws {
@@ -599,7 +599,7 @@ struct ClearTests {
 @Suite(.serialized, .modelBacked) struct ClearBindingTests {
     private func enhancer() async throws -> Clear {
         let files = try await ModelFixture.files(ClearModel.self)
-        return try Clear(modelPath: files.path(ClearModel.artifact), revision: "1d8810f")
+        return try Clear(modelPath: files.path(ClearModel.artifact), revision: ClearModel.revision)
     }
 
     private func input(_ channels: [[Float]], sampleRate: Double = 48_000) -> FFIReader {


### PR DESCRIPTION
- Tag the Hub at the revision the SDK pins (`v0.3.0`, the ANE-shaped Core ML exports alongside the LiteRT builds) and pin that tag instead of a bare commit
- Read the pinned revision from the catalog in tests rather than repeating the SHA
- Flip the README's Clear row from `soon` to the coordinates this release publishes
