### PR TITLE
Release npm job: skip pure packages' natives, install the workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,8 @@ jobs:
           cp -a /tmp/natives/. packages/
           find packages/*-node/native -type f | sort
           for dir in packages/*-node; do
+            # A pure package (dal_node_pure in Tools/dal.sh) ships no native core.
+            grep -q '"pure"[[:space:]]*:[[:space:]]*true' "$dir/package.json" && continue
             for target in linux-x64 linux-arm64 darwin-arm64; do
               [ -d "$dir/native/$target" ] || { echo "::error::$dir is missing the $target native"; exit 1; }
             done
@@ -204,6 +206,10 @@ jobs:
 
       # The browser half of every package.
       - run: mise run build:wasm
+
+      # A pure package's `prepare` builds its dist from TypeScript at publish
+      # time, which needs the workspace devDependencies on the PATH.
+      - run: mise run npm-install
 
       - name: Publish
         if: needs.gate.outputs.publish == 'true'


### PR DESCRIPTION
Second and last release-machinery gap for pure packages, found by the v1.2.0 re-run: the npm job's "Stage the natives" step demanded linux-x64/linux-arm64/darwin-arm64 from every packages/*-node (tongue ships none), and nothing installed the workspace, so tongue's `prepare` (tsc) would have no toolchain at `npm publish` time. Verified locally: the staging loop now skips exactly the pure package, and `npm pack --dry-run` in packages/tongue-node builds dist and shows the 2 MB model in the tarball. Maven Central and all natives already published/built green on the previous run; after merge, v1.2.0 is re-pointed and the release re-run (publish tasks skip artifacts already live).