### PR TITLE
Cut CI test time: gist loads once, iOS suites run in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,9 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build deps (static Foundation autolinks these)
         run: |
-          # apt has wedged on a bad mirror here, sitting on `update` until the
+          # These three are already on the ubuntu-22.04 runner image, so the
+          # common path installs nothing and never touches the network. That
+          # matters: apt has wedged on a bad mirror here, sitting on `update` until the
           # job's 6 h timeout rather than failing - one hung runner blocked two
           # PRs at once. Bound each attempt and retry, so a bad mirror costs
           # seconds and a retry instead of the run. Retrying rather than just
@@ -142,10 +144,19 @@ jobs:
           # runner user, which cannot signal the root apt-get it is trying to
           # stop (EPERM), so the hang survives its own timeout. -k follows up
           # with SIGKILL for an apt wedged past SIGTERM.
+          pkgs="libcurl4-openssl-dev libxml2-dev zlib1g-dev"
+          missing=""
+          for p in $pkgs; do
+            dpkg -s "$p" > /dev/null 2>&1 || missing="$missing $p"
+          done
+          if [ -z "$missing" ]; then
+            echo "already on the runner image: $pkgs"
+            exit 0
+          fi
+          echo "missing:$missing"
           for attempt in 1 2 3; do
             if sudo timeout -k 10 120 apt-get update -qq \
-              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends \
-                   libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
+              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends $missing; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt timed out or failed; retrying"
@@ -189,7 +200,9 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build deps (static Foundation autolinks these)
         run: |
-          # apt has wedged on a bad mirror here, sitting on `update` until the
+          # These three are already on the ubuntu-22.04 runner image, so the
+          # common path installs nothing and never touches the network. That
+          # matters: apt has wedged on a bad mirror here, sitting on `update` until the
           # job's 6 h timeout rather than failing - one hung runner blocked two
           # PRs at once. Bound each attempt and retry, so a bad mirror costs
           # seconds and a retry instead of the run. Retrying rather than just
@@ -200,10 +213,19 @@ jobs:
           # runner user, which cannot signal the root apt-get it is trying to
           # stop (EPERM), so the hang survives its own timeout. -k follows up
           # with SIGKILL for an apt wedged past SIGTERM.
+          pkgs="libcurl4-openssl-dev libxml2-dev zlib1g-dev"
+          missing=""
+          for p in $pkgs; do
+            dpkg -s "$p" > /dev/null 2>&1 || missing="$missing $p"
+          done
+          if [ -z "$missing" ]; then
+            echo "already on the runner image: $pkgs"
+            exit 0
+          fi
+          echo "missing:$missing"
           for attempt in 1 2 3; do
             if sudo timeout -k 10 120 apt-get update -qq \
-              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends \
-                   libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
+              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends $missing; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt timed out or failed; retrying"
@@ -349,7 +371,9 @@ jobs:
 
       - name: Swift toolchain system deps
         run: |
-          # apt has wedged on a bad mirror here, sitting on `update` until the
+          # These three are already on the ubuntu-22.04 runner image, so the
+          # common path installs nothing and never touches the network. That
+          # matters: apt has wedged on a bad mirror here, sitting on `update` until the
           # job's 6 h timeout rather than failing - one hung runner blocked two
           # PRs at once. Bound each attempt and retry, so a bad mirror costs
           # seconds and a retry instead of the run. Retrying rather than just
@@ -360,10 +384,19 @@ jobs:
           # runner user, which cannot signal the root apt-get it is trying to
           # stop (EPERM), so the hang survives its own timeout. -k follows up
           # with SIGKILL for an apt wedged past SIGTERM.
+          pkgs="libcurl4-openssl-dev libxml2-dev zlib1g-dev"
+          missing=""
+          for p in $pkgs; do
+            dpkg -s "$p" > /dev/null 2>&1 || missing="$missing $p"
+          done
+          if [ -z "$missing" ]; then
+            echo "already on the runner image: $pkgs"
+            exit 0
+          fi
+          echo "missing:$missing"
           for attempt in 1 2 3; do
             if sudo timeout -k 10 120 apt-get update -qq \
-              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends \
-                   libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
+              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends $missing; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt timed out or failed; retrying"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,15 @@ jobs:
           key: models-${{ runner.os }}-${{ hashFiles('Sources/*/Catalog.swift') }}
           restore-keys: models-${{ runner.os }}-
 
