### PR TITLE
Add Voz: on-device speech recognition, Apple only

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -463,9 +463,34 @@ let testTargets: [Target] = [
 ]
 
 
+// Voz is Apple-only (Core ML, AVFoundation) and, like Align, gets no
+// Android/Node/Web products and no NativeBindings. It bundles nothing: its
+// Core ML models are downloaded on demand via Sources/Voz/Catalog.swift. It
+// drives Core ML directly rather than going through `InferenceSession`, because
+// preallocated buffers, `outputBackings` and a lane-batched decode loop are not
+// expressible through a generic run(inputs:outputs:) call, and dropping them
+// costs roughly 127x on load and about a third of decode throughput.
+let vozProducts: [Product] = [
+    .library(name: "Voz", targets: ["Voz"]),
+]
+
+let vozTargets: [Target] = [
+    .target(
+        name: "Voz",
+        dependencies: [
+            .byName(name: "DesertAnt"),
+            .byName(name: "AudioIO"),
+        ]
+    ),
+    .testTarget(
+        name: "VozTests",
+        dependencies: ["Voz", "DesertAnt", "TestSupport"]
+    ),
+]
+
 let coreTargets: [Target] =
     libraryTargets + testTargets + modelTargets + modelTestTargets + alignTargets
-    + tongueTargets
+    + tongueTargets + vozTargets
 
 let package = Package(
     name: "DesertAnt",
@@ -497,7 +522,7 @@ let package = Package(
     // sits below iOS 17, and Linux/Android/wasm ignore Apple floors entirely. If such a
     // consumer appears, this is the line to argue about.
     platforms: [.iOS(.v17), .macOS(.v14), .tvOS(.v16), .visionOS(.v1)],
-    products: products + modelProducts + alignProducts,
+    products: products + modelProducts + alignProducts + vozProducts,
     traits: [
         .trait(
             name: "MLX",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 | **Title** | On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text. | Apple | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/title.md) |
 | **Tongue** | On-device language identification for short text across 84 languages. | Apple · Android · Linux · Windows · Web · Node | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/tongue.md) |
 | **Uhm** | On-device filler-word detection: frame-precise "uh"/"um"/"hmm" spans. | Apple | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/uhm.md) |
+| **Voz** | On-device speech recognition: transcripts with word-level timestamps, 25 languages. | Apple | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/voz.md) |
 
 ### In closed beta
 

--- a/Sources/Voz/Assets.swift
+++ b/Sources/Voz/Assets.swift
@@ -1,0 +1,67 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// The loaded model: three Core ML programs plus the host-side tables.
+struct Assets {
+    let configuration: Configuration
+    let vocabulary: [String]
+    /// Row-major `[vocab + 1, predHidden]`, already float16 so a decode step
+    /// copies a row without converting. The embedding stays outside the graph:
+    /// a gather over an 8193 x 640 table has no Neural Engine kernel and is a
+    /// table read the host does for free.
+    let embedding: [Element]
+    let mel: MLModel
+    let encoder: MLModel
+    let decodeStep: MLModel
+    /// Windows decoded per dispatch, read from the model rather than assumed.
+    let decodeLanes: Int
+
+    init(directory: URL, computeUnits: MLComputeUnits) throws {
+        let decoder = JSONDecoder()
+        configuration = try decoder.decode(
+            Configuration.self,
+            from: try Data(contentsOf: directory.appendingPathComponent("meta.json")))
+        try configuration.validate()
+        vocabulary = try decoder.decode(
+            [String].self,
+            from: try Data(contentsOf: directory.appendingPathComponent("vocab.json")))
+        guard vocabulary.count >= configuration.vocabSize else {
+            throw VozError.invalidModel("vocabulary is smaller than the model's vocab size")
+        }
+
+        let raw = try Data(contentsOf: directory.appendingPathComponent("embedding.f16"),
+                           options: .mappedIfSafe)
+        let expected = (configuration.vocabSize + 1) * configuration.predHidden
+        guard raw.count == expected * MemoryLayout<Element>.size else {
+            throw VozError.invalidModel(
+                "embedding.f16 has \(raw.count) bytes, expected \(expected * 2)")
+        }
+        embedding = raw.withUnsafeBytes { buf in
+            (0..<expected).map { buf.loadUnaligned(fromByteOffset: $0 * 2, as: Element.self) }
+        }
+
+        let mlConfiguration = MLModelConfiguration()
+        mlConfiguration.computeUnits = computeUnits
+        func load(_ name: String) throws -> MLModel {
+            let url = directory.appendingPathComponent(name)
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw VozError.invalidModel("missing \(name) in \(directory.path)")
+            }
+            return try MLModel(contentsOf: url, configuration: mlConfiguration)
+        }
+        mel = try load(VozModel.mel)
+        encoder = try load(VozModel.encoder)
+        decodeStep = try load(VozModel.decodeStep)
+
+        guard let embed = decodeStep.modelDescription.inputDescriptionsByName["embed"],
+              let constraint = embed.multiArrayConstraint else {
+            throw VozError.invalidModel("decode step is missing its embed input")
+        }
+        decodeLanes = constraint.shape[0].intValue
+        guard decodeLanes > 0 else {
+            throw VozError.invalidModel("decode step declares no lanes")
+        }
+    }
+}
+#endif

--- a/Sources/Voz/AudioStream.swift
+++ b/Sources/Voz/AudioStream.swift
@@ -1,0 +1,147 @@
+#if canImport(CoreML)
+import Foundation
+
+#if canImport(AVFoundation)
+// `@preconcurrency` for the same reason AudioIO uses it: the converter callback
+// runs synchronously on this thread, so its Sendable warnings do not apply.
+@preconcurrency import AVFoundation
+#endif
+
+/// A source of mono 16 kHz samples that does not require the whole file at once.
+///
+/// Transcription reads the file in order and never looks back further than the
+/// window it is working on, so holding all of it is only ever a convenience. On
+/// a long recording it is an expensive one: an hour of audio is 230 MB of
+/// `Float` before the model has allocated anything, and a video editor is
+/// working with an hour-long timeline and its own buffers at the same time.
+protocol AudioStream {
+    /// Total samples, if the source knows. Used only for progress reporting.
+    var totalSamples: Int? { get }
+    /// Append up to `count` further samples to `into`, returning how many were
+    /// added. Zero means the source is exhausted.
+    mutating func read(_ count: Int, into: inout [Float]) throws -> Int
+}
+
+/// An already-decoded buffer, for callers that hand over samples directly.
+struct ArrayAudioStream: AudioStream {
+    private let samples: [Float]
+    private var position = 0
+
+    init(_ samples: [Float]) { self.samples = samples }
+
+    var totalSamples: Int? { samples.count }
+
+    mutating func read(_ count: Int, into buffer: inout [Float]) throws -> Int {
+        let n = Swift.min(count, samples.count - position)
+        guard n > 0 else { return 0 }
+        buffer.append(contentsOf: samples[position..<(position + n)])
+        position += n
+        return n
+    }
+}
+
+#if canImport(AVFoundation)
+/// Reads and converts a file incrementally, a few seconds at a time.
+struct FileAudioStream: AudioStream {
+    private let file: AVAudioFile
+    private let converter: AVAudioConverter
+    private let outputFormat: AVAudioFormat
+    private let chunkFrames: AVAudioFrameCount
+    private var finished = false
+    private var drained = false
+
+    let totalSamples: Int?
+
+    init(url: URL, sampleRate: Double, chunkSeconds: Double = 10) throws {
+        do {
+            file = try AVAudioFile(forReading: url)
+        } catch {
+            throw VozError.invalidAudio("\(url.path): \(error)")
+        }
+        let inputFormat = file.processingFormat
+        guard file.length > 0,
+              let output = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                         sampleRate: sampleRate,
+                                         channels: 1, interleaved: false),
+              let made = AVAudioConverter(from: inputFormat, to: output)
+        else { throw VozError.invalidAudio("\(url.path) decoded to no audio") }
+        outputFormat = output
+        converter = made
+        chunkFrames = AVAudioFrameCount(chunkSeconds * inputFormat.sampleRate)
+        totalSamples = Int(Double(file.length) * sampleRate / inputFormat.sampleRate)
+    }
+
+    mutating func read(_ count: Int, into buffer: inout [Float]) throws -> Int {
+        if finished { return try drain(into: &buffer) }
+        let format = file.processingFormat
+        // Convert in whole chunks and stop once the request is met. The
+        // converter is stateful across calls, which is what keeps a resampled
+        // stream continuous instead of clicking at every chunk edge.
+        var produced = 0
+        while produced < count && !finished {
+            guard let input = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
+                throw VozError.invalidAudio("cannot allocate a read buffer")
+            }
+            // Asking for frames past the end throws rather than returning
+            // none, so stop at the end rather than reading into it.
+            let remaining = file.length - file.framePosition
+            if remaining <= 0 { finished = true; break }
+            do {
+                try file.read(into: input,
+                              frameCount: AVAudioFrameCount(Swift.min(Int64(chunkFrames), remaining)))
+            } catch {
+                throw VozError.invalidAudio("read failed: \(error)")
+            }
+            if input.frameLength == 0 { finished = true; break }
+            let capacity = AVAudioFrameCount(
+                Double(input.frameLength) * (outputFormat.sampleRate / format.sampleRate) + 4096)
+            guard let output = AVAudioPCMBuffer(pcmFormat: outputFormat,
+                                                frameCapacity: capacity) else {
+                throw VozError.invalidAudio("cannot allocate a convert buffer")
+            }
+            // `nonisolated(unsafe)` is sound here because the block runs
+            // synchronously on this thread inside `convert`.
+            nonisolated(unsafe) var fed = false
+            var failure: NSError?
+            converter.convert(to: output, error: &failure) { _, status in
+                if fed { status.pointee = .noDataNow; return nil }
+                fed = true; status.pointee = .haveData; return input
+            }
+            if let failure { throw VozError.invalidAudio("convert failed: \(failure)") }
+            guard let channel = output.floatChannelData?[0] else { break }
+            let n = Int(output.frameLength)
+            if n > 0 {
+                buffer.append(contentsOf: UnsafeBufferPointer(start: channel, count: n))
+                produced += n
+            }
+            if file.framePosition >= file.length { finished = true }
+        }
+        if finished { produced += try drain(into: &buffer) }
+        return produced
+    }
+
+    /// Flush whatever the converter is still holding.
+    ///
+    /// Rate conversion keeps a tail internally, and telling it "no data right
+    /// now" between chunks correctly does not release that. Only end-of-stream
+    /// does, and without this the last few hundred samples of every file were
+    /// silently lost - 40 ms of an eleven-second clip, which is a whole word.
+    private mutating func drain(into buffer: inout [Float]) throws -> Int {
+        guard !drained else { return 0 }
+        drained = true
+        guard let output = AVAudioPCMBuffer(pcmFormat: outputFormat,
+                                            frameCapacity: 8192) else { return 0 }
+        var failure: NSError?
+        converter.convert(to: output, error: &failure) { _, status in
+            status.pointee = .endOfStream
+            return nil
+        }
+        if let failure { throw VozError.invalidAudio("drain failed: \(failure)") }
+        guard let channel = output.floatChannelData?[0], output.frameLength > 0 else { return 0 }
+        let n = Int(output.frameLength)
+        buffer.append(contentsOf: UnsafeBufferPointer(start: channel, count: n))
+        return n
+    }
+}
+#endif
+#endif

--- a/Sources/Voz/Buffers.swift
+++ b/Sources/Voz/Buffers.swift
@@ -1,0 +1,33 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// Element type of every model-facing buffer.
+///
+/// The models declare float16 I/O. That halves the bytes crossing the boundary,
+/// and matters more than it looks: with float32 I/O the Neural Engine declined
+/// to reuse its cached specialization and re-specialized the encoder on every
+/// load. Compute precision was already float16, so the narrower I/O is lossless.
+typealias Element = Float16
+
+/// A reusable float16 `MLMultiArray` with direct pointer access.
+///
+/// Everything on the hot path is preallocated. Core ML otherwise allocates a
+/// fresh `MLMultiArray` per output per call, and the decode loop dispatches
+/// hundreds of times per minute of audio, so that allocation is a visible share
+/// of the total.
+final class Buffer {
+    let array: MLMultiArray
+    let ptr: UnsafeMutablePointer<Element>
+    let count: Int
+
+    init(_ shape: [Int]) throws {
+        array = try MLMultiArray(shape: shape.map(NSNumber.init), dataType: .float16)
+        ptr = UnsafeMutableRawPointer(array.dataPointer).assumingMemoryBound(to: Element.self)
+        count = shape.reduce(1, *)
+        ptr.update(repeating: 0, count: count)
+    }
+
+    func zero() { ptr.update(repeating: 0, count: count) }
+}
+#endif

