### PR TITLE
Coalesce server usage deltas to hourly

### DIFF
--- a/Sources/Usage/Transport.swift
+++ b/Sources/Usage/Transport.swift
@@ -90,6 +90,7 @@ public func makeClient(
     deviceId: String? = nil,
     platform: String = defaultPlatform,
     windowMs: Int64 = dayMs,
+    emitIntervalMs: Int64? = nil,
     callCount: (() -> Int)? = nil,
     context: (() -> [String: String]?)? = nil,
     storage: UsageStorage? = nil
@@ -99,6 +100,8 @@ public func makeClient(
     let namespace = resolvedKey ?? resolvedAppId    // state namespaced per attribution identity
     let store = storage ?? defaultStorage()
     let device = resolveDeviceId(deviceId, store)
+    // Coalesce a continuously-running server's delta loads to hourly by default.
+    let resolvedEmitInterval = emitIntervalMs ?? (platform == "server" ? hourMs : 0)
     return UsageClient(ClientDeps(
         deviceId: device,
         key: resolvedKey,
@@ -108,6 +111,7 @@ public func makeClient(
         callCount: callCount,
         context: context,
         windowMs: windowMs,
+        emitIntervalMs: resolvedEmitInterval,
         now: systemNowMs,
         loadState: { store.loadState(namespace, device) },
         saveState: { store.saveState($0, namespace, device) },

--- a/Sources/Usage/UsageClient.swift
+++ b/Sources/Usage/UsageClient.swift
@@ -10,6 +10,8 @@
 public let dayMs: Int64 = 24 * 60 * 60 * 1000
 /// Session-shaped window (30-min idle timeout) for ephemeral, web-like hosts.
 public let webSessionMs: Int64 = 30 * 60 * 1000
+/// Default coalescing interval for a continuously-running `server` host's deltas.
+public let hourMs: Int64 = 60 * 60 * 1000
 
 /// Persisted per install, across sessions.
 public struct UsageState: Sendable, Equatable {
@@ -48,6 +50,8 @@ public struct ClientDeps {
     public var context: (() -> [String: String]?)?
     /// Re-emit window (ms): `dayMs` for persistent installs, `webSessionMs` for web-like.
     public var windowMs: Int64
+    /// Min gap (ms) between post-turnstile delta sends; 0 = send every flush.
+    public var emitIntervalMs: Int64
     public var now: () -> Int64
     public var loadState: () -> UsageState
     public var saveState: (UsageState) -> Void
@@ -62,6 +66,7 @@ public struct ClientDeps {
         callCount: (() -> Int)? = nil,
         context: (() -> [String: String]?)? = nil,
         windowMs: Int64 = dayMs,
+        emitIntervalMs: Int64 = 0,
         now: @escaping () -> Int64 = systemNowMs,
         loadState: @escaping () -> UsageState,
         saveState: @escaping (UsageState) -> Void,
@@ -75,6 +80,7 @@ public struct ClientDeps {
         self.callCount = callCount
         self.context = context
         self.windowMs = windowMs
+        self.emitIntervalMs = emitIntervalMs
         self.now = now
         self.loadState = loadState
         self.saveState = saveState
@@ -88,6 +94,7 @@ public final class UsageClient {
     private var sessionCalls = 0      // recordCall() accrued this session, not yet accounted
     private var pending: IngestEvent? // queued turnstile, awaiting first flush
     private var emitted = false       // did we open a turnstile this session?
+    private var lastEmitAt: Int64 = 0 // clock of the last actual send; gates delta coalescing
 
     public init(_ deps: ClientDeps) { self.deps = deps }
 
@@ -133,14 +140,29 @@ public final class UsageClient {
                 deps.saveState(UsageState(lastActiveAt: st.lastActiveAt, carryCallCount: 0))
             }
             sessionCalls = 0
+            lastEmitAt = deps.now()
             deps.send(makeBody([ev]), opts)
             return
         }
 
-        if emitted && sessionCalls > 0 {
-            // Turnstile already sent; late calls ride a delta load (server sums them).
-            let ev = IngestEvent(deviceId: deps.deviceId, callCount: resolveCount(sessionCalls), context: currentContext())
+        if emitted && (sessionCalls > 0 || st.carryCallCount > 0) {
+            // Turnstile already sent; late calls ride a delta load (server sums them),
+            // coalesced to one send per emitIntervalMs — an unload (beacon) always drains.
+            let due = opts.beacon || deps.emitIntervalMs <= 0
+                || deps.now() - lastEmitAt >= deps.emitIntervalMs
+            if !due {
+                if deps.callCount == nil && sessionCalls > 0 {
+                    deps.saveState(UsageState(lastActiveAt: st.lastActiveAt, carryCallCount: st.carryCallCount + sessionCalls))
+                    sessionCalls = 0
+                }
+                return
+            }
+            let ev = IngestEvent(deviceId: deps.deviceId, callCount: resolveCount(st.carryCallCount + sessionCalls), context: currentContext())
+            if deps.callCount == nil && st.carryCallCount != 0 {
+                deps.saveState(UsageState(lastActiveAt: st.lastActiveAt, carryCallCount: 0))
+            }
             sessionCalls = 0
+            lastEmitAt = deps.now()
             deps.send(makeBody([ev]), opts)
             return
         }

--- a/Tests/UsageTests/UsageClientTests.swift
+++ b/Tests/UsageTests/UsageClientTests.swift
@@ -9,7 +9,7 @@ private final class Harness {
     var sent: [(body: IngestBody, opts: SendOptions)] = []
     let client: UsageClient
 
-    init(_ initial: UsageState = UsageState(), callCount: (() -> Int)? = nil, windowMs: Int64 = dayMs) {
+    init(_ initial: UsageState = UsageState(), callCount: (() -> Int)? = nil, windowMs: Int64 = dayMs, emitIntervalMs: Int64 = 0) {
         self.state = initial
         // Captured by reference through the closures below.
         var boxRef: Harness!
@@ -19,6 +19,7 @@ private final class Harness {
             platform: "test",
             callCount: callCount,
             windowMs: windowMs,
+            emitIntervalMs: emitIntervalMs,
             now: { boxRef.clock },
             loadState: { boxRef.state },
             saveState: { boxRef.state = $0 },
@@ -92,6 +93,48 @@ struct UsageClientTests {
         #expect(h.events.count == 2)
         #expect(h.events[0].callCount == 1)
         #expect(h.events[1].callCount == 4)
+        #expect(h.sent[1].opts.beacon == true)
+    }
+
+    @Test func serverCoalescesDeltaLoadsWithinInterval() {
+        let h = Harness(UsageState(lastActiveAt: 0), emitIntervalMs: hourMs)
+        h.client.start()
+        h.client.recordCall(1)
+        h.client.flush() // turnstile
+        #expect(h.sent.count == 1)
+        #expect(h.events[0].callCount == 1)
+
+        // Flushes within the hour are held, not sent.
+        for _ in 0..<3 {
+            h.advance(60_000)
+            h.client.recordCall(2)
+            h.client.flush()
+        }
+        #expect(h.sent.count == 1)
+        #expect(h.state.carryCallCount == 6)
+
+        // Past the hour: one delta carrying everything held.
+        h.advance(hourMs)
+        h.client.recordCall(2)
+        h.client.flush()
+        #expect(h.sent.count == 2)
+        #expect(h.events[1].callCount == 8)
+        #expect(h.state.carryCallCount == 0)
+    }
+
+    @Test func beaconFlushesHeldDeltasImmediately() {
+        let h = Harness(UsageState(lastActiveAt: 0), emitIntervalMs: hourMs)
+        h.client.start()
+        h.client.flush()
+        h.advance(60_000)
+        h.client.recordCall(5)
+        h.client.flush() // held within the hour
+        #expect(h.sent.count == 1)
+
+        h.client.recordCall(2)
+        h.client.flush(SendOptions(beacon: true)) // unload drains held + new
+        #expect(h.sent.count == 2)
+        #expect(h.events[1].callCount == 7)
         #expect(h.sent[1].opts.beacon == true)
     }
 


### PR DESCRIPTION
A long-running `server` host records inference calls continuously, and until now flushed a separate delta `load` on every debounced flush — so a single process emitted a load every few seconds. This holds post-turnstile deltas and emits at most once per `emitIntervalMs`, folding the held calls into the next send; an unload (beacon) flush still drains immediately. `makeClient` defaults this to one hour for the `server` platform and leaves web/native unchanged (0 = send per flush). Totals are unaffected since the server sums `callCount` across loads. Adds tests for the coalescing and beacon-drain paths.