-      # The iOS simulator build compiles swift-syntax (via JavaScriptKit's
-      # macro plugin) from source, which dominates the job. test:ios pins
-      # DerivedData and the SPM clones to .build/ when $CI is set, so this
-      # cache turns that into an incremental build. Package.resolved keys the
-      # dependency graph; restore-keys accept a stale cache, which xcodebuild
-      # then patches incrementally.
+      # test:ios pins DerivedData and the SPM clones to .build/ when $CI is set,
+      # so this cache turns the simulator build into an incremental one.
+      # Package.resolved keys the dependency graph; restore-keys accept a stale
+      # cache, which xcodebuild then patches incrementally.
+      #
+      # (This used to say swift-syntax dominated the job, via JavaScriptKit's
+      # macro plugin. That stopped being true when JavaScriptKit became opt-in
+      # behind DAL_WASM_BUILD, which test:ios does not set: swift-syntax no
+      # longer appears in the build log at all.)
       - name: Cache iOS DerivedData and SPM clones
         uses: actions/cache@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,14 @@ jobs:
           # seconds and a retry instead of the run. Retrying rather than just
           # `timeout-minutes`: that would still lose the run to a manual re-run,
           # which is the toil this is here to remove.
+          #
+          # `sudo timeout`, not `timeout sudo`: the latter runs the killer as the
+          # runner user, which cannot signal the root apt-get it is trying to
+          # stop (EPERM), so the hang survives its own timeout. -k follows up
+          # with SIGKILL for an apt wedged past SIGTERM.
           for attempt in 1 2 3; do
-            if timeout 120 sudo apt-get update -qq \
-              && timeout 180 sudo apt-get install -y -qq --no-install-recommends \
+            if sudo timeout -k 10 120 apt-get update -qq \
+              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends \
                    libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
               exit 0
             fi
@@ -190,9 +195,14 @@ jobs:
           # seconds and a retry instead of the run. Retrying rather than just
           # `timeout-minutes`: that would still lose the run to a manual re-run,
           # which is the toil this is here to remove.
+          #
+          # `sudo timeout`, not `timeout sudo`: the latter runs the killer as the
+          # runner user, which cannot signal the root apt-get it is trying to
+          # stop (EPERM), so the hang survives its own timeout. -k follows up
+          # with SIGKILL for an apt wedged past SIGTERM.
           for attempt in 1 2 3; do
-            if timeout 120 sudo apt-get update -qq \
-              && timeout 180 sudo apt-get install -y -qq --no-install-recommends \
+            if sudo timeout -k 10 120 apt-get update -qq \
+              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends \
                    libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
               exit 0
             fi
@@ -345,9 +355,14 @@ jobs:
           # seconds and a retry instead of the run. Retrying rather than just
           # `timeout-minutes`: that would still lose the run to a manual re-run,
           # which is the toil this is here to remove.
+          #
+          # `sudo timeout`, not `timeout sudo`: the latter runs the killer as the
+          # runner user, which cannot signal the root apt-get it is trying to
+          # stop (EPERM), so the hang survives its own timeout. -k follows up
+          # with SIGKILL for an apt wedged past SIGTERM.
           for attempt in 1 2 3; do
-            if timeout 120 sudo apt-get update -qq \
-              && timeout 180 sudo apt-get install -y -qq --no-install-recommends \
+            if sudo timeout -k 10 120 apt-get update -qq \
+              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends \
                    libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,9 +131,23 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build deps (static Foundation autolinks these)
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
-            libcurl4-openssl-dev libxml2-dev zlib1g-dev
+          # apt has wedged on a bad mirror here, sitting on `update` until the
+          # job's 6 h timeout rather than failing - one hung runner blocked two
+          # PRs at once. Bound each attempt and retry, so a bad mirror costs
+          # seconds and a retry instead of the run. Retrying rather than just
+          # `timeout-minutes`: that would still lose the run to a manual re-run,
+          # which is the toil this is here to remove.
+          for attempt in 1 2 3; do
+            if timeout 120 sudo apt-get update -qq \
+              && timeout 180 sudo apt-get install -y -qq --no-install-recommends \
+                   libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt timed out or failed; retrying"
+            sleep $((attempt * 10))
+          done
+          echo "::error::apt failed after 3 attempts"
+          exit 1
       - uses: jdx/mise-action@v4
       # `mise run` vendors libLiteRt.so out of the ai-edge-litert wheel with uv.
       - uses: astral-sh/setup-uv@v7