--- a/Sources/Voz/Catalog.swift
+++ b/Sources/Voz/Catalog.swift
@@ -1,0 +1,47 @@
+// This model's catalog declaration: coordinates, file names, and which of them
+// each platform ships. The shared behaviour (distribution, resolve, availability)
+// comes from `ModelDeclaration` in the catalog's shared half.
+
+import DesertAnt
+
+/// The voz model: on-device speech recognition.
+///
+/// Apple-only. The runtime drives Core ML directly rather than going through
+/// `InferenceSession`, because the things that make it fast - preallocated
+/// buffers, `outputBackings`, and a lane-batched decode loop - are not
+/// expressible through a generic run(inputs:outputs:) shape. There is therefore
+/// no Android, Linux or web entry here.
+public enum VozModel: ModelDeclaration {
+    public static let id = "voz"
+    public static let product = "Voz"
+    public static let revision = "v0.1.0"
+    /// Matches VERSION (check:version enforces it; this repo releases as one).
+    public static let sdkVersion = "3.0.0"
+    public static let summary =
+        "On-device speech recognition: transcripts with word-level timestamps, 25 languages."
+
+    /// Artifact names describe roles rather than the network behind them, so
+    /// replacing the recogniser is a new upload rather than an SDK change. The
+    /// current export is a Parakeet TDT 0.6B v3 conformer transducer; nothing
+    /// outside this comment depends on that.
+    ///
+    /// Compiled Core ML programs, not `.mlpackage`s. Core ML keys its specialized
+    /// Neural Engine program cache on the compiled model's path, so loading an
+    /// `.mlpackage` recompiles into a fresh temporary directory on every launch
+    /// and never hits that cache: measured 27.9 s per load against 0.13 s.
+    public static let encoder = "encoder.mlmodelc"
+    public static let mel = "mel.mlmodelc"
+    public static let decodeStep = "decoder.mlmodelc"
+
+    /// Sidecars: geometry the runtime refuses to hardcode (`meta.json`), the
+    /// sentencepiece vocabulary, and the prediction network's embedding table,
+    /// which is a host-side lookup rather than a graph op. The table ships as
+    /// float16 because that is what the decode step consumes - float32 would be
+    /// 10 MB more to download and a conversion at load for no added precision.
+    public static let files: [ModelPlatform: [String]] = [
+        .apple: [encoder + "/", mel + "/", decodeStep + "/",
+                 "meta.json", "vocab.json", "embedding.f16"],
+    ]
+
+    public static func artifact(for platform: ModelPlatform) -> String { encoder }
+}

--- a/Sources/Voz/Configuration.swift
+++ b/Sources/Voz/Configuration.swift
@@ -1,0 +1,63 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// Model geometry, read from the export rather than assumed.
+///
+/// Every field here was hardcoded at some point and caused a bug: a window
+/// length mismatch silently misframed audio, and a missing `nFFT` dropped the
+/// centering pad and shifted every frame by 256 samples while still producing
+/// fluent output.
+struct Configuration: Decodable, Sendable {
+    let sampleRate: Int
+    let hopLength: Int
+    let nSamples: Int
+    let nRows: Int
+    let nMels: Int
+    let nFFT: Int
+    let preemph: Float
+    let nPaddedSamples: Int
+    let validFrames: Int
+    let encFrames: Int
+    let jointHidden: Int
+    let predHidden: Int
+    let predLayers: Int
+    let vocabSize: Int
+    let blankIdx: Int
+    let durations: [Int]
+    let decodeWidth: Int
+
+    enum CodingKeys: String, CodingKey {
+        case sampleRate = "sample_rate"
+        case hopLength = "hop_length"
+        case nSamples = "n_samples"
+        case nRows = "n_rows"
+        case nMels = "n_mels"
+        case nFFT = "n_fft"
+        case preemph
+        case nPaddedSamples = "n_padded_samples"
+        case validFrames = "valid_frames"
+        case encFrames = "enc_frames"
+        case jointHidden = "joint_hidden"
+        case predHidden = "pred_hidden"
+        case predLayers = "pred_layers"
+        case vocabSize = "vocab_size"
+        case blankIdx = "blank_idx"
+        case durations
+        case decodeWidth = "decode_width"
+    }
+
+    /// Seconds of audio per encoder frame: the resolution of every word time.
+    var secondsPerFrame: Double { Double(hopLength * 8) / Double(sampleRate) }
+
+    func validate() throws {
+        guard sampleRate > 0, hopLength > 0, nSamples > 0, nRows > 0, nMels > 0,
+              nFFT > 0, encFrames > 0, jointHidden > 0, predHidden > 0, predLayers > 0
+        else { throw VozError.invalidModel("model metadata has invalid geometry") }
+        guard vocabSize > 0, blankIdx >= 0, blankIdx <= vocabSize, !durations.isEmpty
+        else { throw VozError.invalidModel("model metadata has an invalid vocabulary") }
+        guard decodeWidth > 0, nPaddedSamples >= nSamples
+        else { throw VozError.invalidModel("model metadata has invalid decode geometry") }
+    }
+}
+#endif

