### PR TITLE
Read the pure-model marker with grep, not node

### DIFF
--- a/Tools/dal.sh
+++ b/Tools/dal.sh
@@ -41,9 +41,12 @@ dal_models_with() {
 # package declares `"desertant": {"pure": true}` (tongue is the first). Tasks
 # that stage or test native artifacts skip these; their suites still run
 # (test:node runs the package's own tests, Gradle runs the Kotlin ones).
+#
+# grep, not node: the release's native-build containers carry no JS toolchain,
+# and a guard that quietly returns false there sends a pure model into a native
+# build that cannot exist (v1.2.0 learned this the hard way).
 dal_node_pure() { # <model>
-    [ -f "packages/$1-node/package.json" ] || return 1
-    [ "$(node -p "require('./packages/$1-node/package.json').desertant?.pure ?? false")" = true ]
+    grep -q '"pure"[[:space:]]*:[[:space:]]*true' "packages/$1-node/package.json" 2> /dev/null
 }
 
 # "emo" -> "Emo". The Swift product/target name, and the native library prefix.


### PR DESCRIPTION
The v1.2.0 release's linux native jobs failed with `no product named 'TongueNode'`: the containers carry no node, so `dal_node_pure` (which shelled out to `node -p`) quietly returned false and the guard never fired. grep the marker instead — the native-build containers all have grep, and the file is our own. Verified the guard's three outcomes locally with node removed from PATH; `mise run test:node tongue` still passes. After merge, v1.2.0 gets re-pointed at the fixed commit and the release re-run (nothing was published from the first attempt: Maven failed on a swift-build planner flake, npm and the GitHub Release never ran).