@@ -170,9 +184,23 @@ jobs:
       - uses: actions/checkout@v5
       - name: Build deps (static Foundation autolinks these)
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
-            libcurl4-openssl-dev libxml2-dev zlib1g-dev
+          # apt has wedged on a bad mirror here, sitting on `update` until the
+          # job's 6 h timeout rather than failing - one hung runner blocked two
+          # PRs at once. Bound each attempt and retry, so a bad mirror costs
+          # seconds and a retry instead of the run. Retrying rather than just
+          # `timeout-minutes`: that would still lose the run to a manual re-run,
+          # which is the toil this is here to remove.
+          for attempt in 1 2 3; do
+            if timeout 120 sudo apt-get update -qq \
+              && timeout 180 sudo apt-get install -y -qq --no-install-recommends \
+                   libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt timed out or failed; retrying"
+            sleep $((attempt * 10))
+          done
+          echo "::error::apt failed after 3 attempts"
+          exit 1
       - uses: jdx/mise-action@v4
       - uses: astral-sh/setup-uv@v7
         with:
@@ -311,9 +339,23 @@ jobs:
 
       - name: Swift toolchain system deps
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
-            libcurl4-openssl-dev libxml2-dev zlib1g-dev
+          # apt has wedged on a bad mirror here, sitting on `update` until the
+          # job's 6 h timeout rather than failing - one hung runner blocked two
+          # PRs at once. Bound each attempt and retry, so a bad mirror costs
+          # seconds and a retry instead of the run. Retrying rather than just
+          # `timeout-minutes`: that would still lose the run to a manual re-run,
+          # which is the toil this is here to remove.
+          for attempt in 1 2 3; do
+            if timeout 120 sudo apt-get update -qq \
+              && timeout 180 sudo apt-get install -y -qq --no-install-recommends \
+                   libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt timed out or failed; retrying"
+            sleep $((attempt * 10))
+          done
+          echo "::error::apt failed after 3 attempts"
+          exit 1
 
       - name: Enable KVM (hardware acceleration for the emulator)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,9 @@ jobs:
           sudo docker image prune --all --force || true
       - name: Swift toolchain system deps
         run: |
-          # apt has wedged on a bad mirror here, sitting on `update` until the
+          # These three are already on the ubuntu-22.04 runner image, so the
+          # common path installs nothing and never touches the network. That
+          # matters: apt has wedged on a bad mirror here, sitting on `update` until the
           # job's 6 h timeout rather than failing - one hung runner blocked two
           # PRs at once. Bound each attempt and retry, so a bad mirror costs
           # seconds and a retry instead of the run. Retrying rather than just
@@ -89,10 +91,19 @@ jobs:
           # runner user, which cannot signal the root apt-get it is trying to
           # stop (EPERM), so the hang survives its own timeout. -k follows up
           # with SIGKILL for an apt wedged past SIGTERM.
+          pkgs="libcurl4-openssl-dev libxml2-dev zlib1g-dev"
+          missing=""
+          for p in $pkgs; do
+            dpkg -s "$p" > /dev/null 2>&1 || missing="$missing $p"
+          done
+          if [ -z "$missing" ]; then
+            echo "already on the runner image: $pkgs"
+            exit 0
+          fi
+          echo "missing:$missing"
           for attempt in 1 2 3; do
             if sudo timeout -k 10 120 apt-get update -qq \
-              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends \
-                   libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
+              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends $missing; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt timed out or failed; retrying"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,14 @@ jobs:
           # seconds and a retry instead of the run. Retrying rather than just
           # `timeout-minutes`: that would still lose the run to a manual re-run,
           # which is the toil this is here to remove.
+          #
+          # `sudo timeout`, not `timeout sudo`: the latter runs the killer as the
+          # runner user, which cannot signal the root apt-get it is trying to
+          # stop (EPERM), so the hang survives its own timeout. -k follows up
+          # with SIGKILL for an apt wedged past SIGTERM.
           for attempt in 1 2 3; do