--- a/Sources/Voz/Pipeline.swift
+++ b/Sources/Voz/Pipeline.swift
@@ -1,0 +1,699 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+
+/// The recognition pipeline: mel, encoder, and a lane-batched transducer decode.
+///
+/// Not `Sendable` and not reentrant: it owns preallocated buffers that every
+/// call mutates. `Voz` serialises access through an actor.
+final class Pipeline {
+    private let assets: Assets
+    private var configuration: Configuration { assets.configuration }
+
+    // Aligning boundaries to silence costs about 13% of throughput - 292 to 255
+    // RTFx on ten minutes of speech, 239 to 208 over half an hour - which is
+    // the 1.12x extra windows it creates and nothing else. The scan itself does
+    // not show up. Measured back to back in one binary via VOZ_FIXED_WINDOWS.
+
+    /// Windows end at the quietest point in this much audio before the nominal
+    /// boundary, so a window rarely stops in the middle of a word.
+    /// Swept on half an hour of narration: 1 s puts boundaries inside speech and
+    /// costs 405 deletions, 3 s costs 34, and going wider buys little for the
+    /// windows it adds. Overridable so the sweep can be repeated.
+    private static let boundarySearch =
+        Double(ProcessInfo.processInfo.environment["VOZ_SEARCH"] ?? "") ?? 3.0
+    /// Energy is measured over frames this long when looking for that point.
+    private static let boundaryFrame = 0.02
+    /// A frame this far below the passage's median energy is a real pause.
+    private static let silenceFactor: Float = 0.05
+    /// Failing that, the best dip between words.
+    private static let valleyFactor: Float = 0.35
+    /// How much louder than the quietest candidate a boundary may still be.
+    private static let nearFloor: Float = 2.0
+    /// How much of a refused window to keep when giving it a second length.
+    /// Shortening by a second recovered every refused window that was tested.
+    private static let retryFraction = 0.93
+    /// How many retries may recover nothing before retrying is abandoned.
+    private static let futileRetryLimit = 8
+    /// Audio a window may leave after its last word before it counts as having
+    /// stopped early. Healthy windows finish within a frame or two of their end;
+    /// the ones worth rerunning leave seconds.
+    /// Swept: 2.5 s beats 4 s and 6 s, which lose the Czech and Dutch gains
+    /// without recovering anything in exchange.
+    private static let truncationTail = 2.5
+    /// A window this quiet relative to full scale is silence, and a recogniser
+    /// returning nothing for it is correct rather than refusing.
+    private static let speechFloor: Float = 1e-5
+    /// How loud a silent stretch must be, against the window holding it, to be
+    /// speech the recogniser skipped rather than a pause it was right about.
+    private static let gapFloor: Float = 0.25
+
+    /// How many windows are encoded before their decode runs. Bounds peak memory
+    /// (each window's encoder output is ~240 KB) and gives progress somewhere to
+    /// be reported from, while staying long enough that the decoder's lanes stay
+    /// full for all but the last group.
+    private static let batchWindows =
+        Int(ProcessInfo.processInfo.environment["VOZ_BATCH_WINDOWS"] ?? "") ?? 64
+
+    private let rows: Buffer
+    private let melOut: Buffer
+    private let keyBias: Buffer
+    private let padMask: Buffer
+    private let melMask: Buffer
+    private let encOut: Buffer
+    private let embed: Buffer
+    private let hIn: Buffer
+    private let cIn: Buffer
+    private let encStep: Buffer
+    private let logitsOut: Buffer
+    private let hOut: Buffer
+    private let cOut: Buffer
+
+    private let melProvider: MLDictionaryFeatureProvider
+    private let encoderProvider: MLDictionaryFeatureProvider
+    private let stepProvider: MLDictionaryFeatureProvider
+    private let melOptions = MLPredictionOptions()
+    private let encoderOptions = MLPredictionOptions()
+    private let stepOptions = MLPredictionOptions()
+
+    init(assets: Assets) throws {
+        self.assets = assets
+        let c = assets.configuration
+        let lanes = assets.decodeLanes
+        let hidden = c.predLayers * c.predHidden
+
+        rows = try Buffer([1, c.hopLength, 1, c.nRows])
+        melOut = try Buffer([1, c.nMels, 1, c.validFrames])
+        keyBias = try Buffer([1, c.encFrames, 1, 1])
+        padMask = try Buffer([1, 1, 1, c.encFrames])
+        melMask = try Buffer([1, 1, 1, c.validFrames])
+        encOut = try Buffer([1, c.jointHidden, 1, c.encFrames])
+        embed = try Buffer([lanes, c.predHidden, 1, 1])
+        hIn = try Buffer([lanes, hidden, 1, 1])
+        cIn = try Buffer([lanes, hidden, 1, 1])
+        encStep = try Buffer([lanes, c.jointHidden, 1, c.decodeWidth])
+        logitsOut = try Buffer([lanes, c.vocabSize + 1 + c.durations.count, 1, c.decodeWidth])
+        hOut = try Buffer([lanes, hidden, 1, 1])
+        cOut = try Buffer([lanes, hidden, 1, 1])
+
+        // pad_mask stays all ones on purpose. Zeroing the convolution input over
+        // padded frames makes those frames explode through the BatchNorm that
+        // follows, until their attention scores overpower the additive mask and
+        // silence the whole utterance. Masking attention alone is enough.
+        padMask.ptr.update(repeating: 1, count: padMask.count)
+
+        melProvider = try MLDictionaryFeatureProvider(dictionary: [
+            "audio_rows": MLFeatureValue(multiArray: rows.array),
+            "mel_mask": MLFeatureValue(multiArray: melMask.array)])
+        encoderProvider = try MLDictionaryFeatureProvider(dictionary: [
+            "mel": MLFeatureValue(multiArray: melOut.array),
+            "key_bias": MLFeatureValue(multiArray: keyBias.array),
+            "pad_mask": MLFeatureValue(multiArray: padMask.array)])
+        stepProvider = try MLDictionaryFeatureProvider(dictionary: [
+            "embed": MLFeatureValue(multiArray: embed.array),
+            "h_in": MLFeatureValue(multiArray: hIn.array),
+            "c_in": MLFeatureValue(multiArray: cIn.array),
+            "enc_step": MLFeatureValue(multiArray: encStep.array)])
+        // Write predictions straight into our own storage instead of letting
+        // Core ML allocate a result per call.
+        melOptions.outputBackings = ["mel": melOut.array]
+        encoderOptions.outputBackings = ["enc_proj": encOut.array]
+        stepOptions.outputBackings = [
+            "logits": logitsOut.array, "h_out": hOut.array, "c_out": cOut.array]
+    }
+
+    // MARK: - Frontend
+
+    /// Lay PCM out the way the mel model expects.
+    ///
+    /// NeMo's featurizer runs `stft(center=True)`, so the signal is zero-padded
+    /// by `nFFT / 2` on the left; without that every frame shifts by 256 samples
+    /// and the transcript changes while still reading naturally. The right pad is
+    /// the geometric tail `preemph^(j+1) * x[-1]` rather than zeros, which is
+    /// what makes in-graph preemphasis agree with NeMo's preemphasise-then-pad
+    /// order across the boundary.
+    private func frame(_ window: ArraySlice<Float>) {
+        rows.zero()
+        let hop = configuration.hopLength
+        let pad = configuration.nFFT / 2
+        let total = min(configuration.nPaddedSamples, configuration.nRows * hop)
+        let n = configuration.nSamples
+        let base = window.startIndex
+        let last: Float = window.count == n ? (window.last ?? 0) : 0
+        for i in pad..<total {
+            let k = i - pad
+            var value: Float
+            if k < n {
+                value = k < window.count ? window[base + k] : 0
+            } else {
+                value = last == 0 ? 0 : powf(configuration.preemph, Float(k - n + 1)) * last
+            }
+            if value != 0 { rows.ptr[(i % hop) * configuration.nRows + i / hop] = Element(value) }
+        }
+    }
+
+    /// One window of audio to encoder projections, written into `destination`.
+    private func encode(window: ArraySlice<Float>, validFrames: Int,
+                        into destination: UnsafeMutablePointer<Element>) throws {
+        frame(window)
+        // Normalization statistics must be taken over the frames that actually
+        // hold audio. A window is a fixed 15 s, so a five-second clip is two
+        // thirds padding, and including it drags the mean down and squashes the
+        // speech: the frontend then agrees with the reference implementation to
+        // 2.7 dB rather than 140 dB, and short clips lose accuracy badly.
+        let melFrames = configuration.validFrames
+        let melValid = max(1, min(melFrames, window.count / configuration.hopLength + 1))
+        melMask.ptr.update(repeating: 1, count: melValid)
+        for i in melValid..<melFrames { melMask.ptr[i] = 0 }
+        _ = try assets.mel.prediction(from: melProvider, options: melOptions)
+        let frames = configuration.encFrames
+        let valid = max(1, min(frames, validFrames))
+        keyBias.zero()
+        // A short window is mostly silence. Without this the encoder attends
+        // over it; -40000 is a float16-representable stand-in for -infinity.
+        for i in valid..<frames { keyBias.ptr[i] = Element(-40000) }
+        _ = try assets.encoder.prediction(from: encoderProvider, options: encoderOptions)
+        destination.update(from: encOut.ptr, count: configuration.jointHidden * frames)
+    }
+
+    // MARK: - Decode
+
+    /// Greedy TDT decode of several independent windows in the lanes of one call.
+    ///
+    /// Decoding is dispatch-bound: a call costs about the same whatever work it
+    /// carries (eight times the window is 1% slower), and every emitted token
+    /// forces its own dispatch because it changes the prediction state. Windows
+    /// do not interact, so running several in lockstep amortises that fixed cost,
+    /// and a lane that finishes takes the next pending window immediately rather
+    /// than idling until the whole group is done.
+    private func decode(projections: [Element], valids: [Int], ends: inout [[Int]],
+                        tokens: inout [[Int]], frames: inout [[Int]]) throws {
+        let c = configuration
+        let width = c.decodeWidth
+        let lanes = assets.decodeLanes
+        let joint = c.jointHidden
+        let total = c.encFrames
+        let vocab = c.vocabSize
+        let blank = c.blankIdx
+        let logitCount = vocab + 1 + c.durations.count
+        let stride = joint * total
+        let hidden = c.predLayers * c.predHidden
+
+        var pending = 0
+        var slot = [Int](repeating: -1, count: lanes)
+        var position = [Int](repeating: 0, count: lanes)
+        var label = [Int](repeating: blank, count: lanes)
+        var emitted = [Int](repeating: 0, count: lanes)
+        var limit = [Int](repeating: 0, count: lanes)
+        hIn.zero(); cIn.zero(); embed.zero(); encStep.zero()
+
+        func admit(_ lane: Int) {
+            guard pending < valids.count else { slot[lane] = -1; return }
+            slot[lane] = pending
+            position[lane] = 0
+            label[lane] = blank
+            emitted[lane] = 0
+            limit[lane] = max(1, min(total, valids[pending]))
+            (hIn.ptr + lane * hidden).update(repeating: 0, count: hidden)
+            (cIn.ptr + lane * hidden).update(repeating: 0, count: hidden)
+            pending += 1
+        }
+        for lane in 0..<lanes { admit(lane) }
+
+        while slot.contains(where: { $0 >= 0 }) {
+            projections.withUnsafeBufferPointer { source in
+                assets.embedding.withUnsafeBufferPointer { table in
+                    for lane in 0..<lanes where slot[lane] >= 0 {
+                        (embed.ptr + lane * c.predHidden)
+                            .update(from: table.baseAddress! + label[lane] * c.predHidden,
+                                    count: c.predHidden)
+                        let span = min(width, limit[lane] - position[lane])
+                        let base = source.baseAddress! + slot[lane] * stride
+                        for channel in 0..<joint {
+                            let destination = encStep.ptr + (lane * joint + channel) * width
+                            destination.update(from: base + channel * total + position[lane],
+                                               count: span)
+                            if span < width {
+                                (destination + span).update(repeating: 0, count: width - span)
+                            }
+                        }
+                    }
+                }
+            }
+            _ = try assets.decodeStep.prediction(from: stepProvider, options: stepOptions)
+
+            for lane in 0..<lanes where slot[lane] >= 0 {
+                let window = slot[lane]
+                let span = min(width, limit[lane] - position[lane])
+                let laneLogits = logitsOut.ptr + lane * logitCount * width
+                var offset = 0
+                var didEmit = false
+                while offset < span {
+                    var best = 0
+                    var bestValue = Float(laneLogits[offset])
+                    for k in 1...vocab {
+                        let value = Float(laneLogits[k * width + offset])
+                        if value > bestValue { bestValue = value; best = k }
+                    }
+                    var bestDuration = 0
+                    var bestDurationValue = Float(laneLogits[(vocab + 1) * width + offset])
+                    for k in 1..<c.durations.count {
+                        let value = Float(laneLogits[(vocab + 1 + k) * width + offset])
+                        if value > bestDurationValue { bestDurationValue = value; bestDuration = k }
+                    }
+                    let duration = c.durations[bestDuration]
+                    if best != blank {
+                        tokens[window].append(best)
+                        frames[window].append(position[lane] + offset)
+                        // How many frames the recogniser says this token spans.
+                        // It predicts one per token and the decode loop uses it
+                        // to advance; kept here because it is also the only
+                        // acoustic evidence available for where a word ends.
+                        ends[window].append(position[lane] + offset + duration)
+                        (hIn.ptr + lane * hidden).update(from: hOut.ptr + lane * hidden, count: hidden)
+                        (cIn.ptr + lane * hidden).update(from: cOut.ptr + lane * hidden, count: hidden)
+                        label[lane] = best
+                        emitted[lane] += 1
+                        var step = duration
+                        // TDT may predict a zero duration; force progress so a
+                        // lane cannot emit forever on one frame.
+                        if step == 0 && emitted[lane] >= 10 { step = 1; emitted[lane] = 0 }
+                        position[lane] += offset + step
+                        didEmit = true
+                        break
+                    }
+                    emitted[lane] = 0
+                    offset += duration > 0 ? duration : 1
+                }
+                if !didEmit { position[lane] += max(offset, 1) }
+                if position[lane] >= limit[lane] { admit(lane) }
+            }
+        }
+    }
+
+    /// The longest stretch of a window that produced no words, as frames.
+    ///
+    /// Counts the run before the first word and the run after the last as well
+    /// as the runs between, so a window that starts late, stops early, or falls
+    /// silent in the middle are all the same question.
+    private func widestSilence(_ frames: [Int], upTo valid: Int) -> (Int, Int) {
+        var best = (0, 0)
+        var previous = 0
+        for frame in frames {
+            if frame - previous > best.1 - best.0 { best = (previous, frame) }
+            previous = Swift.max(previous, frame)
+        }
+        if valid - previous > best.1 - best.0 { best = (previous, valid) }
+        return best
+    }
+
+    /// The quietest 20 ms in the second before `at` and the half second after.
+    ///
+    /// Used to place a recovery window, so that it begins between words like
+    /// every other window rather than wherever the previous one happened to
+    /// stop.
+    private func quietestPoint(near at: Int, from lowest: Int, limit: Int,
+                               audio: (Int) -> Float) -> Int {
+        let c = configuration
+        let frame = Swift.max(1, Int(Self.boundaryFrame * Double(c.sampleRate)))
+        let first = Swift.max(lowest, at - c.sampleRate)
+        let last = Swift.min(limit - frame, at + c.sampleRate / 2)
+        guard last > first else { return Swift.max(lowest, Swift.min(at, limit - 1)) }
+        var bestAt = at
+        var best = Float.greatestFiniteMagnitude
+        var index = first
+        while index + frame <= last {
+            var sum: Float = 0
+            for i in index..<(index + frame) {
+                let value = audio(i)
+                sum += value * value
+            }
+            if sum < best { best = sum; bestAt = index + frame / 2 }
+            index += frame
+        }
+        return bestAt
+    }
+
+    /// Mean square level of a span, for comparing one stretch against another.
+    private func loudness(_ window: ArraySlice<Float>) -> Float {
+        var sum: Float = 0
+        var count = 0
+        var i = window.startIndex
+        while i < window.endIndex {
+            sum += window[i] * window[i]
+            count += 1
+            i += 16
+        }
+        return count > 0 ? sum / Float(count) : 0
+    }
+
+    /// Does this window hold anything worth transcribing?
+    ///
+    /// Only used to tell a window the recogniser refused from one that is
+    /// genuinely silent, so that silence is not re-run pointlessly.
+    private func holdsSpeech(_ window: ArraySlice<Float>) -> Bool {
+        var sum: Float = 0
+        var count = 0
+        var i = window.startIndex
+        while i < window.endIndex {
+            sum += window[i] * window[i]
+            count += 1
+            i += 16   // every sixteenth sample is plenty for a level check
+        }
+        return count > 0 && sum / Float(count) > Self.speechFloor
+    }
+
+    /// Where each window should start, in samples.
+    ///
+    /// A fixed 15 s grid cuts wherever it lands, and the model is measurably
+    /// sensitive to that: a crop beginning mid-word can decode to nothing at all
+    /// or stop emitting well before its end, while the same audio at any other
+    /// offset transcribes normally. That is the model's behaviour and not this
+    /// export's - float32 PyTorch reproduces it, and the encoder matches NeMo's
+    /// reference to 116 dB - so the fix is to stop handing it crops it handles
+    /// badly rather than to check its output afterwards.
+    ///
+    /// The model was trained on utterances, which begin and end in silence, so
+    /// each boundary is placed at the quietest point in the last few seconds of
+    /// the window. Windows are therefore up to `nSamples` long and usually a
+    /// little shorter, and each one starts where the speaker paused.
+    /// Where the window after `start` should begin, given a way to read audio.
+    ///
+    /// Only ever looks inside `[start, start + nSamples]`, which is what lets a
+    /// long file be walked with a sliding buffer instead of being held whole.
+    private func nextBoundary(after start: Int, audio: (Int) -> Float) -> Int {
+        let c = configuration
+        let window = c.nSamples
+        let search = Int(Self.boundarySearch * Double(c.sampleRate))
+        let frame = max(1, Int(Self.boundaryFrame * Double(c.sampleRate)))
+        let from = start + window - search
+        var scores: [(at: Int, energy: Float)] = []
+        var at = from
+        while at + frame <= start + window {
+            var sum: Float = 0
+            for i in at..<(at + frame) { sum += audio(i) * audio(i) }
+            scores.append((at + frame / 2, sum / Float(frame)))
+            at += frame
+        }
+        guard !scores.isEmpty else { return start + window }
+        var bestAt = start + window
+        let floorEnergy = Swift.max(scores.map(\.energy).min() ?? 0, 1e-9)
+        let admissible = scores.filter { $0.energy <= Self.nearFloor * floorEnergy }
+        let pool = admissible.isEmpty ? scores : admissible
+        var bestScore = Float.greatestFiniteMagnitude
+        for candidate in pool {
+            let earliness = Float(start + window - candidate.at) / Float(search)
+            let score = candidate.energy * (1 + earliness)
+            if score <= bestScore { bestScore = score; bestAt = candidate.at }
+        }
+        return bestAt
+    }
+
+
+    // MARK: - Entry point
+
+    /// Transcribe a stream of mono 16 kHz samples.
+    ///
+    /// The audio is walked with a sliding buffer rather than held whole. Only
+    /// the batch being worked on has to be resident, so peak memory is set by
+    /// the batch size and not by the length of the recording: an hour of audio
+    /// is 230 MB of `Float`, and a video editor has a timeline and its own
+    /// buffers to fit alongside it.
+    func run(stream: inout some AudioStream, progress: (Double) -> Void) throws -> (String, [Word]) {
+        let c = configuration
+        let frames = c.encFrames
+        let stride = c.jointHidden * frames
+        let window = c.nSamples
+
+        var buffer: [Float] = []
+        var origin = 0                    // absolute index of buffer[0]
+        var exhausted = false
+        var available: Int { origin + buffer.count }
+
+        /// Read until the buffer covers up to `absolute`, or the source ends.
+        func ensure(through absolute: Int) throws {
+            while !exhausted && available < absolute {
+                let wanted = Swift.max(absolute - available, c.sampleRate * 4)
+                if try stream.read(wanted, into: &buffer) == 0 { exhausted = true }
+            }
+        }
+        /// Release audio behind `absolute`; it is never looked at again.
+        ///
+        /// Rebuilt rather than trimmed in place: `removeFirst` keeps the array's
+        /// capacity, so the storage would stay as large as the largest span ever
+        /// held and none of this would give memory back.
+        func release(before absolute: Int) {
+            let drop = Swift.min(Swift.max(absolute - origin, 0), buffer.count)
+            guard drop > 0 else { return }
+            buffer = Array(buffer[drop...])
+            origin += drop
+        }
+        func slice(_ low: Int, _ high: Int) -> ArraySlice<Float> {
+            buffer[(low - origin)..<(high - origin)]
+        }
+        let total = stream.totalSamples
+        // Progress is how much audio has been read and encoded, which advances
+        // in order through the file. Reporting from the splice pass as well sent
+        // it back to the start of the batch each time, since the two passes walk
+        // the same windows.
+        func reported(_ at: Int) -> Double {
+            guard let total, total > 0 else { return 0 }
+            return Swift.min(1, Double(at + window) / Double(total))
+        }
+
+        var words: [Word] = []
+        var futileRetries = 0
+        var starts: [Int] = [0]
+        var processed = 0
+
+        while true {
+            // Extend the boundary list to fill a batch, reading only as far as
+            // each decision needs. This has to happen before the loop decides
+            // it is finished: checking `processed < starts.count` first stops
+            // after a single batch, which silently truncated any file longer
+            // than one, and left the transcript reading perfectly well.
+            while starts.count - processed < Self.batchWindows {
+                let last = starts[starts.count - 1]
+                try ensure(through: last + window + 1)
+                guard available > last + window else { break }
+                starts.append(nextBoundary(after: last) { buffer[$0 - origin] })
+            }
+            guard processed < starts.count else { break }
+            let group = processed..<Swift.min(processed + Self.batchWindows, starts.count)
+            // Everything before this batch is finished with. Releasing here
+            // rather than after the batch matters: at that point the boundary
+            // list has already been extended to exactly the batch that was just
+            // processed, so the release never fired and the buffer grew with the
+            // file - 5.8 MB for every minute of audio.
+            release(before: starts[group.lowerBound])
+            try ensure(through: starts[group.upperBound - 1] + window)
+            var projections = [Element](repeating: 0, count: group.count * stride)
+            var valids = [Int](repeating: frames, count: group.count)
+
+            try projections.withUnsafeMutableBufferPointer { buffer in
+                for (i, w) in group.enumerated() {
+                    let low = starts[w]
+                    let high = Swift.min(low + c.nSamples, available)
+                    // ceil(samples / hop / 8): rounding this down loses the final frame.
+                    valids[i] = Swift.max(1, Swift.min(
+                        frames, (high - low + c.hopLength * 8 - 1) / (c.hopLength * 8)))
+                    try encode(window: slice(low, high), validFrames: valids[i],
+                               into: buffer.baseAddress! + i * stride)
+                    progress(reported(low))
+                }
+            }
+
+            var tokens = [[Int]](repeating: [], count: group.count)
+            var emitFrames = [[Int]](repeating: [], count: group.count)
+            var emitEnds = [[Int]](repeating: [], count: group.count)
+            var extra = [Int: ([Int], [Int], [Int], Int)]()
+            try decode(projections: projections, valids: valids, ends: &emitEnds,
+                       tokens: &tokens, frames: &emitFrames)
+
+            // Some windows come back empty even though they are full of speech.
+            // This is the recogniser's own behaviour and not this runtime's: the
+            // reference implementation refuses exactly the same crops, and on
+            // one ten-minute file about a quarter of all fifteen-second crops at
+            // half-second spacing produce nothing at all. It is not the audio
+            // level, and it is not where the crop starts relative to a word; the
+            // same seconds transcribe normally at a different crop length, and
+            // the boundary between working and refusing moves with the content.
+            //
+            // Nothing in the boundary search can steer around that, so a refused
+            // window is given the one thing that reliably changes the outcome: a
+            // different length. Every refused window tested recovered when its
+            // audio was shortened, and this costs a second pass only over the
+            // windows that produced nothing, which is normally none of them.
+            // Audio that is not speech at all - music, room tone, a held
+            // note - legitimately produces nothing from every window, and
+            // retrying all of them doubles the work to learn that. So a run of
+            // retries that recovers nothing switches retrying off, and any
+            // recovery switches it back on: the cost is bounded on material
+            // that has nothing to say, without giving up on a file that is
+            // quiet for a while and then starts talking.
+            // A window can fail in two ways, and they look different. It can
+            // produce nothing at all, or it can produce a plausible transcript
+            // and stop partway through - one French window emitted 37% of its
+            // audio and read perfectly, so nothing downstream could tell. Both
+            // are the same behaviour and both are fixed by the same thing,
+            // running the window at a different length: that one goes from 37%
+            // to 99% at fourteen seconds instead of fifteen.
+            //
+            // A window counts as having stopped early by how much audio it left
+            // after its last word, and only if that audio holds speech, so one
+            // whose tail is genuinely silent is left alone.
+            let refused = futileRetries >= Self.futileRetryLimit ? [] :
+                group.enumerated().filter { i, w in
+                    let low = starts[w]
+                    let high = Swift.min(low + c.nSamples, available)
+                    if tokens[i].isEmpty { return holdsSpeech(slice(low, high)) }
+                    // The hole is not always at the end. A Czech window reached
+                    // its final frame and still emitted a third of the words its
+                    // neighbours did, because it said nothing at all across ten
+                    // seconds in the middle. Looking only at what follows the
+                    // last word misses that entirely, so this takes the largest
+                    // silence between consecutive words, wherever it falls.
+                    let (from, to) = widestSilence(emitFrames[i], upTo: valids[i])
+                    guard Double(to - from) * c.secondsPerFrame > Self.truncationTail
+                    else { return false }
+                    let a = Swift.min(high, low + Int(Double(from) * c.secondsPerFrame
+                        * Double(c.sampleRate)))
+                    let b = Swift.min(high, low + Int(Double(to) * c.secondsPerFrame
+                        * Double(c.sampleRate)))
+                    // Judged against this window's own loudness rather than an
+                    // absolute floor: a pause with room tone in it clears a
+                    // fixed threshold, and rerunning genuine pauses costs more
+                    // than it recovers.
+                    return a < b && loudness(slice(a, b)) > Self.gapFloor * loudness(slice(low, high))
+                }
+            if !refused.isEmpty {
+                // Retried together rather than one at a time, for the same
+                // reason the first pass batches: a decode call costs about the
+                // same whatever it carries. Run singly, a file of pure
+                // non-speech - where every window legitimately produces
+                // nothing and every one is retried - ran at a third of its
+                // usual speed instead of half.
+                var retryProjections = [Element](repeating: 0, count: refused.count * stride)
+                var retryValids = [Int](repeating: frames, count: refused.count)
+                var retryStarts = [Int](repeating: 0, count: refused.count)
+                try retryProjections.withUnsafeMutableBufferPointer { out in
+                    for (slot, entry) in refused.enumerated() {
+                        let windowStart = starts[entry.element]
+                        // Where to run the window again. A window that produced
+                        // nothing gets the same audio at a different length,
+                        // which is the only thing that reliably changes the
+                        // outcome. A window that stopped early gets something
+                        // better than luck: the audio it missed, as a window of
+                        // its own, starting a second before it gave up so the
+                        // splice has an overlap to align on. Rerunning a
+                        // truncated window at a different length is a coin flip
+                        // - it rescued one of French's three worst and left the
+                        // other two exactly where they were - because the model
+                        // is sensitive to the crop in a way that does not
+                        // reward guessing.
+                        let stopped = widestSilence(emitFrames[entry.offset],
+                                                    upTo: valids[entry.offset]).0
+                        // Start the recovery window at the quietest point near
+                        // where the last one gave up, rather than exactly there.
+                        // Every other window start is chosen this way for the
+                        // same reason: the recogniser is sensitive to where a
+                        // crop begins, so handing it an arbitrary one wastes the
+                        // rerun.
+                        let gaveUp = windowStart
+                            + Int(Double(stopped) * c.secondsPerFrame * Double(c.sampleRate))
+                        let low = tokens[entry.offset].isEmpty ? windowStart
+                            // `buffer` is the audio, not `out`: this searches the
+                            // waveform for a quiet point. The two were briefly the
+                            // same name, and this read went into the projections
+                            // with sample indices, which is unmapped memory a few
+                            // megabytes in.
+                            : quietestPoint(near: gaveUp, from: windowStart,
+                                            limit: available, audio: { buffer[$0 - origin] })
+                        let high = Swift.min(low + c.nSamples, available)
+                        let shortened = tokens[entry.offset].isEmpty
+                            ? low + Int(Self.retryFraction * Double(high - low)) : high
+                        retryStarts[slot] = low
+                        retryValids[slot] = Swift.max(1, Swift.min(
+                            frames, (shortened - low + c.hopLength * 8 - 1) / (c.hopLength * 8)))
+                        try encode(window: slice(low, shortened),
+                                   validFrames: retryValids[slot],
+                                   into: out.baseAddress! + slot * stride)
+                    }
+                }
+                var retryTokens = [[Int]](repeating: [], count: refused.count)
+                var retryFrames = [[Int]](repeating: [], count: refused.count)
+                var retryEnds = [[Int]](repeating: [], count: refused.count)
+                try decode(projections: retryProjections, valids: retryValids,
+                           ends: &retryEnds,
+                           tokens: &retryTokens, frames: &retryFrames)
+                for (slot, entry) in refused.enumerated() {
+                    if tokens[entry.offset].isEmpty {
+                        // Nothing to keep, so the rerun simply replaces it.
+                        tokens[entry.offset] = retryTokens[slot]
+                        emitFrames[entry.offset] = retryFrames[slot]
+                        emitEnds[entry.offset] = retryEnds[slot]
+                    } else {
+                        // The window said something before it stopped, and that
+                        // part is good. The rerun covers what came after it, on
+                        // its own timeline, and is spliced in behind it.
+                        extra[entry.offset] = (retryTokens[slot], retryFrames[slot],
+                                               retryEnds[slot], retryStarts[slot])
+                    }
+                    let recovered = !retryTokens[slot].isEmpty
+                        && Double(retryValids[slot] - (retryFrames[slot].last ?? 0))
+                            * c.secondsPerFrame <= Self.truncationTail
+                    if recovered { futileRetries = 0 } else { futileRetries += 1 }
+                }
+            }
+
+            for (i, w) in group.enumerated() {
+                // The window's position in the file is how much audio precedes
+                // it, not how many encoder frames do. Subsampling rounds up --
+                // 1500 mel frames become ceil(1500/8) = 188 - so a frame-based
+                // offset runs 40 ms long per window and accumulates: 9.6 s of
+                // drift across an hour of audio.
+                //
+                // Every word the window produced is kept, including the part
+                // past the next boundary. Consecutive windows overlap, so that
+                // tail is what lets the splice align them; cutting purely on
+                // time duplicated any word whose two estimates straddled the
+                // seam, which is where "they they walked" came from.
+                let low = starts[w]
+                let high = Swift.min(low + c.nSamples, available)
+                let produced = refineEnds(
+                    timedWords(tokens: tokens[i], frames: emitFrames[i],
+                               ends: emitEnds[i],
+                               vocabulary: assets.vocabulary,
+                               secondsPerFrame: c.secondsPerFrame,
+                               timeOffset: Double(low) / Double(c.sampleRate)),
+                    samples: slice(low, high),
+                    windowStart: Double(low) / Double(c.sampleRate),
+                    sampleRate: Double(c.sampleRate))
+                func join(_ produced: [Word], at sample: Int) {
+                    if words.isEmpty {
+                        words = produced
+                    } else {
+                        words = spliceOverlap(words, produced,
+                                              boundary: Double(sample) / Double(c.sampleRate),
+                                              overlap: Self.boundarySearch)
+                    }
+                }
+                join(produced, at: starts[w])
+                if let (t, f, e, at) = extra[i] {
+                    join(refineEnds(timedWords(tokens: t, frames: f, ends: e,
+                                               vocabulary: assets.vocabulary,
+                                               secondsPerFrame: c.secondsPerFrame,
+                                               timeOffset: Double(at) / Double(c.sampleRate)),
+                                    samples: slice(at, Swift.min(at + c.nSamples, available)),
+                                    windowStart: Double(at) / Double(c.sampleRate),
+                                    sampleRate: Double(c.sampleRate)),
+                         at: at)
+                }
+            }
+            processed = group.upperBound
+        }
+        words = clampMonotonic(words)
+        return (words.map(\.text).joined(separator: " "), words)
+    }
+}
+#endif