-            if timeout 120 sudo apt-get update -qq \
-              && timeout 180 sudo apt-get install -y -qq --no-install-recommends \
+            if sudo timeout -k 10 120 apt-get update -qq \
+              && sudo timeout -k 10 180 apt-get install -y -qq --no-install-recommends \
                    libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
               exit 0
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,23 @@ jobs:
           sudo docker image prune --all --force || true
       - name: Swift toolchain system deps
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends \
-            libcurl4-openssl-dev libxml2-dev zlib1g-dev
+          # apt has wedged on a bad mirror here, sitting on `update` until the
+          # job's 6 h timeout rather than failing - one hung runner blocked two
+          # PRs at once. Bound each attempt and retry, so a bad mirror costs
+          # seconds and a retry instead of the run. Retrying rather than just
+          # `timeout-minutes`: that would still lose the run to a manual re-run,
+          # which is the toil this is here to remove.
+          for attempt in 1 2 3; do
+            if timeout 120 sudo apt-get update -qq \
+              && timeout 180 sudo apt-get install -y -qq --no-install-recommends \
+                   libcurl4-openssl-dev libxml2-dev zlib1g-dev; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt timed out or failed; retrying"
+            sleep $((attempt * 10))
+          done
+          echo "::error::apt failed after 3 attempts"
+          exit 1
       - uses: jdx/mise-action@v4
       # v7 is the newest floating major tag this action publishes (its later
       # releases ship no vN alias), and it already runs on node24.

--- a/Tests/GistTests/Fixture.swift
+++ b/Tests/GistTests/Fixture.swift
@@ -1,0 +1,43 @@
+import Foundation
+import DesertAnt
+import TestSupport
+@_spi(GistBindings) @testable import Gist
+
+#if !os(WASI)
+/// One resolve and one model build for the whole GistTests target.
+///
+/// Gist is the most expensive model here to load: resolving verifies 71 MB and
+/// costs ~9 s, and building the 67 MB embedding table another ~2 s, while a
+/// classify costs ~1 ms. So the suite's runtime is entirely a function of how
+/// many times it loads, and nothing else.
+///
+/// `Gist()` resolves through its own `LoadedModel`, which does not share
+/// `ModelFixture`'s memo — so a suite that used both paid the 9 s twice. Building
+/// the tagger from the fixture's already-resolved files collapses that to one,
+/// shared with `PipelineTests`, which needs the same files for its oracles.
+///
+/// The public `Gist()` construction path is deliberately not exercised here: it
+/// resolves through its own `LoadedModel`, and even `isDownloaded()` costs the
+/// full 9 s, because `ModelStore.isDownloaded` re-reads and SHA256s every file
+/// on each call. The resolve/download machinery is core's and is covered by the
+/// Emo and Redact `HubDownloadTests`, so paying for it again here buys nothing.
+enum GistFixture {
+    struct Loaded {
+        /// The resolved model directory, for tests that read sidecars directly.
+        let files: StoredModel
+        /// A ready tagger over those files. Shared: do not mutate.
+        let gist: Gist
+    }
+
+    // A static `let` Task is created lazily and exactly once, so concurrent
+    // suites await the same load rather than racing to repeat it.
+    private static let load = Task<Loaded, Error> {
+        let files = try await ModelFixture.files(GistModel.self)
+        return Loaded(
+            files: files,
+            gist: Gist(assets: try await ModelAssets.gist(files: files, variant: .default)))
+    }
+
+    static func loaded() async throws -> Loaded { try await load.value }
+}
+#endif

--- a/Tests/GistTests/GistTests.swift
+++ b/Tests/GistTests/GistTests.swift
@@ -9,12 +9,16 @@ import TestSupport
 /// same checkpoint, so the topics match.
 final class GistTests: XCTestCase {
 #if !os(WASI)
+    /// The tagger shared by every test here — see `GistFixture` for why the
+    /// suite loads the model exactly once.
+    private func gist() async throws -> Gist { try await GistFixture.loaded().gist }
+
     private func requireModelBacked() throws {
         try XCTSkipUnless(runsModelBackedTests, "model-backed tests do not run on iOS or Android")
     }
 
     private func slugs(_ text: String, topK: Int = 3) async throws -> [String] {
-        try await Gist().classify(text, topK: topK).map(\.slug)
+        try await gist().classify(text, topK: topK).map(\.slug)
     }
 
     func testEnglishTopics() async throws {
@@ -52,8 +56,7 @@ final class GistTests: XCTestCase {
     /// threshold, and never more than `topK`.
     func testRankingAndTopK() async throws {
         try requireModelBacked()
-        let gist = Gist()
-        let ranked = try await gist.classify("A one-pan roast chicken recipe for weeknights", topK: 5)
+        let ranked = try await gist().classify("A one-pan roast chicken recipe for weeknights", topK: 5)
         XCTAssertFalse(ranked.isEmpty)
         XCTAssertLessThanOrEqual(ranked.count, 5)
         XCTAssertEqual(ranked.map(\.score), ranked.map(\.score).sorted(by: >), "topics must be ranked")
@@ -62,14 +65,14 @@ final class GistTests: XCTestCase {
             XCTAssertTrue((0...1).contains(topic.score), "\(topic.slug) score out of range")
         }
         // An unrankable input still yields the single best topic.
-        let noise = try await gist.classify("asdfgh qwerty", topK: 3)
+        let noise = try await gist().classify("asdfgh qwerty", topK: 3)
         XCTAssertEqual(noise.count, 1, "got \(noise.map(\.slug))")
     }
 
     /// `scores` is the whole taxonomy, and it is a distribution over it.
     func testScoresCoverTheTaxonomy() async throws {
         try requireModelBacked()
-        let scores = try await Gist().scores(of: "How to start a podcast with just your iPhone")
+        let scores = try await gist().scores(of: "How to start a podcast with just your iPhone")
         XCTAssertEqual(scores.count, 36, "the taxonomy is 36 topics")
         for (slug, p) in scores {
             XCTAssertTrue((0...1).contains(p), "\(slug) = \(p) is not a probability")
@@ -81,10 +84,9 @@ final class GistTests: XCTestCase {
     /// wire format against a change made only on the Swift side.
     func testBindingPayloadCarriesTheTaxonomy() async throws {
         try requireModelBacked()
-        let gist = Gist()
         var input = FFIWriter()
         input.string("A one-pan roast chicken recipe for weeknights")
-        let bytes = await gist.run(input: FFIReader(input.bytes), options: FFIReader([]))
+        let bytes = try await gist().run(input: FFIReader(input.bytes), options: FFIReader([]))
         var r = FFIReader(try XCTUnwrap(bytes))
 
         let threshold = r.f64()

--- a/Tests/GistTests/PipelineTests.swift
+++ b/Tests/GistTests/PipelineTests.swift
@@ -17,10 +17,11 @@ final class PipelineTests: XCTestCase {
 
     // The tokenizer and the 67 MB embedding table come from the Hub rather than
     // from committed fixtures — the same files a user gets, and the reason this
-    // suite is model-backed. Only the 53 KB oracle is a test resource.
+    // suite is model-backed. Only the 53 KB oracle is a test resource. Resolved
+    // through `GistFixture` so the whole target verifies those files once.
     func testSemanticAndLexicalStreams() async throws {
         try XCTSkipUnless(runsModelBackedTests, "model-backed tests do not run on iOS or Android")
-        let files = try await ModelFixture.files(GistModel.self)
+        let files = try await GistFixture.loaded().files
 
         let tok = try XCTUnwrap(Tokenizer(bytes: try files.read(GistModel.tokenizer)))
         let embedding = try Embedding(

--- a/Tests/GistTests/TokenizerTests.swift
+++ b/Tests/GistTests/TokenizerTests.swift
@@ -18,7 +18,7 @@ final class TokenizerTests: XCTestCase {
     // is a test resource.
     func testMatchesPythonOracle() async throws {
         try XCTSkipUnless(runsModelBackedTests, "model-backed tests do not run on iOS or Android")
-        let files = try await ModelFixture.files(GistModel.self)
+        let files = try await GistFixture.loaded().files
         let tok = try XCTUnwrap(Tokenizer(bytes: try files.read(GistModel.tokenizer)))
 
         let oracleURL = try XCTUnwrap(Bundle.module.url(forResource: "gist-sdk-oracle", withExtension: "json"))

--- a/mise-tasks/test/ios
+++ b/mise-tasks/test/ios
@@ -6,9 +6,22 @@ source "$MISE_PROJECT_ROOT/Tools/dal.sh"
 # The auto-generated "<package>-Package" scheme builds every target and runs
 # every suite, so this covers every model. -skipMacroValidation avoids the
 # swift-syntax macro fingerprint prompt (pulled in via JavaScriptKit's plugin).
-# Newest available iPhone simulator.
-device=$(xcrun simctl list devices available | grep -oE 'iPhone [0-9]+( Pro)?( Max)?' | tail -1)
-echo "Using simulator: ${device:?no iPhone simulator is available}"
+
+# The newest available iPhone simulator, selected by udid rather than by name.
+# A bare name lets xcodebuild default the destination to `OS:latest`, which
+# means the *SDK's* iOS version — and if that runtime is not installed it is a
+# hard "unable to find a destination" failure rather than a fallback to a
+# runtime that is. Picking the udid pins both the device and its runtime.
+device=$(xcrun simctl list devices available \
+    | awk '/^-- iOS /{ios=1; next} /^-- /{ios=0} ios && /^ *iPhone /{last=$0} END{print last}')
+udid=$(printf '%s' "$device" | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f-]{27}')
+[ -n "$udid" ] || {
+    echo "error: no iPhone simulator is available." >&2
+    echo "       Install a runtime with 'xcodebuild -downloadPlatform iOS'." >&2
+    exit 1
+}
+name=$(printf '%s' "${device%% (*}" | sed 's/^ *//')
+echo "Using simulator: $name ($udid)"
 
 # On CI, pin DerivedData and the SPM clone dir to repo-local paths so
 # actions/cache can persist them across runs; locally, leave Xcode's defaults
@@ -22,8 +35,16 @@ if [[ -n "${CI:-}" ]]; then
     )
 fi
 
+# Run the bundles in parallel. This package has 21 test targets, so the run is
+# 21 separate .xctest installs and launches on the simulator; the tests inside
+# them take ~37 s in total, while the launches around them cost ~105 s. Letting
+# xcodebuild clone the simulator and overlap them halves the phase (69 s -> 40 s
+# measured locally). The worker count is left to xcodebuild: pinning it to 8
+# measured no better than the default. Safe here because the model-backed tests
+# — the only ones that touch shared state, the model cache — are skipped on iOS.
 xcodebuild test \
     -scheme DesertAnt-Package \
-    -destination "platform=iOS Simulator,name=$device" \
+    -destination "platform=iOS Simulator,id=$udid" \
     -skipMacroValidation \
+    -parallel-testing-enabled YES \
     ${ci_flags[@]+"${ci_flags[@]}"}


### PR DESCRIPTION
Two independent test-time fixes. CI's Apple job was 615 s in `test:swift` and 309 s in `test:ios`.

**`test:swift` — gist loaded the model ten times**
- A classify costs ~1 ms; a load costs ~11 s (resolving verifies 71 MB at ~9 s, then the 67 MB embedding table takes ~2 s). XCTest makes a fresh instance per test method, and `slugs()` built a new `Gist` on every call, so `testEnglishTopics` alone paid for three loads
- A shared `GistFixture` resolves once and hands out one tagger; `PipelineTests` and `TokenizerTests` read sidecars from it, so the target verifies its 71 MB once instead of twice
- **112 s -> 14 s** locally; individual tests go from 11–33 s to 2–5 ms. Same 8 tests, no assertion changed

**`test:ios` — 21 bundle launches, run serially**
- 21 test targets means 21 separate `.xctest` installs and launches; the tests inside take ~37 s in total, the launches around them ~105 s
- `-parallel-testing-enabled YES`: **69 s -> 40 s** for the test phase, measured locally. Worker count left to xcodebuild (pinning 8 measured no better)
- Pins the destination to a concrete simulator udid. Selecting by name let xcodebuild default to `OS:latest` — the SDK's iOS version — which hard-fails when that runtime is not installed rather than using one that is
- Drops the `ci.yml` claim that swift-syntax dominates the job: JavaScriptKit went opt-in behind `DAL_WASM_BUILD`, which `test:ios` does not set, and swift-syntax no longer appears in the log

**Found but not fixed:** `ModelStore.isDownloaded` re-reads and SHA256s every file on every call — 9.3 s for gist, measured three times in a row with no caching. It is synchronous public API, so an app calling it blocks its thread that long. Affects every model; whether availability should fully verify, trust size+mtime, or cache its verdict is a core design call, so it wants its own issue.