--- a/Sources/Voz/Voz+Audio.swift
+++ b/Sources/Voz/Voz+Audio.swift
@@ -1,0 +1,49 @@
+#if canImport(CoreML)
+import AudioIO
+import CoreML
+import Foundation
+
+public extension Voz {
+    /// Transcribe an audio file. Any format `AudioIO` can decode is accepted and
+    /// is downmixed and resampled to the rate the model expects.
+    func transcribe(
+        path: String,
+        progress: @Sendable (Progress) -> Void = { _ in }
+    ) async throws -> Result {
+        #if canImport(AVFoundation)
+        // Read and convert as we go. Decoding the file up front costs 230 MB of
+        // `Float` per hour of audio before the model has allocated anything.
+        var stream = try FileAudioStream(url: URL(fileURLWithPath: path),
+                                         sampleRate: sampleRate)
+        let duration = Double(stream.totalSamples ?? 0) / sampleRate
+        return try transcribe(stream: &stream, duration: duration, progress: progress)
+        #else
+        let samples = try await AudioIO.decode(path: path, sampleRate: sampleRate)
+        guard !samples.isEmpty else {
+            throw VozError.invalidAudio("\(path) decoded to no audio")
+        }
+        return try transcribe(samples: samples, progress: progress)
+        #endif
+    }
+
+    /// Transcribe an audio file at `url`.
+    func transcribe(
+        _ url: URL,
+        progress: @Sendable (Progress) -> Void = { _ in }
+    ) async throws -> Result {
+        try await transcribe(path: url.path, progress: progress)
+    }
+
+    /// Transcribe already-decoded audio at an arbitrary rate.
+    func transcribe(
+        samples: [Float],
+        sampleRate rate: Double,
+        progress: @Sendable (Progress) -> Void = { _ in }
+    ) throws -> Result {
+        let converted = rate == sampleRate
+            ? samples
+            : Resample.linear(samples, from: rate, to: sampleRate)
+        return try transcribe(samples: converted, progress: progress)
+    }
+}
+#endif

--- a/Sources/Voz/Voz.swift
+++ b/Sources/Voz/Voz.swift
@@ -1,0 +1,158 @@
+#if canImport(CoreML)
+import CoreML
+import Foundation
+#endif
+import DesertAnt
+
+public enum VozError: Error, CustomStringConvertible, Sendable {
+    case unsupportedPlatform
+    case invalidModel(String)
+    case invalidAudio(String)
+
+    public var description: String {
+        switch self {
+        case .unsupportedPlatform:
+            return "Voz requires Core ML and runs on Apple platforms only"
+        case .invalidModel(let m): return "invalid model: \(m)"
+        case .invalidAudio(let m): return "invalid audio: \(m)"
+        }
+    }
+}
+
+#if canImport(CoreML)
+
+/// On-device speech recognition: a transcript with word-level timestamps,
+/// running entirely on the Neural Engine.
+///
+/// ```swift
+/// let voz = try await Voz()
+/// let result = try await voz.transcribe(url) { print($0.fractionCompleted) }
+/// print(result.text, result.words.first?.start ?? 0)
+/// ```
+///
+/// The model downloads on first use and is cached; pass a `directory` to adopt
+/// files you have already placed somewhere, or call ``download(progress:)`` to
+/// fetch it ahead of time.
+public actor Voz {
+
+    /// How far along a transcription is, and what it has produced so far.
+    public struct Progress: Sendable {
+        /// 0...1 over the whole request.
+        public let fractionCompleted: Double
+    }
+
+    public struct Result: Sendable {
+        /// The full transcript.
+        public let text: String
+        /// Every word with the time it starts. Resolution is 80 ms.
+        public let words: [Word]
+        /// Length of the audio transcribed.
+        public let duration: TimeInterval
+        /// Wall-clock time spent transcribing it.
+        public let processingTime: TimeInterval
+        /// Seconds of audio processed per second of wall clock.
+        public var realtimeFactor: Double {
+            processingTime > 0 ? duration / processingTime : 0
+        }
+    }
+
+    private let pipeline: Pipeline
+    /// Audio rate the model expects. Input at another rate is resampled.
+    public nonisolated let sampleRate: Double
+
+
+    /// The languages the model was trained on, as ISO 639-1 codes.
+    ///
+    /// It does not detect which one it is hearing, and audio in a language that
+    /// is not here produces confident nonsense rather than an error. A caller
+    /// routing mixed input should name the language first (see `Ear`) and check
+    /// it against this set.
+    public static let supportedLanguages: Set<String> = [
+        "bg", "cs", "da", "de", "el", "en", "es", "et", "fi",
+        "fr", "hr", "hu", "it", "lt", "lv", "mt", "nl", "pl",
+        "pt", "ro", "ru", "sk", "sl", "sv", "uk",
+    ]
+
+    // MARK: - Availability
+
+    /// Whether the model is already on disk, so a caller can decide whether to
+    /// show a download step.
+    public static func isDownloaded(directory: String? = nil, cacheRoot: String? = nil) -> Bool {
+        VozModel.isAvailable(directory: directory, cacheRoot: cacheRoot)
+    }
+
+    /// Fetch the model without loading it, for downloading during onboarding.
+    ///
+    /// Worth doing: the first load after a download pays a one-time Neural Engine
+    /// specialization of roughly 20 s, and every load after it takes about
+    /// 0.2 s. Doing both here keeps that cost off the first transcription.
+    @discardableResult
+    public static func download(
+        directory: String? = nil,
+        cacheRoot: String? = nil,
+        progress: @Sendable @escaping (DownloadProgress) -> Void = { _ in }
+    ) async throws -> String {
+        try await VozModel.resolve(directory: directory, cacheRoot: cacheRoot,
+                                        progress: progress).rootPath
+    }
+
+    // MARK: - Creation
+
+    /// Load the model, downloading it first if needed.
+    public init(
+        directory: String? = nil,
+        cacheRoot: String? = nil,
+        progress: @Sendable @escaping (DownloadProgress) -> Void = { _ in }
+    ) async throws {
+        guard VozModel.supports(.current) else { throw VozError.unsupportedPlatform }
+        let stored = try await VozModel.resolve(directory: directory, cacheRoot: cacheRoot,
+                                                     progress: progress)
+        try self.init(modelDirectory: URL(fileURLWithPath: stored.rootPath))
+    }
+
+    /// Load from a directory of model files you manage yourself.
+    public init(modelDirectory: URL, computeUnits: MLComputeUnits = .cpuAndNeuralEngine) throws {
+        let assets = try Assets(directory: modelDirectory, computeUnits: computeUnits)
+        pipeline = try Pipeline(assets: assets)
+        sampleRate = Double(assets.configuration.sampleRate)
+    }
+
+    // MARK: - Transcription
+
+    /// Transcribe mono samples at ``sampleRate``.
+    public func transcribe(
+        samples: [Float],
+        progress: @Sendable (Progress) -> Void = { _ in }
+    ) throws -> Result {
+        guard !samples.isEmpty else { throw VozError.invalidAudio("no samples") }
+        var stream = ArrayAudioStream(samples)
+        return try transcribe(stream: &stream,
+                              duration: Double(samples.count) / sampleRate,
+                              progress: progress)
+    }
+
+    /// Transcribe from a source that is read as it goes, so that a long
+    /// recording does not have to be resident all at once.
+    func transcribe(
+        stream: inout some AudioStream,
+        duration: Double,
+        progress: @Sendable (Progress) -> Void
+    ) throws -> Result {
+        let started = Date()
+        let (text, words) = try pipeline.run(stream: &stream) {
+            progress(Progress(fractionCompleted: min(1, max(0, $0))))
+        }
+        progress(Progress(fractionCompleted: 1))
+        guard !words.isEmpty || duration > 0 else {
+            throw VozError.invalidAudio("no samples")
+        }
+        let bounded = words.map {
+            $0.end <= duration ? $0
+                : Word(text: $0.text, start: Swift.min($0.start, duration), end: duration)
+        }
+        return Result(text: text, words: bounded, duration: duration,
+                      processingTime: Date().timeIntervalSince(started))
+    }
+}
+
+#endif

--- a/Sources/Voz/Words.swift
+++ b/Sources/Voz/Words.swift
@@ -1,0 +1,282 @@
+#if canImport(CoreML)
+import Foundation
+
+/// A word and when it starts, in seconds from the beginning of the audio.
+public struct Word: Sendable, Equatable, Codable {
+    public let text: String
+    public let start: TimeInterval
+    /// When the word stops sounding. Never before ``start``.
+    public let end: TimeInterval
+
+    public init(text: String, start: TimeInterval, end: TimeInterval) {
+        self.text = text
+        self.start = start
+        self.end = Swift.max(start, end)
+    }
+
+    /// How long the word sounds for.
+    public var duration: TimeInterval { end - start }
+}
+
+/// Group sentencepiece pieces into words, timed by the frame that emitted the
+/// first piece of each word.
+///
+/// TDT states how far to advance after every emission, so the frame a token came
+/// from is known exactly rather than inferred. Accuracy is bounded by the frame
+/// period: one encoder frame is 80 ms, so a word time can only land on a frame
+/// boundary. Measured against an independent forced aligner over 300 utterances,
+/// word starts are within 80 ms of the reference 63% of the time and within
+/// 200 ms 94% of the time (MAE 76 ms), and about half of that residual is the
+/// frame grid rather than the model.
+func timedWords(tokens: [Int], frames: [Int], ends: [Int], vocabulary: [String],
+                secondsPerFrame: Double, timeOffset: Double) -> [Word] {
+    var out: [Word] = []
+    var current = ""
+    var currentFrame = 0
+    var currentEnd = 0
+
+    func flush() {
+        guard !current.isEmpty else { return }
+        out.append(Word(text: current,
+                        start: Double(currentFrame) * secondsPerFrame + timeOffset,
+                        end: Double(currentEnd) * secondsPerFrame + timeOffset))
+        current = ""
+    }
+
+    for (i, token) in tokens.enumerated() where token >= 0 && token < vocabulary.count {
+        let piece = vocabulary[token]
+        // Control pieces such as a language tag are not words.
+        if piece.hasPrefix("<") && piece.hasSuffix(">") { continue }
+        if piece.hasPrefix("\u{2581}") { flush() }
+        if current.isEmpty { currentFrame = i < frames.count ? frames[i] : 0 }
+        // The word ends where its last piece ends.
+        if i < ends.count { currentEnd = Swift.max(currentEnd, ends[i]) }
+        current += piece.replacingOccurrences(of: "\u{2581}", with: "")
+    }
+    flush()
+    return out
+}
+
+/// Join two windows that overlap in time.
+///
+/// Consecutive windows share up to `boundarySearch` seconds of audio, so both
+/// transcribe the speech around the seam. Cutting purely on time duplicates any
+/// word whose two estimates straddle the boundary - the emission times differ
+/// by a frame or two between windows - which is where "they they walked" comes
+/// from.
+///
+/// Instead the overlap is aligned: the longest run of words both windows agree
+/// on becomes the splice point, so each word survives exactly once and the
+/// transition happens where the two transcripts actually meet. When they agree
+/// on nothing, fall back to cutting at the boundary.
+func spliceOverlap(_ previous: [Word], _ next: [Word], boundary: TimeInterval,
+                   overlap: TimeInterval) -> [Word] {
+    guard !previous.isEmpty, !next.isEmpty else { return previous + next }
+    let from = boundary - overlap
+    let tail = previous.enumerated().filter { $0.element.start >= from }
+    let head = next.enumerated().filter { $0.element.start < boundary + overlap }
+    guard !tail.isEmpty, !head.isEmpty else {
+        return previous.filter { $0.start < boundary } + next.filter { $0.start >= boundary }
+    }
+
+    // Longest run of words the two windows agree on. Two constraints keep the
+    // alignment honest, and both were learned by measurement: a single matching
+    // word is not evidence - "the" appears everywhere, and splicing on one
+    // dropped 181 words over half an hour - and the time tolerance has to be
+    // tight enough that a word cannot match a different occurrence of itself
+    // seconds away.
+    var best = (length: 0, tailAt: 0, headAt: 0, drift: Double.greatestFiniteMagnitude)
+    for ti in tail.indices {
+        for hi in head.indices {
+            var length = 0
+            while ti + length < tail.count, hi + length < head.count,
+                  matches(tail[ti + length].element, head[hi + length].element,
+                          matchTolerance) {
+                length += 1
+            }
+            guard length >= minimumRun else { continue }
+            let drift = abs(tail[ti].element.start - head[hi].element.start)
+            if length > best.length || (length == best.length && drift < best.drift) {
+                best = (length, ti, hi, drift)
+            }
+        }
+    }
+
+    guard best.length >= minimumRun else {
+        return repairJoin(previous.filter { $0.start < boundary },
+                          next.filter { $0.start >= boundary })
+    }
+    // Keep the earlier window's copy of the agreed run: it has real left
+    // context, where the later window began cold at the seam.
+    let cut = tail[best.tailAt].offset
+    let resume = head[best.headAt].offset + best.length
+    let agreed = Array(tail[best.tailAt..<min(tail.count, best.tailAt + best.length)].map(\.element))
+    return repairJoin(Array(previous[..<cut]) + agreed, Array(next[resume...]))
+}
+
+/// Clean up the two artifacts a seam leaves even when the windows are aligned.
+///
+/// Both are one word wide, so neither is caught by matching runs of words, and
+/// both are obvious on sight in a transcript.
+private func repairJoin(_ left: [Word], _ right: [Word]) -> [Word] {
+    var right = right
+    guard let last = left.last, let first = right.first else { return left + right }
+
+    // A window beginning mid-sentence capitalises its first word as a false
+    // sentence start, so the seam word appears twice differing only in case:
+    // "your first episode. Episode. The most". The earlier window's copy has
+    // real left context, so that is the one kept. A same-case repeat is left
+    // alone, because people do say "that that" and "yeah yeah".
+    if fold(last.text) == fold(first.text), last.text != first.text {
+        right.removeFirst()
+    } else if fold(last.text) == fold(first.text), first.start < last.end {
+        // The same word in the same case, twice, and the two spans overlap in
+        // time. A speaker saying "that that" says it twice, one after the
+        // other; these two occupy the same moment, so they are one word timed
+        // by two windows. Without end times the two cases are
+        // indistinguishable, which is why this repeat used to be left alone.
+        right.removeFirst()
+    }
+
+    // The earlier window ends where its audio ends, so it punctuates as though
+    // the sentence ended there, and the later window carries on in lower case:
+    // "we made the bet to build for iOS. because we got stuck". A lower-case
+    // continuation means the sentence did not end.
+    //
+    // ".!?" is the model's entire stock of sentence-ending punctuation - it has
+    // no token containing a semicolon, an ellipsis or a Greek question mark - so
+    // this covers every terminator that can actually arrive. The test is weaker
+    // in languages that capitalise nouns: a German window resuming on a noun
+    // reads as a sentence start and the false break is left in place. That is a
+    // repair missed rather than a wrong repair made, which is the right way for
+    // it to fail when the language is unknown.
+    if let head = right.first, let tail = left.last,
+       head.text.first?.isLowercase == true,
+       let terminator = tail.text.last, ".!?".contains(terminator) {
+        var fixed = left
+        fixed[fixed.count - 1] = Word(text: String(tail.text.dropLast()),
+                                      start: tail.start, end: tail.end)
+        return fixed + right
+    }
+    return left + right
+}
+
+/// Words this far apart are different utterances, not two readings of one.
+private let matchTolerance: TimeInterval = 1.0
+/// A run shorter than this is coincidence rather than alignment.
+private let minimumRun = 2
+
+private func matches(_ a: Word, _ b: Word, _ tolerance: TimeInterval) -> Bool {
+    abs(a.start - b.start) <= tolerance && fold(a.text) == fold(b.text)
+}
+
+/// Compare words the way a reader would: ignoring case and edge punctuation, so
+/// a window that starts mid-sentence and capitalises its first word still aligns.
+/// Compare two words ignoring case, for spotting a seam duplicate.
+///
+/// Unicode case folding rather than lowercasing, so that German "STRASSE" and
+/// "straße" are recognised as the same word. Folding stops at case: making it
+/// diacritic-insensitive as well would merge five of the five genuinely
+/// distinct pairs it was tested against, including "résumé" against "resume",
+/// and this comparison deletes a word when it matches. Turkish dotted and
+/// dotless i and accented Greek capitals still fail to match, because both need
+/// a locale this code does not have.
+func fold(_ s: String) -> String {
+    String(s.folding(options: [.caseInsensitive], locale: nil).unicodeScalars.filter {
+        CharacterSet.alphanumerics.contains($0) || $0 == "'"
+    })
+}
+
+/// Force word times to be non-decreasing without reordering the words.
+///
+/// The splice chooses which window each word comes from, and the two windows
+/// time the same speech a frame or two apart, so a word can legitimately follow
+/// another in the text while carrying a slightly earlier timestamp. Sorting by
+/// time to fix that would be wrong: it reorders subwords of the same word and
+/// scrambles the seam. The text order is what the splice established and is
+/// authoritative, so a backward step is raised to the running maximum instead.
+func clampMonotonic(_ words: [Word]) -> [Word] {
+    var out: [Word] = []
+    out.reserveCapacity(words.count)
+    var highest = -Double.greatestFiniteMagnitude
+    for word in words {
+        let start = Swift.max(word.start, highest)
+        highest = start
+        out.append(start == word.start ? word : Word(text: word.text, start: start, end: word.end))
+    }
+    // Then pull each end back to where the next word begins. Two windows time
+    // the same speech a frame or two apart, so a word spliced from the earlier
+    // one can be credited with sound that the later one has already given to
+    // the next word. An end that overruns the next start is unusable for
+    // cutting, which is most of what an end time is for.
+    for i in out.indices.dropLast() {
+        let limit = out[i + 1].start
+        if out[i].end > limit {
+            out[i] = Word(text: out[i].text, start: out[i].start,
+                          end: Swift.max(out[i].start, limit))
+        }
+    }
+    return out
+}
+
+/// Trim word ends back to where the sound actually stops.
+///
+/// The recogniser predicts, for each token, how many frames to skip before
+/// looking for the next one. That is the only evidence it offers about where a
+/// word ends, but it overshoots: the skip runs to wherever the next token is
+/// picked up, so a word followed by a pause is credited with the pause. Against
+/// a forced aligner the ends came out 86 ms late on average and words measured
+/// 341 ms against the aligner's 223 ms.
+///
+/// The audio settles this without a fitted constant. Within the span the model
+/// claims, the end is taken to be the last point still sounding at a tenth of
+/// the loudest part of that word, which is a threshold relative to the speaker
+/// and so survives a change of level, language or recording.
+func refineEnds(_ words: [Word], samples: ArraySlice<Float>, windowStart: TimeInterval,
+                sampleRate: Double, frame: TimeInterval = 0.01) -> [Word] {
+    guard !words.isEmpty, !samples.isEmpty else { return words }
+    let step = Swift.max(1, Int(frame * sampleRate))
+    let base = samples.startIndex
+
+    func energy(at index: Int) -> Float {
+        let low = Swift.max(base, base + index)
+        let high = Swift.min(samples.endIndex, low + step)
+        guard low < high else { return 0 }
+        var sum: Float = 0
+        for i in low..<high { sum += samples[i] * samples[i] }
+        return sum / Float(high - low)
+    }
+
+    return words.map { word in
+        let from = Int((word.start - windowStart) * sampleRate)
+        let to = Int((word.end - windowStart) * sampleRate)
+        guard to > from, from >= 0, to - base <= samples.count else { return word }
+        var peak: Float = 0
+        var index = from
+        while index < to { peak = Swift.max(peak, energy(at: index)); index += step }
+        guard peak > 0 else { return word }
+        // Swept against the aligner over 6295 words: 0.02 through 0.10 all land
+        // within 2 ms of the same error, so this is a shallow choice rather than
+        // a fitted one. The lower end wins narrowly and errs late, which is the
+        // safe direction - an end that runs a little long falls in the gap
+        // after the word, where a short one clips the word itself.
+        let floorEnergy = peak * 0.05
+        var last = from
+        index = from
+        while index < to {
+            if energy(at: index) >= floorEnergy { last = index }
+            index += step
+        }
+        // Keep the frame that was still sounding, not the one after it.
+        let refined = windowStart + Double(last + step) / sampleRate
+        return Word(text: word.text, start: word.start,
+                    end: Swift.max(word.start, Swift.min(word.end, refined)))
+    }
+}
+
+func detokenize(_ pieces: [String]) -> String {
+    pieces.joined()
+        .replacingOccurrences(of: "\u{2581}", with: " ")
+        .trimmingCharacters(in: .whitespaces)
+}
+#endif

--- a/Tests/VozTests/IntegrationTests.swift
+++ b/Tests/VozTests/IntegrationTests.swift
@@ -1,0 +1,86 @@
+#if canImport(CoreML)
+import Foundation
+import Testing
+
+@testable import Voz
+
+// End-to-end coverage against a real model directory. The weights are a ~490 MB
+// download, so this is opt-in: point VOZ_MODEL_DIR at a laid-out model and
+// VOZ_AUDIO at a file to transcribe.
+//
+//   VOZ_MODEL_DIR=... VOZ_AUDIO=... swift test --filter VozIntegration
+
+private struct Fixture {
+    let model: URL
+    let audio: URL
+
+    init?() {
+        let env = ProcessInfo.processInfo.environment
+        guard let model = env["VOZ_MODEL_DIR"], let audio = env["VOZ_AUDIO"] else {
+            return nil
+        }
+        self.model = URL(fileURLWithPath: model)
+        self.audio = URL(fileURLWithPath: audio)
+    }
+}
+
+@Suite(.enabled(if: Fixture() != nil, "set VOZ_MODEL_DIR and VOZ_AUDIO"))
+struct VozIntegration {
+
+    @Test func transcribesWithWordsAndMonotonicProgress() async throws {
+        let fixture = try #require(Fixture())
+        let voz = try Voz(modelDirectory: fixture.model)
+
+        // The callback is not isolated to this task, so collect through a lock
+        // rather than assuming ordering.
+        let ticks = Ticks()
+        let result = try await voz.transcribe(fixture.audio) { ticks.record($0.fractionCompleted) }
+
+        print(String(format: "  voz: %.1f s audio in %.2f s -> RTFx %.1f, %d words",
+                     result.duration, result.processingTime, result.realtimeFactor,
+                     result.words.count))
+        // VOZ_DUMP writes the transcript out so it can be scored against a
+        // reference or another system.
+        if let path = ProcessInfo.processInfo.environment["VOZ_DUMP"] {
+            try result.text.write(toFile: path, atomically: true, encoding: .utf8)
+        }
+        #expect(!result.text.isEmpty)
+        #expect(!result.words.isEmpty)
+        #expect(result.duration > 0)
+        // The whole point of the port: comfortably faster than real time.
+        #expect(result.realtimeFactor > 10)
+
+        let values = ticks.values
+        #expect(!values.isEmpty, "progress should be reported")
+        #expect(values.allSatisfy { $0 >= 0 && $0 <= 1 })
+        #expect(zip(values, values.dropFirst()).allSatisfy(<=), "progress must not go backwards")
+        #expect(values.last == 1, "progress must finish at 1")
+
+        // Word times are ordered and inside the audio.
+        let starts = result.words.map(\.start)
+        #expect(zip(starts, starts.dropFirst()).allSatisfy(<=))
+        #expect(starts.allSatisfy { $0 >= 0 && $0 <= result.duration + 1 })
+        // Every word appears in the transcript.
+        for word in result.words.prefix(20) {
+            #expect(result.text.contains(word.text.trimmingCharacters(in: .punctuationCharacters))
+                    || word.text.isEmpty)
+        }
+    }
+
+    @Test func rejectsEmptyAudio() async throws {
+        let fixture = try #require(Fixture())
+        let voz = try Voz(modelDirectory: fixture.model)
+        await #expect(throws: VozError.self) {
+            try await voz.transcribe(samples: [])
+        }
+    }
+}
+
+/// Small lock so the progress callback can be collected from any isolation.
+private final class Ticks: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Double] = []
+    func record(_ v: Double) { lock.lock(); storage.append(v); lock.unlock() }
+    var values: [Double] { lock.lock(); defer { lock.unlock() }; return storage }
+}
+#endif

--- a/Tests/VozTests/StressTests.swift
+++ b/Tests/VozTests/StressTests.swift
@@ -1,0 +1,318 @@
+#if canImport(CoreML)
+import AudioIO
+import Foundation
+import Testing
+
+@testable import Voz
+
+// A battery over real audio of varying length, rate and channel count, plus
+// synthetic edge cases. Opt-in, because it needs the model and a corpus:
+//
+//   VOZ_MODEL_DIR=... VOZ_CORPUS=/path/to/audio swift test -c release \
+//     --filter VozStress
+//
+// Each case asserts the invariants that should hold for *any* input, so a
+// failure points at the implementation rather than at a WER target: word times
+// must be ordered, land inside the audio, and agree with the transcript; the
+// same input must produce the same output; and audio that carries speech must
+// produce words.
+//
+// The corpus must hold only languages in `Voz.supportedLanguages`. This model
+// covers 25 European languages, and on anything else it does not fail: it
+// returns fluent-looking words in the wrong language. Korean audio yields a few
+// hundred of them, and NVIDIA's own checkpoint does the same, so the coverage
+// checks below would be measuring the density of that noise. Unsupported audio
+// is a question for the caller's language ID, not for this suite.
+
+private struct Corpus {
+    let model: URL
+    let files: [URL]
+
+    init?() {
+        let env = ProcessInfo.processInfo.environment
+        guard let model = env["VOZ_MODEL_DIR"], let dir = env["VOZ_CORPUS"] else {
+            return nil
+        }
+        self.model = URL(fileURLWithPath: model)
+        let root = URL(fileURLWithPath: dir)
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: dir)) ?? []
+        files = names.sorted()
+            .filter { ["wav", "flac", "mp3", "m4a"].contains(($0 as NSString).pathExtension) }
+            .map { root.appendingPathComponent($0) }
+    }
+}
+
+/// Whether the benchmark has somewhere to read from. A test that returns early
+/// when its inputs are absent reports as passed, so this is a trait instead.
+var benchmarkIsConfigured: Bool {
+    let environment = ProcessInfo.processInfo.environment
+    return environment["VOZ_BENCH"] != nil && environment["VOZ_MODEL_DIR"] != nil
+}
+
+
+/// The widest stretch between two words, as absolute times.
+private func largestHole(_ words: [Word]) -> (Double, Double)? {
+    var best: (Double, Double)?
+    var widest = 0.0
+    for (a, b) in zip(words, words.dropFirst()) where b.start - a.end > widest {
+        widest = b.start - a.end
+        best = (a.end, b.start)
+    }
+    return best
+}
+
+
+@Suite(.enabled(if: Corpus() != nil, "set VOZ_MODEL_DIR and VOZ_CORPUS"),
+       .serialized)
+struct VozStress {
+
+    /// Invariants that must hold for every transcription, whatever the audio.
+    private func check(_ result: Voz.Result, label: String, duration: TimeInterval) {
+        let starts = result.words.map(\.start)
+        #expect(zip(starts, starts.dropFirst()).allSatisfy(<=), "\(label): word times must be non-decreasing")
+        for start in starts {
+            #expect(start >= 0 && start <= duration + 0.5, "\(label): word at \(start)s outside \(duration)s of audio")
+        }
+        // Words and text are two views of the same tokens; they must not diverge.
+        let fromWords = result.words.map(\.text).joined(separator: " ")
+        #expect(fromWords.split(separator: " ").count == result.words.count, "\(label): a word contains a space")
+        if !result.words.isEmpty {
+            #expect(!result.text.isEmpty, "\(label): words without text")
+        }
+        #expect(result.duration > 0, "\(label): duration not reported")
+    }
+
+    @Test func realWorldFiles() async throws {
+        let corpus = try #require(Corpus())
+        let voz = try Voz(modelDirectory: corpus.model)
+        print("\n  \(pad("file", 22)) \(pad("audio", 9)) \(pad("proc", 8)) "
+              + "\(pad("RTFx", 7)) \(pad("words", 7)) \(pad("covered", 7)) "
+              + "\(pad("lead", 8)) \(pad("hole", 9)) trail")
+        for file in corpus.files {
+            let samples = try await AudioIO.decode(path: file.path, sampleRate: 16000)
+            let duration = Double(samples.count) / 16000
+            let result = try await voz.transcribe(file)
+            check(result, label: file.lastPathComponent, duration: duration)
+
+            // Four numbers, not one. The old single `gap` folded the lead-in
+            // together with the holes and never looked past the last word, which
+            // hid both a legitimate music intro (reported as an 11.9 s hole) and
+            // a French recording that stopped after 70 s of 547 and reported the
+            // rest as silence. Every one of its other numbers looked healthy.
+            let lead = result.words.first?.start ?? duration
+            let trail = duration - (result.words.last?.end ?? 0)
+            let covered = duration > 0 ? (result.words.last?.end ?? 0) / duration : 0
+            // Silence between words, not start to start: the latter counts the
+            // first word's own length as part of the hole.
+            var interior = 0.0
+            for (a, b) in zip(result.words, result.words.dropFirst()) {
+                interior = max(interior, b.start - a.end)
+            }
+            print("  \(pad(file.lastPathComponent, 22)) "
+                  + "\(pad(String(format: "%.1fs", duration), 9)) "
+                  + "\(pad(String(format: "%.2fs", result.processingTime), 8)) "
+                  + "\(pad(String(format: "%.0f", result.realtimeFactor), 7)) "
+                  + "\(pad(String(result.words.count), 7)) "
+                  + "\(pad(String(format: "%.0f%%", covered * 100), 7)) "
+                  + "\(pad(String(format: "%.1fs", lead), 8)) "
+                  + "\(pad(String(format: "%.1fs", interior), 9)) "
+                  + String(format: "%.1fs", trail))
+            // A window is 15 s, so a hole approaching that means one produced
+            // nothing. The bar is deliberately below the window length: at 15 s
+            // a lost window passes by a tenth of a second and the defect ships.
+            if interior >= 8, let (from, to) = largestHole(result.words) {
+                let lo = max(0, Int(from * 16000)), hi = min(samples.count, Int(to * 16000))
+                let alone = try await voz.transcribe(samples: Array(samples[lo..<hi]))
+                let detail = "\(file.lastPathComponent): \(interior) s the recognizer skipped "
+                    + "here, but alone it reads as \"\(alone.text.prefix(60))\" - a window was lost"
+                #expect(alone.words.isEmpty, "\(detail)")
+            }
+            // The transcript has to reach the end of the audio. This is the one
+            // that catches a recogniser that stops early rather than one that
+            // drops a window in the middle, and nothing else here can see it.
+            if covered <= 0.95 {
+                let lo = min(samples.count, Int((result.words.last?.end ?? 0) * 16000))
+                let tail = try await voz.transcribe(samples: Array(samples[lo...]))
+                let detail = "\(file.lastPathComponent): transcript covers "
+                    + "\(Int(covered * 100))% of the audio, and the rest reads as "
+                    + "\"\(tail.text.prefix(60))\" - the recognizer stopped early"
+                #expect(tail.words.isEmpty, "\(detail)")
+            }
+            // A lead-in longer than a window means the first window produced
+            // nothing. Shorter than that is a title card or music, which is not
+            // this test's business.
+            #expect(lead < 15,
+                    "\(file.lastPathComponent): \(lead) s before the first word is a lost opening window")
+
+            // Ends have to be usable for cutting: after the word starts, before
+            // the file ends, and never running past where the next word begins.
+            for (a, b) in zip(result.words, result.words.dropFirst()) {
+                #expect(a.end >= a.start, "\(file.lastPathComponent): \(a.text) ends before it starts")
+                #expect(a.end <= b.start + 1e-6,
+                        "\(file.lastPathComponent): \(a.text) runs past the start of \(b.text)")
+            }
+            if let last = result.words.last {
+                #expect(last.end <= duration + 1,
+                        "\(file.lastPathComponent): last word ends after the audio does")
+            }
+
+            // Speech runs at a few words a second, so anything under one word
+            // per two seconds means audio went missing rather than that the
+            // speaker was terse. Without this, a bug that dropped everything
+            // past the first batch of windows halved a half-hour transcript and
+            // the suite stayed green, because what remained read perfectly.
+            if !result.words.isEmpty {
+                #expect(Double(result.words.count) / duration > 0.5,
+                        "\(file.lastPathComponent): \(result.words.count) words in \(duration) s is too few to be the whole file")
+            }
+        }
+    }
+
+    @Test func repeatedRunsAreIdentical() async throws {
+        let corpus = try #require(Corpus())
+        let file = try #require(corpus.files.first)
+        let voz = try Voz(modelDirectory: corpus.model)
+        let a = try await voz.transcribe(file)
+        let b = try await voz.transcribe(file)
+        #expect(a.text == b.text, "transcription is not deterministic")
+        #expect(a.words == b.words, "word times are not deterministic")
+    }
+
+    /// Lengths chosen around the fixed 15 s window: shorter than one window,
+    /// exactly one, one sample over, and several with a partial tail.
+    @Test func lengthSweepAroundTheWindow() async throws {
+        let corpus = try #require(Corpus())
+        // The longest file gives the sweep room to reach a minute.
+        var file = try #require(corpus.files.first)
+        var full = try await AudioIO.decode(path: file.path, sampleRate: 16000)
+        for candidate in corpus.files.dropFirst() {
+            let samples = try await AudioIO.decode(path: candidate.path, sampleRate: 16000)
+            if samples.count > full.count { full = samples; file = candidate }
+        }
+        let voz = try Voz(modelDirectory: corpus.model)
+        print("\n  length sweep on \(file.lastPathComponent)")
+        for seconds in [0.5, 1.0, 5.0, 14.9, 15.0, 15.1, 20.0, 30.0, 45.1, 60.0] {
+            let count = Int(seconds * 16000)
+            guard count <= full.count else { continue }
+            let result = try await voz.transcribe(samples: Array(full[0..<count]))
+            check(result, label: "\(seconds)s", duration: seconds)
+            let last = result.words.last?.start ?? 0
+            print("    \(pad(String(format: "%.1fs", seconds), 8)) "
+                  + "\(pad(String(result.words.count), 5)) words, "
+                  + "last at \(String(format: "%.1f", last))s")
+            #expect(last <= seconds + 0.5, "\(seconds)s: last word at \(last)s is past the audio")
+        }
+    }
+
+    /// Silence and tones carry no speech, so an empty transcript is correct.
+    /// What must not happen is a flood of invented words.
+    @Test func nonSpeechDoesNotHallucinate() async throws {
+        let corpus = try #require(Corpus())
+        let voz = try Voz(modelDirectory: corpus.model)
+        let cases: [(String, [Float])] = [
+            ("silence 30s", [Float](repeating: 0, count: 16000 * 30)),
+            ("quiet noise 30s", (0..<(16000 * 30)).map { _ in Float.random(in: -1e-4...1e-4) }),
+            ("1 kHz tone 20s", (0..<(16000 * 20)).map {
+                0.2 * sin(2 * .pi * 1000 * Float($0) / 16000) }),
+        ]
+        for (label, samples) in cases {
+            let result = try await voz.transcribe(samples: samples)
+            let seconds = Double(samples.count) / 16000
+            check(result, label: label, duration: seconds)
+            print("    \(pad(label, 18)) \(result.words.count) words: "
+                  + String(result.text.prefix(60)))
+            #expect(Double(result.words.count) < seconds, "\(label): \(result.words.count) words from non-speech")
+        }
+    }
+
+    /// Rates and channel counts the SDK is expected to normalize.
+    @Test func acceptsOtherRates() async throws {
+        let corpus = try #require(Corpus())
+        let voz = try Voz(modelDirectory: corpus.model)
+        let file = try #require(corpus.files.first)
+        let base = try await AudioIO.decode(path: file.path, sampleRate: 16000)
+        let native = try await voz.transcribe(samples: base)
+        for rate in [8000.0, 22050.0, 44100.0, 48000.0] {
+            let resampled = Resample.linear(base, from: 16000, to: rate)
+            let result = try await voz.transcribe(samples: resampled, sampleRate: rate)
+            check(result, label: "\(rate) Hz", duration: Double(base.count) / 16000)
+            print("    \(pad(String(format: "%.0f Hz", rate), 10)) "
+                  + "\(result.words.count) words (16 kHz gave \(native.words.count))")
+            #expect(!result.words.isEmpty, "\(rate) Hz produced nothing")
+        }
+    }
+
+    /// Transcribe every file in a directory, reporting throughput and dumping
+    /// the text for scoring. Set VOZ_BENCH to the directory.
+    ///
+    /// The files this is aimed at are long on purpose. A ten-minute file
+    /// crosses about forty window boundaries, so the merge logic is exercised
+    /// forty times per language rather than not at all, which is what a corpus
+    /// of ten-second utterances would measure.
+    @Test(.enabled(if: benchmarkIsConfigured, "set VOZ_BENCH and VOZ_MODEL_DIR"))
+    func benchmarkDirectory() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        // Force-unwrapped rather than guarded: the trait above is what decides
+        // whether this runs, and a guard here would let a misconfigured run
+        // report a pass while measuring nothing.
+        let dir = environment["VOZ_BENCH"]!
+        let models = environment["VOZ_MODEL_DIR"]!
+        let root = URL(fileURLWithPath: dir)
+        let files = try FileManager.default
+            .contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+            .filter { ["wav", "flac", "m4a", "mp3"].contains($0.pathExtension) }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        let voz = try Voz(modelDirectory: URL(fileURLWithPath: models))
+        for file in files {
+            // Deliberately does not decode the file here. Doing so to work out
+            // the duration would hold the whole recording in memory and hide
+            // the very thing the streaming path exists to avoid.
+            let result = try await voz.transcribe(file)
+            let duration = result.duration
+            let name = file.deletingPathExtension().lastPathComponent
+            try? result.text.write(to: root.appendingPathComponent(name + ".hyp"),
+                                   atomically: true, encoding: .utf8)
+            if environment["VOZ_WORDS"] != nil {
+                let times = result.words.map {
+                    ["text": $0.text, "start": "\($0.start)", "end": "\($0.end)"]
+                }
+                if let data = try? JSONSerialization.data(withJSONObject: times) {
+                    try? data.write(to: root.appendingPathComponent(name + ".words"))
+                }
+            }
+            print("BENCH\t\(name)\t\(duration)\t\(result.processingTime)"
+                  + "\t\(result.realtimeFactor)\t\(result.words.count)")
+        }
+    }
+}
+
+private func pad(_ s: String, _ n: Int) -> String {
+    s.count >= n ? s : s + String(repeating: " ", count: n - s.count)
+
+}
+
+@Suite("VozAudioStream", .enabled(if: Corpus() != nil, "set VOZ_MODEL_DIR and VOZ_CORPUS"))
+struct VozAudioStreamTests {
+    /// The streaming reader must deliver exactly what decoding the whole file
+    /// delivers. It is easy for a chunked reader to lose audio at a chunk
+    /// boundary and still look healthy, because the transcript stays readable.
+    @Test func streamMatchesWholeFileDecode() async throws {
+        let corpus = Corpus()!
+        for file in corpus.files {
+            let whole = try await AudioIO.decode(path: file.path, sampleRate: 16000)
+            var stream = try FileAudioStream(url: file, sampleRate: 16000)
+            var streamed: [Float] = []
+            while try stream.read(1 << 16, into: &streamed) > 0 {}
+            let name = file.lastPathComponent
+            #expect(abs(streamed.count - whole.count) <= 16000 / 100,
+                    "\(name): streamed \(streamed.count) samples, whole file has \(whole.count)")
+            let n = Swift.min(streamed.count, whole.count)
+            var worst: Float = 0
+            for i in Swift.stride(from: 0, to: n, by: 7) {
+                worst = Swift.max(worst, abs(streamed[i] - whole[i]))
+            }
+            #expect(worst < 1e-3, "\(name): samples differ by \(worst)")
+        }
+    }
+}
+#endif

--- a/Tests/VozTests/VozTests.swift
+++ b/Tests/VozTests/VozTests.swift
@@ -1,0 +1,147 @@
+import DesertAnt
+import Foundation
+import Testing
+
+@testable import Voz
+
+// The model is a download, so these cover what can be checked without it: the
+// catalog declaration, the geometry contract, and the token-to-word grouping
+// that produces timestamps. Anything needing the weights lives in the
+// parakeet-ane repo's evaluation harness, which scores WER against a manifest.
+
+@Test func catalogDeclaresAppleOnly() {
+    #expect(VozModel.id == "voz")
+    #expect(VozModel.repo == "desert-ant-labs/voz")
+    #expect(VozModel.supports(.apple))
+    let unsupported: [ModelPlatform] = [.android, .linux, .windows, .web]
+    for platform in unsupported {
+        #expect(!VozModel.supports(platform), "voz has no \(platform) backend")
+    }
+}
+
+@Test func catalogShipsCompiledModelsAndSidecars() {
+    let files = VozModel.files[.apple] ?? []
+    // Compiled programs are directories on the Hub, hence the trailing slash.
+    #expect(files.contains("encoder.mlmodelc/"))
+    #expect(files.contains("mel.mlmodelc/"))
+    #expect(files.contains("decoder.mlmodelc/"))
+    #expect(files.contains("meta.json"))
+    #expect(files.contains("vocab.json"))
+    #expect(files.contains("embedding.f16"))
+    // An .mlpackage would silently cost ~127x on every load.
+    #expect(!files.contains { $0.hasSuffix(".mlpackage/") })
+}
+
+#if canImport(CoreML)
+
+private let geometry = """
+{"sample_rate":16000,"hop_length":160,"n_samples":240000,"n_rows":1503,"n_mels":128,
+ "n_fft":512,"preemph":0.97,"n_padded_samples":240480,"valid_frames":1500,
+ "enc_frames":188,"joint_hidden":640,"pred_hidden":640,"pred_layers":2,
+ "vocab_size":8192,"blank_idx":8192,"durations":[0,1,2,3,4],"decode_width":8}
+"""
+
+@Test func configurationDecodesAndValidates() throws {
+    let c = try JSONDecoder().decode(Configuration.self, from: Data(geometry.utf8))
+    try c.validate()
+    // One encoder frame is 80 ms: the resolution of every word time.
+    #expect(abs(c.secondsPerFrame - 0.08) < 1e-9)
+}
+
+@Test func configurationRejectsImpossibleGeometry() throws {
+    let broken = geometry.replacingOccurrences(of: "\"enc_frames\":188", with: "\"enc_frames\":0")
+    let c = try JSONDecoder().decode(Configuration.self, from: Data(broken.utf8))
+    #expect(throws: VozError.self) { try c.validate() }
+}
+
+@Test func wordsGroupOnSentencepieceBoundaries() {
+    let vocab = ["\u{2581}hello", "\u{2581}wor", "ld", "<en-US>"]
+    let words = timedWords(tokens: [0, 1, 2], frames: [1, 5, 7], ends: [4, 7, 9],
+                           vocabulary: vocab, secondsPerFrame: 0.08, timeOffset: 0)
+    #expect(words.map(\.text) == ["hello", "world"])
+    // A word takes the time of the frame that emitted its first piece, and runs
+    // to where its last piece ends - "world" is two pieces, so it ends where
+    // "ld" does and not where "wor" does.
+    #expect(abs(words[0].start - 0.08) < 1e-9)
+    #expect(abs(words[0].end - 0.32) < 1e-9)
+    #expect(abs(words[1].start - 0.40) < 1e-9)
+    #expect(abs(words[1].end - 0.72) < 1e-9)
+}
+
+@Test func wordsSkipControlPiecesAndApplyOffset() {
+    let vocab = ["\u{2581}hello", "\u{2581}wor", "ld", "<en-US>"]
+    let words = timedWords(tokens: [3, 0], frames: [0, 2], ends: [0, 5],
+                           vocabulary: vocab, secondsPerFrame: 0.08, timeOffset: 15.04)
+    #expect(words.map(\.text) == ["hello"])
+    // The offset carries the window's position in the file, on both ends.
+    #expect(abs(words[0].start - (15.04 + 0.16)) < 1e-9)
+    #expect(abs(words[0].end - (15.04 + 0.40)) < 1e-9)
+}
+
+@Test func wordEndsAreTrimmedToWhereTheSoundStops() {
+    // A word sounding for 200 ms, then silence, inside a span the recogniser
+    // claims runs for a full second. The claim is what its duration head
+    // predicts; it runs to wherever the next token was picked up, so it
+    // includes the pause.
+    let rate = 16000.0
+    var samples = [Float](repeating: 0, count: Int(rate))
+    for i in 0..<Int(0.2 * rate) { samples[i] = i % 2 == 0 ? 0.5 : -0.5 }
+    let claimed = [Word(text: "hello", start: 0, end: 1.0)]
+    let refined = refineEnds(claimed, samples: samples[...], windowStart: 0, sampleRate: rate)
+    #expect(abs(refined[0].end - 0.21) < 0.02,
+            "the end should land where the sound stops, not where the model stopped looking")
+    #expect(refined[0].start == 0)
+
+    // Nothing to trim: a word sounding for its whole claimed span keeps it.
+    for i in 0..<Int(rate) { samples[i] = i % 2 == 0 ? 0.5 : -0.5 }
+    let full = refineEnds([Word(text: "hello", start: 0, end: 0.5)],
+                          samples: samples[...], windowStart: 0, sampleRate: rate)
+    #expect(abs(full[0].end - 0.5) < 0.02)
+
+    // Silence carries no evidence, so the claim stands rather than collapsing
+    // the word to zero length.
+    let quiet = refineEnds([Word(text: "hello", start: 0, end: 0.5)],
+                           samples: [Float](repeating: 0, count: Int(rate))[...],
+                           windowStart: 0, sampleRate: rate)
+    #expect(quiet[0].end == 0.5)
+}
+
+@Test func detokenizationRestoresSpacing() {
+    #expect(detokenize(["\u{2581}a", "\u{2581}b", "c"]) == "a bc")
+}
+
+#endif
+
+#if canImport(CoreML)
+@Test("seam repair works in every language the model transcribes")
+func seamRepairAcrossLanguages() {
+    // Every language here is written in a bicameral script, which is what the
+    // seam repairs depend on: a window resuming mid-sentence capitalises its
+    // first word, and that is the signal. The model's other languages are all
+    // bicameral too, so there is no supported language where these go blind.
+    let duplicatesAtASeam = [
+        ("en", "Episode", "episode"), ("de", "Folge", "folge"),
+        ("fr", "Épisode", "épisode"), ("es", "Episodio", "episodio"),
+        ("pl", "Odcinek", "odcinek"), ("cs", "Epizoda", "epizoda"),
+        ("sv", "Avsnitt", "avsnitt"), ("hu", "Epizód", "epizód"),
+        ("ru", "Эпизод", "эпизод"), ("uk", "Епізод", "епізод"),
+        ("bg", "Епизод", "епизод"), ("el", "Επεισόδιο", "επεισόδιο"),
+        ("de-ß", "STRASSE", "straße"),
+    ]
+    for (language, upper, lower) in duplicatesAtASeam {
+        #expect(fold(upper) == fold(lower),
+                "\(language): a window's capitalised restart must match the earlier copy")
+    }
+
+    // Folding must not go so far that it merges words that merely look alike.
+    // This comparison deletes a word when it matches, so a false match at a
+    // seam loses real speech.
+    let distinctWords = [("fr", "résumé", "resume"), ("fr", "père", "pere"),
+                         ("de", "schön", "schon"), ("el", "ή", "η"),
+                         ("fr", "côte", "cote")]
+    for (language, one, other) in distinctWords {
+        #expect(fold(one) != fold(other),
+                "\(language): distinct words must not be folded together")
+    }
+}
+#endif

--- a/docs/hub-cards/voz.md
+++ b/docs/hub-cards/voz.md
@@ -1,0 +1,49 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- bg
+- cs
+- da
+- de
+- el
+- en
+- es
+- et
+- fi
+- fr
+- hr
+- hu
+- it
+- lt
+- lv
+- mt
+- nl
+- pl
+- pt
+- ro
+- ru
+- sk
+- sl
+- sv
+- uk
+tags:
+- speech
+- speech-recognition
+- transcription
+- word-timestamps
+- on-device
+- core-ml
+- apple-neural-engine
+- multilingual
+pipeline_tag: automatic-speech-recognition
+---
+
+# Voz
+
+Every word, with the time it was said.
+
+On-device speech recognition: transcripts with word-level timestamps, 25 languages.
+
+- **SDKs, install and examples:** https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/voz.md

--- a/docs/models/voz.md
+++ b/docs/models/voz.md
@@ -1,0 +1,113 @@
+<!-- model:start -->
+# Voz
+
+Every word, with the time it was said.
+
+On-device speech recognition: transcripts with word-level timestamps, 25 languages.
+
+| | |
+| --- | --- |
+| **Platforms** | iOS, macOS, tvOS, visionOS |
+| **Languages** | 25 |
+| **Weights** | [v0.1.0](https://huggingface.co/desert-ant-labs/voz) |
+
+## Install
+
+**Swift** ([requirements](../../README.md#swift))
+
+```swift
+.package(url: "https://github.com/Desert-Ant-Labs/desert-ant-core.git", from: "3.0.0")
+```
+
+Then add the `Voz` product to your target.
+<!-- model:end -->
+
+## Usage
+
+`Voz` turns speech into text, with a start and an end on every word. Create one
+and reuse it; the model downloads on first use and is cached.
+
+```swift
+import Voz
+
+let voz = try await Voz()
+let result = try await voz.transcribe(url)
+
+result.text                     // the transcript
+result.words.first?.start       // 80 ms resolution
+result.realtimeFactor           // seconds of audio per second of wall clock
+```
+
+Samples work too, mono at `voz.sampleRate`:
+
+```swift
+let result = try await voz.transcribe(samples: samples)
+```
+
+### Downloading ahead of time
+
+The first load after a download pays a one-time Neural Engine specialization of
+roughly 20 seconds; every load after it takes about 0.2 s. Doing both during
+onboarding keeps that cost off the first transcription.
+
+```swift
+if !Voz.isDownloaded() {
+    try await Voz.download { progress in
+        show(progress.fraction)
+    }
+}
+```
+
+### Picking a language first
+
+`Voz` covers 25 languages and does not detect which one it is hearing. Pair it
+with [Ear](ear.md) when the input could be anything:
+
+```swift
+let detection = try await Ear().identify(contentsOf: url)
+guard detection.isReliable, Voz.supportedLanguages.contains(detection.language ?? "") else {
+    return try await yourFallbackRecognizer(url)   // Voz does not cover it
+}
+let result = try await Voz().transcribe(url)
+```
+
+The fallback is yours to choose: `Voz` ships the recognizer, not a router.
+
+## Accuracy
+
+| | |
+|---|---|
+| Speed | 2.1 s for 611 s of audio (about 290x real time) on long files |
+| Word error rate | 7.40% over six Open ASR Leaderboard sets, against 7.00% for Whisper large-v3-turbo |
+| Long-form | 2.83% on half an hour of narration, against 2.72% for the same Whisper |
+| Word timestamps | starts 83 ms, ends 95 ms mean absolute error against a forced aligner |
+| Neural Engine | 100% resident, no CPU or GPU fallback |
+| Size | 467 MB, against 1.6 GB for Whisper large-v3-turbo |
+
+Close to a model three and a half times its size, two points better on meetings,
+behind on prepared and read speech.
+
+**Expect the conversational figures, not the LibriSpeech one.** Read speech in a
+clean recording scores around 2%; meetings, earnings calls and podcast audio
+score 10-13%, and most real material is nearer the second group. Roughly one word
+in ten wanting a look is the honest expectation for a podcast.
+
+Per-language figures on long audio, and the full leaderboard breakdown, are in
+the [model card](https://huggingface.co/desert-ant-labs/voz).
+
+## Limits
+
+- **Apple platforms only.** The runtime drives Core ML directly, because the
+  things that make it fast (preallocated buffers, `outputBackings`, a
+  lane-batched decode loop) are not expressible through the generic inference
+  shape the other models share. There is no Android, Linux or web build.
+- **25 languages**, and it does not know which one it is hearing. Feeding it a
+  language it does not cover produces confident nonsense rather than an error.
+  See [Ear](ear.md).
+- **Accuracy varies widely by language.** Italian is 3.31% and Greek 39.46% on
+  the same ten-minute-per-language protocol. Check the model card before
+  promising a language.
+- **Word ends are the harder half.** The recognizer reports how far to skip after
+  each token rather than where a word stops, so ends are trimmed back using the
+  audio. 80 ms is the frame resolution and the floor for any timestamp here.
+- **467 MB** is a real download. Fetch it during onboarding, not on first use.

--- a/manifest.json
+++ b/manifest.json
@@ -625,6 +625,89 @@
       }
     },
     {
+      "id": "voz",
+      "name": "Voz",
+      "tagline": "Every word, with the time it was said.",
+      "summary": "On-device speech recognition: transcripts with word-level timestamps, 25 languages.",
+      "category": "Speech recognition",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": {
+          "status": "live",
+          "package": "Voz",
+          "platforms": [
+            "apple"
+          ]
+        },
+        "kotlin": {
+          "status": "none"
+        },
+        "js": {
+          "status": "none"
+        }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/voz",
+        "url": "https://huggingface.co/desert-ant-labs/voz",
+        "revision": "v0.1.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": [
+        "coreml"
+      ],
+      "variants": [],
+      "hub": {
+        "tags": [
+          "speech",
+          "speech-recognition",
+          "transcription",
+          "word-timestamps",
+          "on-device",
+          "core-ml",
+          "apple-neural-engine",
+          "multilingual"
+        ],
+        "pipelineTag": "automatic-speech-recognition",
+        "libraryName": null
+      },
+      "languages": {
+        "count": 25,
+        "codes": [
+          "bg",
+          "cs",
+          "da",
+          "de",
+          "el",
+          "en",
+          "es",
+          "et",
+          "fi",
+          "fr",
+          "hr",
+          "hu",
+          "it",
+          "lt",
+          "lv",
+          "mt",
+          "nl",
+          "pl",
+          "pt",
+          "ro",
+          "ru",
+          "sk",
+          "sl",
+          "sv",
+          "uk"
+        ],
+        "basis": "declared",
+        "source": null
+      },
+      "demo": null
+    },
+    {
       "id": "who",
       "name": "Who",
       "tagline": "An interview, ready to cut.",


### PR DESCRIPTION
On-device speech recognition with word-level timestamps, 25 languages, entirely
on the Neural Engine. Apple only.

```swift
let voz = try await Voz()
let result = try await voz.transcribe(url)
result.text
result.words.first?.start   // 80 ms resolution
```

- 467 MB against 1.6 GB for Whisper large-v3-turbo, 7.40% WER against its 7.00%
- ~290x real time on long files, 100% Neural Engine