### PR TITLE
Add Shapes: on-device single-stroke shape recognition

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -128,6 +128,12 @@ let models: [ModelPackage] = [
             .copy("Resources/gist-feature-oracle.json"),
         ]
     ),
+    // The geometric fitters and snapping replace `simd` (Apple-only) with a
+    // portable V2, so their transcendental math comes from swift-numerics.
+    .init(
+        name: "Shapes",
+        dependencies: [.product(name: "RealModule", package: "swift-numerics")]
+    ),
 ] + [
     // Cards are written for a `Clip`, which `Transcript` declares. Declared unconditionally;
     // without the `MLX` trait its MLX dependencies are pruned and the target compiles as a

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 | **Gist** | Content topic tagging over a 36-topic taxonomy, 101 languages | `Gist` | `ai.desertant:gist` | `@desert-ant-labs/gist` | [Hugging Face](https://huggingface.co/desert-ant-labs/gist) |
 | **Align** | Word-timestamp refinement for Apple's `SpeechAnalyzer` pipeline, 9 languages | `Align` | Apple-only | Apple-only | [Hugging Face](https://huggingface.co/desert-ant-labs/align) |
 | **Tongue** | Language identification for short text, 84 languages | `Tongue` | `ai.desertant:tongue` | `@desert-ant-labs/tongue` | Bundled (2 MB) |
+| **Shapes** | Single-stroke shape recognition: one hand-drawn stroke to clean vector geometry | `Shapes` | `ai.desertant:shapes` | `@desert-ant-labs/shapes` | [Hugging Face](https://huggingface.co/desert-ant-labs/shapes) |
 
 Each model behaves the same on every platform, so you can build a feature once
 and ship it everywhere. New models are added regularly; the current set is always
@@ -160,6 +161,31 @@ detection.candidates        // [Prediction(language: "de", probability: 0.999…
 detection.isTooCloseToCall  // false
 ```
 
+**Shapes**
+
+```swift
+import Shapes
+
+let shapes = Shapes()
+if let shape = try await shapes.recognize(points: strokePoints) {
+    switch shape {
+    case let .rectangle(corners): ...       // [Point]
+    case let .ellipse(center, semiMajor, semiMinor, rotation): ...
+    default: break
+    }
+}
+```
+
+`recognize` accepts `[Point]` or, on Apple platforms, `[CGPoint]` and PencilKit
+`PKStroke`; `Shape.path` gives a renderable `CGPath`. On iOS and visionOS, live
+snapping on a PencilKit canvas is one line - pausing mid-stroke previews the
+recognized shape, lifting the pen swaps it in, and the swap is registered with
+the canvas's undo manager:
+
+```swift
+canvasView.enableShapeSnapping()
+```
+
 **Download ahead of time**
 
 Any model can be fetched before first use, for example during onboarding:
@@ -266,6 +292,20 @@ detection.language                               // "de"
 detection.isTooCloseToCall                       // false
 ```
 
+```kotlin
+import ai.desertant.shapes.Point
+import ai.desertant.shapes.Shape
+import ai.desertant.shapes.Shapes
+
+Shapes(context).use { shapes ->
+    when (val shape = shapes.recognize(strokePoints)) {   // Shape? (null if rejected)
+        is Shape.Rectangle -> shape.corners
+        is Shape.Ellipse -> shape.center
+        else -> {}
+    }
+}
+```
+
 Download before first use, or point at your own directory:
 
 ```kotlin
@@ -348,6 +388,15 @@ so a copy script can `require.resolve` them under pnpm and Yarn PnP too:
 
 ```ts
 const tongue = await Tongue.load({ from: "/models/tongue" });
+```
+
+```ts
+import { Shapes } from "@desert-ant-labs/shapes";
+
+const shapes = await Shapes.load();
+const shape = await shapes.recognize(points);   // [{x, y}, ...] or [x0, y0, ...]
+if (shape?.kind === "ellipse") shape.center;    // null when the stroke is rejected
+shapes.dispose();
 ```
 
 Self-host the model files or track download progress:

--- a/Sources/Shapes/Binding.swift
+++ b/Sources/Shapes/Binding.swift
@@ -1,0 +1,96 @@
+// Shapes' side of the cross-language binding: construction, plus the two payload
+// schemas that are genuinely model-specific (the options a run takes, and what a
+// result looks like). The generic handle lifecycle and the exported symbols live
+// in NativeBindings and ShapesNative, so this file is only the model's adapter.
+
+import DesertAnt
+
+extension Shapes: BoundModel {
+    /// Input payload: `u32 count`, then that many `f64 x`, `f64 y` pairs - one
+    /// stroke in canvas coordinates. Nothing about the modality reaches the ABI:
+    /// a stroke is just this model's payload, like text is emo's and samples are
+    /// clear's.
+    ///
+    /// Options payload: `f64 minimumConfidence`. An empty payload means the SDK
+    /// defaults.
+    ///
+    /// Result payload: `u32 present` (0 when the stroke was rejected or
+    /// degenerate, and nothing follows); otherwise `u32 kind` (1 line,
+    /// 2 rectangle, 3 triangle, 4 ellipse, 5 star) followed by that kind's
+    /// fields. Points are `f64` pairs, point lists are a `u32` count then that
+    /// many points.
+    public func run(input: FFIReader, options: FFIReader) async -> [UInt8]? {
+        var input = input
+        var options = options
+        let count = input.u32()
+        var points: [Point] = []
+        points.reserveCapacity(count)
+        for _ in 0..<count {
+            let x = input.f64()
+            points.append(Point(x: x, y: input.f64()))
+        }
+        // An empty payload means the SDK defaults, so this must match the default
+        // every SDK declares for `minimumConfidence` (0), not a number of its own.
+        let opts = Options(minimumConfidence: options.isEmpty ? 0 : options.f64())
+        // `try?` alone would flatten the two nils into one: a rejected stroke
+        // (a result the host must see as "no shape") and a failed load or run
+        // (a NULL buffer). They are different answers, so they are caught apart.
+        let recognized: Shape?
+        do { recognized = try await recognize(points: points, options: opts) }
+        catch { return nil }
+
+        var w = FFIWriter()
+        guard let shape = recognized else {
+            w.u32(0)
+            return w.bytes
+        }
+        w.u32(1)
+        switch shape {
+        case let .line(from, to):
+            w.u32(1)
+            w.point(from)
+            w.point(to)
+        case let .rectangle(corners):
+            w.u32(2)
+            w.points(corners)
+        case let .triangle(vertices):
+            w.u32(3)
+            w.points(vertices)
+        case let .ellipse(center, semiMajor, semiMinor, rotation):
+            w.u32(4)
+            w.point(center)
+            w.f64(semiMajor)
+            w.f64(semiMinor)
+            w.f64(rotation)
+        case let .star(center, outerRadius, innerRadius, rotation, pointCount):
+            w.u32(5)
+            w.point(center)
+            w.f64(outerRadius)
+            w.f64(innerRadius)
+            w.f64(rotation)
+            w.u32(pointCount)
+        }
+        return w.bytes
+    }
+}
+
+private extension FFIWriter {
+    mutating func point(_ p: Point) {
+        f64(p.x)
+        f64(p.y)
+    }
+
+    mutating func points(_ ps: [Point]) {
+        u32(ps.count)
+        for p in ps { point(p) }
+    }
+}
+
+/// How the generic bindings construct Shapes.
+public enum ShapesBinding: ModelBinding {
+    public static let id = ShapesModel.id
+
+    public static func make(cacheRoot: String?, directory: String?) -> any BoundModel {
+        Shapes(directory: directory, cacheRoot: cacheRoot)
+    }
+}

--- a/Sources/Shapes/Catalog.swift
+++ b/Sources/Shapes/Catalog.swift
@@ -1,0 +1,41 @@
+// This model's catalog declaration: coordinates, file names, and which of them
+// each platform ships. The shared behaviour (distribution, resolve, availability)
+// comes from `ModelDeclaration` in the catalog's shared half.
+
+import DesertAnt
+
+/// The shapes model: on-device single-stroke shape recognition.
+public enum ShapesModel: ModelDeclaration {
+    public static let id = "shapes"
+    public static let product = "Shapes"
+    public static let revision = "v0.3.0"
+    /// Matches packages/shapes-node/package.json and
+    /// packages/shapes-kotlin/build.gradle.kts (ModelCatalogTests enforces it).
+    public static let sdkVersion = "3.0.0"
+    public static let summary = "On-device single-stroke shape recognition."
+
+    /// Class order, calibrated gates, and the frozen preprocessing constants.
+    public static let meta = "shapes_meta.json"
+    /// LiteRT export: Android/Linux/Windows + wasm.
+    public static let tflite = "shapes.tflite"
+    /// Core ML export (a directory on the Hub): Apple.
+    public static let coreML = "shapes.mlmodelc"
+
+    /// Sidecars every platform needs alongside the artifact.
+    public static let sidecars = [meta]
+
+    public static let files: [ModelPlatform: [String]] = [
+        .apple: [coreML + "/"] + sidecars,
+        .android: [tflite] + sidecars,
+        .linux: [tflite] + sidecars,
+        .windows: [tflite] + sidecars,
+        .web: [tflite] + sidecars,
+    ]
+
+    /// Both exports share one graph: a fixed 256-length window of
+    /// `[distance, cos, sin]` features plus a 1/0 validity mask, so there is no
+    /// per-artifact tensor shaping to track.
+    public static func artifact(for platform: ModelPlatform) -> String {
+        platform == .apple ? coreML : tflite
+    }
+}

--- a/Sources/Shapes/CoreGraphicsInterop.swift
+++ b/Sources/Shapes/CoreGraphicsInterop.swift
@@ -1,0 +1,42 @@
+#if canImport(CoreGraphics)
+import CoreGraphics
+
+// Apple-only ergonomics: convert between the portable `Point` and `CGPoint`,
+// render a fitted `Shape` to a `CGPath`, and accept `CGPoint` strokes directly.
+// CoreGraphics exists only on Apple platforms, so this whole file is gated and
+// never affects the Android/wasm builds.
+
+public extension Point {
+    /// Create a point from a `CGPoint`.
+    init(_ p: CGPoint) { self.init(x: Double(p.x), y: Double(p.y)) }
+    /// The point as a `CGPoint`.
+    var cgPoint: CGPoint { CGPoint(x: x, y: y) }
+}
+
+public extension Shape {
+    /// The shape's outline as `CGPoint` values (see ``outline(samples:)``).
+    func cgOutline(samples: Int = 96) -> [CGPoint] {
+        outline(samples: samples).map(\.cgPoint)
+    }
+
+    /// A renderable path. Closed for all shapes except `.line`.
+    var path: CGPath {
+        let pts = cgOutline()
+        let path = CGMutablePath()
+        guard let first = pts.first else { return path }
+        path.move(to: first)
+        for p in pts.dropFirst() { path.addLine(to: p) }
+        if case .line = self {} else { path.closeSubpath() }
+        return path
+    }
+}
+
+public extension Shapes {
+    /// Recognize a stroke given as ordered `CGPoint` values (canvas
+    /// coordinates). Returns the snapped ``Shape``, or `nil` when rejected or
+    /// degenerate.
+    func recognize(points: [CGPoint], options: Options = .init()) async throws -> Shape? {
+        try await recognize(points: points.map(Point.init), options: options)
+    }
+}
+#endif

--- a/Sources/Shapes/Fitter.swift
+++ b/Sources/Shapes/Fitter.swift
@@ -1,0 +1,300 @@
+import RealModule
+
+/// Stage-2 geometric fitters (port of the Python `fitter.py`).
+///
+/// Each fitter takes the raw stroke points and returns clean vector geometry
+/// plus a normalized fit residual (RMS point-to-shape distance / bbox diagonal),
+/// which the recognizer's gates use to verify the neural-net's proposal. Math
+/// is the portable ``V2`` type (no `simd`), so it runs identically everywhere.
+enum Fitter {
+    static func fit(_ shape: ShapeKind, points: [Point], snap config: SnapConfig)
+        -> (Shape, Double) {
+        // Resample to uniform arc length first: raw input points are unevenly
+        // spaced (fast straight runs, slow curves), which biases centroid- and
+        // moment-based fits (notably the ellipse/star center).
+        let pts = resampleUniform(points.map { V2($0.x, $0.y) }, count: 256)
+        let (fitted, residual): (Shape, Double)
+        switch shape {
+        case .line: (fitted, residual) = fitLine(pts)
+        case .rectangle: (fitted, residual) = fitRectangle(pts)
+        case .triangle: (fitted, residual) = fitTriangle(pts)
+        case .ellipse: (fitted, residual) = fitEllipse(pts)
+        case .star: (fitted, residual) = fitStar(pts)
+        }
+        // Gate on the accurate raw-fit residual; clean the output geometry.
+        return (snap(fitted, config: config), residual)
+    }
+
+    private static func resampleUniform(_ p: [V2], count: Int) -> [V2] {
+        guard p.count > 2, count > 1 else { return p }
+        var cum = [0.0]
+        cum.reserveCapacity(p.count)
+        for i in 1..<p.count { cum.append(cum[i - 1] + (p[i] - p[i - 1]).length) }
+        let total = cum[cum.count - 1]
+        guard total > 0 else { return p }
+        var out = [V2]()
+        out.reserveCapacity(count)
+        var j = 0
+        for i in 0..<count {
+            let target = total * Double(i) / Double(count - 1)
+            while j < p.count - 2 && cum[j + 1] < target { j += 1 }
+            let seg = cum[j + 1] - cum[j]
+            let t = seg > 0 ? (target - cum[j]) / seg : 0
+            out.append(p[j] + (p[j + 1] - p[j]) * t)
+        }
+        return out
+    }
+
+    // MARK: Residual helpers
+
+    private static func bboxDiag(_ p: [V2]) -> Double {
+        var lo = p[0], hi = p[0]
+        for v in p { lo = vmin(lo, v); hi = vmax(hi, v) }
+        let d = (hi - lo).length
+        return d > 0 ? d : 1
+    }
+
+    private static func ptSegDist(_ q: V2, _ a: V2, _ b: V2) -> Double {
+        let ab = b - a
+        let l2 = dot(ab, ab)
+        if l2 == 0 { return (q - a).length }
+        let t = max(0.0, min(1.0, dot(q - a, ab) / l2))
+        return (q - (a + t * ab)).length
+    }
+
+    private static func residual(_ stroke: [V2], _ poly: [V2], closed: Bool) -> Double {
+        var ring = poly
+        if closed, let f = poly.first { ring.append(f) }
+        var sumSq = 0.0
+        for q in stroke {
+            var best = Double.greatestFiniteMagnitude
+            for i in 0..<(ring.count - 1) {
+                best = min(best, ptSegDist(q, ring[i], ring[i + 1]))
+            }
+            sumSq += best * best
+        }
+        let rms = (sumSq / Double(stroke.count)).squareRoot()
+        return rms / bboxDiag(stroke)
+    }
+
+    private static func cgp(_ v: V2) -> Point { Point(x: v.x, y: v.y) }
+    private static func centroid(_ p: [V2]) -> V2 { p.reduce(V2(0, 0), +) / Double(p.count) }
+
+    // MARK: Line — PCA principal axis
+
+    private static func fitLine(_ pts: [V2]) -> (Shape, Double) {
+        let c = centroid(pts)
+        var sxx = 0.0, sxy = 0.0, syy = 0.0
+        for p in pts {
+            let d = p - c
+            sxx += d.x * d.x; sxy += d.x * d.y; syy += d.y * d.y
+        }
+        let dir = symEig2x2Major(sxx, sxy, syy)
+        var lo = Double.greatestFiniteMagnitude, hi = -Double.greatestFiniteMagnitude
+        for p in pts {
+            let t = dot(p - c, dir)
+            lo = min(lo, t); hi = max(hi, t)
+        }
+        let a = c + lo * dir, b = c + hi * dir
+        return (.line(from: cgp(a), to: cgp(b)), residual(pts, [a, b], closed: false))
+    }
+
+    // MARK: Rectangle — minimum-area oriented box
+
+    private static func fitRectangle(_ pts: [V2]) -> (Shape, Double) {
+        // Minimum-area oriented bounding box via rotating calipers over the
+        // convex hull; rotation = atan2 of the best box edge direction. PCA of
+        // the perimeter is unstable for near-squares (it picks the diagonal), so
+        // we keep the tightest hull-edge-aligned box instead.
+        let hull = convexHull(pts)
+        if hull.count < 3 { return fitLine(pts) }
+        var best: (area: Double, corners: [V2])?
+        for i in 0..<hull.count {
+            let edge = hull[(i + 1) % hull.count] - hull[i]
+            let ang = Double.atan2(y: edge.y, x: edge.x)
+            let r = Mat2.rotation(-ang)
+            var lo = V2(.greatestFiniteMagnitude, .greatestFiniteMagnitude)
+            var hi = V2(-.greatestFiniteMagnitude, -.greatestFiniteMagnitude)
+            for h in hull { let p = r * h; lo = vmin(lo, p); hi = vmax(hi, p) }
+            let area = (hi.x - lo.x) * (hi.y - lo.y)
+            if best == nil || area < best!.area {
+                let cr = [V2(lo.x, lo.y), V2(hi.x, lo.y), V2(hi.x, hi.y), V2(lo.x, hi.y)]
+                let back = Mat2.rotation(ang)
+                best = (area, cr.map { back * $0 })
+            }
+        }
+        let corners = best!.corners
+        return (.rectangle(corners: corners.map(cgp)), residual(pts, corners, closed: true))
+    }
+
+    // MARK: Triangle — largest-area triangle over the hull
+
+    private static func fitTriangle(_ pts: [V2]) -> (Shape, Double) {
+        var hull = convexHull(pts)
+        if hull.count < 3 { return fitLine(pts) }
+        if hull.count > 36 {
+            let idx = (0..<36).map { Int((Double($0) * Double(hull.count - 1) / 35.0).rounded()) }
+            var seen = Set<Int>(); hull = idx.filter { seen.insert($0).inserted }.map { hull[$0] }
+        }
+        var best = -1.0
+        var tri = [hull[0], hull[1], hull[2]]
+        for i in 0..<hull.count {
+            for j in (i + 1)..<hull.count {
+                for k in (j + 1)..<hull.count {
+                    let area = abs(crossZ(hull[j] - hull[i], hull[k] - hull[i])) * 0.5
+                    if area > best { best = area; tri = [hull[i], hull[j], hull[k]] }
+                }
+            }
+        }
+        return (.triangle(vertices: tri.map(cgp)), residual(pts, tri, closed: true))
+    }
+
+    // MARK: Ellipse — principal axis + projected extents
+
+    private static func fitEllipse(_ pts: [V2]) -> (Shape, Double) {
+        // Principal-axis direction from the covariance, then center and semi-axes
+        // from the min/max projection onto those axes (an ellipse touches its
+        // bounding box at the axis endpoints). Center and axes are sampling-
+        // independent, avoiding the centroid/variance bias of a pure moment fit.
+        let c = centroid(pts)
+        var sxx = 0.0, sxy = 0.0, syy = 0.0
+        for p in pts {
+            let d = p - c
+            sxx += d.x * d.x; sxy += d.x * d.y; syy += d.y * d.y
+        }
+        let (_, _, v1, _) = symEig2x2Full(sxx, sxy, syy)
+        let u = v1, v = V2(-v1.y, v1.x)
+        var uLo = Double.greatestFiniteMagnitude, uHi = -uLo
+        var vLo = Double.greatestFiniteMagnitude, vHi = -vLo
+        for p in pts {
+            let tu = dot(p - c, u), tv = dot(p - c, v)
+            uLo = min(uLo, tu); uHi = max(uHi, tu)
+            vLo = min(vLo, tv); vHi = max(vHi, tv)
+        }
+        let center = c + (uLo + uHi) / 2 * u + (vLo + vHi) / 2 * v
+        let major = (uHi - uLo) / 2, minor = (vHi - vLo) / 2
+        let rotation = Double.atan2(y: u.y, x: u.x)
+        if major <= 0 || minor <= 0 || !major.isFinite || !minor.isFinite {
+            let r = pts.reduce(0.0) { $0 + ($1 - c).length } / Double(pts.count)
+            let poly = ellipseOutline(c, r, r, 0)
+            return (.ellipse(center: cgp(c), semiMajor: r, semiMinor: r,
+                             rotation: 0), residual(pts, poly, closed: true))
+        }
+        let poly = ellipseOutline(center, major, minor, rotation)
+        return (.ellipse(center: cgp(center), semiMajor: major, semiMinor: minor,
+                         rotation: rotation), residual(pts, poly, closed: true))
+    }
+
+    private static func ellipseOutline(_ c: V2, _ major: Double, _ minor: Double,
+                                       _ rotation: Double) -> [V2] {
+        let cc = Double.cos(rotation), ss = Double.sin(rotation)
+        return (0..<160).map { i -> V2 in
+            let t = 2 * Double.pi * Double(i) / 160
+            let x = major * Double.cos(t), y = minor * Double.sin(t)
+            return c + V2(x * cc - y * ss, x * ss + y * cc)
+        }
+    }
+
+    // MARK: Star — instantiate template at a fitted pose
+
+    private static func fitStar(_ pts: [V2]) -> (Shape, Double) {
+        let center = centroid(pts)
+        let radii = pts.map { ($0 - center).length }
+
+        // Rotation: radius-weighted circular mean in 5x angle space (5-fold
+        // symmetry). Template outer tip 0 sits at angle -pi/2 + rotation, so
+        // 5*(-pi/2 + rotation) == phase  =>  rotation = phase/5 + pi/2.
+        var sc = 0.0, ss = 0.0
+        for (i, p) in pts.enumerated() {
+            let a = Double.atan2(y: (p - center).y, x: (p - center).x)
+            let w = radii[i] * radii[i]
+            sc += w * Double.cos(5 * a); ss += w * Double.sin(5 * a)
+        }
+        let rot0 = Double.atan2(y: ss, x: sc) / 5 + Double.pi / 2
+
+        // Size: outer radius from the largest radii (the tips); template fixes
+        // the inner/outer ratio at 0.4.
+        let sorted = radii.sorted()
+        let topCount = max(1, sorted.count / 5)
+        let outer = sorted.suffix(topCount).reduce(0, +) / Double(topCount)
+        let inner = outer * 0.4
+
+        // The 5x mean is periodic in 72°; disambiguate with a half-period offset.
+        var best = (Double.greatestFiniteMagnitude, rot0)
+        for angle in [rot0, rot0 + Double.pi / 5] {
+            let res = residual(pts, starVertices(center, outer, inner, angle), closed: true)
+            if res < best.0 { best = (res, angle) }
+        }
+        return (.star(center: cgp(center), outerRadius: outer,
+                      innerRadius: inner, rotation: best.1, pointCount: 5),
+                best.0)
+    }
+
+    private static func starVertices(_ center: V2, _ outer: Double, _ inner: Double,
+                                     _ rotation: Double) -> [V2] {
+        (0..<10).map { i in
+            let a = rotation - Double.pi / 2 + Double(i) * Double.pi / 5
+            let r = i % 2 == 0 ? outer : inner
+            return center + V2(r * Double.cos(a), r * Double.sin(a))
+        }
+    }
+
+    // MARK: Convex hull (monotone chain)
+
+    private static func convexHull(_ points: [V2]) -> [V2] {
+        var pts = Array(Set(points.map { HashV2(($0.x * 1e6).rounded() / 1e6,
+                                               ($0.y * 1e6).rounded() / 1e6) })).map(\.v)
+        if pts.count <= 2 { return pts }
+        pts.sort { $0.x == $1.x ? $0.y < $1.y : $0.x < $1.x }
+        func cross(_ o: V2, _ a: V2, _ b: V2) -> Double {
+            (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x)
+        }
+        var lower: [V2] = []
+        for p in pts {
+            while lower.count >= 2 && cross(lower[lower.count - 2], lower[lower.count - 1], p) <= 0 {
+                lower.removeLast()
+            }
+            lower.append(p)
+        }
+        var upper: [V2] = []
+        for p in pts.reversed() {
+            while upper.count >= 2 && cross(upper[upper.count - 2], upper[upper.count - 1], p) <= 0 {
+                upper.removeLast()
+            }
+            upper.append(p)
+        }
+        return Array(lower.dropLast()) + Array(upper.dropLast())
+    }
+
+    // MARK: small linear algebra
+
+    /// Major eigenvector of the symmetric 2x2 [[a,b],[b,c]].
+    private static func symEig2x2Major(_ a: Double, _ b: Double, _ c: Double) -> V2 {
+        let (_, _, v1, _) = symEig2x2Full(a, b, c)
+        return v1
+    }
+
+    /// Returns (largerEigval, smallerEigval, vecForLarger, vecForSmaller).
+    private static func symEig2x2Full(_ a: Double, _ b: Double, _ c: Double)
+        -> (Double, Double, V2, V2) {
+        let tr = a + c
+        let disc = (((a - c) / 2) * ((a - c) / 2) + b * b).squareRoot()
+        let l1 = tr / 2 + disc
+        let l2 = tr / 2 - disc
+        func vec(_ l: Double) -> V2 {
+            let v = abs(b) > 1e-15 ? V2(l - c, b) : (a >= c ? V2(1, 0) : V2(0, 1))
+            let n = v.length
+            return n > 0 ? v / n : V2(1, 0)
+        }
+        return (l1, l2, vec(l1), vec(l2))
+    }
+}
+
+/// Hashable wrapper so the convex hull can dedupe rounded points in a `Set`
+/// (portable; `V2` stays a plain arithmetic value type).
+private struct HashV2: Hashable {
+    let v: V2
+    init(_ x: Double, _ y: Double) { v = V2(x, y) }
+    static func == (a: HashV2, b: HashV2) -> Bool { a.v == b.v }
+    func hash(into h: inout Hasher) { h.combine(v.x); h.combine(v.y) }
+}

--- a/Sources/Shapes/Geometry.swift
+++ b/Sources/Shapes/Geometry.swift
@@ -1,0 +1,46 @@
+import RealModule
+
+/// Internal 2D vector math. Replaces `simd` (Apple-only) with a small portable
+/// struct so the geometric fitters and snapping run identically on every
+/// platform (Apple, Linux, Android, wasm). All transcendental math goes through
+/// `swift-numerics` (`Double.cos`, `Double.atan2`, ...); the stdlib has none and
+/// importing the platform libm per target is messier.
+struct V2: Equatable {
+    var x: Double
+    var y: Double
+
+    init(_ x: Double, _ y: Double) {
+        self.x = x
+        self.y = y
+    }
+
+    static func + (a: V2, b: V2) -> V2 { V2(a.x + b.x, a.y + b.y) }
+    static func - (a: V2, b: V2) -> V2 { V2(a.x - b.x, a.y - b.y) }
+    static func * (s: Double, v: V2) -> V2 { V2(s * v.x, s * v.y) }
+    static func * (v: V2, s: Double) -> V2 { V2(v.x * s, v.y * s) }
+    static func / (v: V2, s: Double) -> V2 { V2(v.x / s, v.y / s) }
+
+    var length: Double { (x * x + y * y).squareRoot() }
+}
+
+func dot(_ a: V2, _ b: V2) -> Double { a.x * b.x + a.y * b.y }
+/// The z component of the 3D cross product of two planar vectors.
+func crossZ(_ a: V2, _ b: V2) -> Double { a.x * b.y - a.y * b.x }
+func vmin(_ a: V2, _ b: V2) -> V2 { V2(Swift.min(a.x, b.x), Swift.min(a.y, b.y)) }
+func vmax(_ a: V2, _ b: V2) -> V2 { V2(Swift.max(a.x, b.x), Swift.max(a.y, b.y)) }
+
+/// A 2x2 rotation matrix (columns), replacing `simd_double2x2`.
+struct Mat2 {
+    let c0: V2
+    let c1: V2
+
+    /// Rotation by `angle` (radians).
+    static func rotation(_ angle: Double) -> Mat2 {
+        let c = Double.cos(angle), s = Double.sin(angle)
+        return Mat2(c0: V2(c, s), c1: V2(-s, c))   // columns
+    }
+
+    static func * (m: Mat2, v: V2) -> V2 {
+        V2(m.c0.x * v.x + m.c1.x * v.y, m.c0.y * v.x + m.c1.y * v.y)
+    }
+}

--- a/Sources/Shapes/Model.swift
+++ b/Sources/Shapes/Model.swift
@@ -1,0 +1,84 @@
+import DesertAnt
+
+/// The neural stage plus geometry verification: preprocess a stroke into the
+/// model's feature vectors, classify it through the shared `InferenceSession`
+/// (Core ML | LiteRT | JS host, chosen by the core), then fit and gate the
+/// proposed shape. This file only knows shapes' tensor layout; the runtime is
+/// oblivious.
+final class Model: @unchecked Sendable {
+    private let session: any InferenceSession
+    private let meta: ShapeMeta
+    private let preprocessor: StrokePreprocessor
+
+    /// The Core ML and LiteRT exports share one graph: a fixed 256-length window
+    /// of `[distance, cos, sin]` features with a 1/0 validity mask.
+    private static let sequenceLength = 256
+
+    init(assets: ModelAssets) throws {
+        session = assets.session
+        meta = try ShapeMeta(json: assets.metaJSON)
+        preprocessor = StrokePreprocessor(config: meta.config)
+    }
+
+    /// Recognize a stroke: preprocess, classify, then fit and gate. Returns the
+    /// snapped ``Shape``, or `nil` when rejected or degenerate.
+    func recognize(points: [Point], options: Options) async throws -> Shape? {
+        let features: [StrokePoint]
+        do {
+            features = try preprocessor.process(points: points)
+        } catch is DegenerateStrokeError {
+            return nil
+        }
+        let (index, confidence) = try await classify(features)
+        guard index < meta.classOrder.count, let kind = meta.classOrder[index] else {
+            return nil  // reject class
+        }
+        guard let gate = meta.gates[kind] else { return nil }
+        if confidence < gate.conf { return nil }
+        if confidence < Float(options.minimumConfidence) { return nil }
+
+        let (shape, residual) = Fitter.fit(kind, points: points, snap: options.snap)
+        if Float(residual) > gate.resid { return nil }
+        return shape
+    }
+
+    // MARK: inference
+
+    /// Run the classifier over one stroke's features, returning the top class
+    /// index and its probability.
+    private func classify(_ features: [StrokePoint]) async throws -> (index: Int, confidence: Float) {
+        let probs = try await probabilities(features)
+        var bestIndex = 0
+        var bestValue = -Float.greatestFiniteMagnitude
+        for i in 0..<probs.count where probs[i] > bestValue {
+            bestValue = probs[i]
+            bestIndex = i
+        }
+        return (bestIndex, bestValue)
+    }
+
+    /// Build the padded-window tensors and read the `probs` output.
+    private func probabilities(_ features: [StrokePoint]) async throws -> [Float] {
+        let seq = Self.sequenceLength
+        var feat = [Float](repeating: 0, count: seq * 3)
+        var mask = [Float](repeating: 0, count: seq)
+        let n = min(features.count, seq)
+        for s in 0..<n {
+            let p = features[s]
+            feat[s * 3 + 0] = p.distance
+            feat[s * 3 + 1] = p.cosTheta
+            feat[s * 3 + 2] = p.sinTheta
+            mask[s] = 1
+        }
+        let output = try await session.run(
+            inputs: [
+                "features": Tensor(float32: feat, shape: [1, seq, 3]),
+                "mask": Tensor(float32: mask, shape: [1, seq]),
+            ],
+            outputs: ["probs"])[0]
+        guard let probs = output.float32Values, !probs.isEmpty else {
+            throw ShapesError.predictionFailed
+        }
+        return probs
+    }
+}

--- a/Sources/Shapes/ModelLoading.swift
+++ b/Sources/Shapes/ModelLoading.swift
@@ -1,0 +1,59 @@
+// How Shapes obtains and shapes its model: the file manifest, the
+// download/adopt sources, and the `ModelAssets` the recognizer consumes.
+// (Running the model is `Model.swift`.) All platform variation is data here
+// (which artifact ships where); building the platform's session is
+// DesertAnt's `inferenceSession` factory.
+import DesertAnt
+
+// The SDK's usage identity (`ShapesModel.sdkInfo`) is derived from the catalog
+// declaration's `product` + `sdkVersion`, so it cannot drift from the published
+// package version or be forgotten on a session.
+
+// The model's file names, per-platform manifest, repo and pinned revision live
+// in the catalog declaration (`Catalog.swift`) as `ShapesModel`, so tooling and
+// this SDK read one declaration.
+
+/// Loaded model inputs: the sidecar metadata plus a ready inference session.
+/// Also the entry point for the cross-language bindings and custom deployments
+/// (not part of the Swift SDK's public API, which loads assets for you).
+@_spi(ShapesBindings)
+public struct ModelAssets: Sendable {
+    /// Contents of `shapes_meta.json` (classes, gates, preprocessing constants).
+    public let metaJSON: String
+    /// The platform's ready-to-run session for the model artifact.
+    let session: any InferenceSession
+
+    /// Bindings entry point: build from an already-constructed session (e.g. the
+    /// wasm host's `JSInferenceSession`) plus the sidecar.
+    @_spi(ShapesBindings)
+    public init(metaJSON: String, session: any InferenceSession) {
+        self.metaJSON = metaJSON
+        self.session = session
+    }
+
+    /// Build from a resolved model directory: read the sidecar and let the core
+    /// pick this platform's session for the artifact.
+    static func shapes(files: StoredModel) async throws -> ModelAssets {
+        ModelAssets(
+            metaJSON: try files.readString(ShapesModel.meta),
+            session: try await files.inferenceSession(
+                model: ShapesModel.artifact, sdk: ShapesModel.sdkInfo))
+    }
+}
+
+public extension Shapes {
+    /// The published model repository.
+    static var modelRepo: String { ShapesModel.repo }
+    /// The model revision this SDK is built against (pinned; not configurable).
+    static var modelRevision: String { ShapesModel.revision }
+}
+
+// MARK: shipping the model with your app
+
+// This package bundles no model artifact and has no resource bundle to load one
+// from. The model is downloaded on demand: to a managed cache location by
+// default, or to the `directory` you pass. Shipping the model with your app is
+// therefore just pointing `directory` at a folder that already holds this
+// platform's artifact plus the sidecar - it is then used offline, with no
+// download. (Android's equivalent is classpath resources, and wasm always
+// downloads.)

--- a/Sources/Shapes/Native.swift
+++ b/Sources/Shapes/Native.swift
@@ -1,0 +1,60 @@
+// Shapes' exported entry points. Everything behind them is model-agnostic and
+// lives in NativeBindings; this file only names the symbols, because symbol
+// names are the one thing that cannot be shared: `@_cdecl` takes a string
+// literal and JNI derives its name from the Kotlin class.
+//
+// The names are model-scoped (`shapes_create`, `Java_ai_desertant_shapes_...`)
+// rather than generic, so two models can be linked into one binary - which is
+// what lets a model be a single target instead of a separate native one.
+
+#if !os(WASI)
+import DesertAnt
+import NativeBindings
+#if os(Android)
+import Android
+#endif
+
+#if !os(Android)
+@_cdecl("shapes_create")
+public func shapes_create(_ modelId: UnsafePointer<CChar>?, _ cacheRoot: UnsafePointer<CChar>?,
+                          _ directory: UnsafePointer<CChar>?) -> UnsafeMutableRawPointer? {
+    nativeCreate(binding: ShapesBinding.self, modelId: modelId,
+                 cacheRoot: cacheRoot, directory: directory)
+}
+#endif
+
+#if os(Android)
+@_cdecl("Java_ai_desertant_shapes_ShapesNative_create")
+public func androidCreateShapes(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                                _ modelId: jbyteArray?, _ cacheRoot: jbyteArray?,
+                                _ directory: jbyteArray?) -> jlong {
+    androidCreate(ShapesBinding.self, env: env, cls: cls, modelId: modelId,
+                  cacheRoot: cacheRoot, directory: directory)
+}
+
+@_cdecl("Java_ai_desertant_shapes_ShapesNative_destroy")
+public func androidDestroyShapes(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                                 _ handle: jlong) {
+    nativeDestroy(androidPointer(handle))
+}
+
+@_cdecl("Java_ai_desertant_shapes_ShapesNative_isDownloaded")
+public func androidIsDownloadedShapes(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                                      _ handle: jlong) -> jint {
+    androidIsDownloaded(env, cls, handle)
+}
+
+@_cdecl("Java_ai_desertant_shapes_ShapesNative_download")
+public func androidDownloadShapes(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                                  _ handle: jlong) -> jint {
+    androidDownload(env, cls, handle)
+}
+
+@_cdecl("Java_ai_desertant_shapes_ShapesNative_run")
+public func androidRunShapes(_ env: UnsafeMutablePointer<JNIEnv?>, _ cls: jclass?,
+                             _ handle: jlong, _ input: jbyteArray?,
+                             _ options: jbyteArray?) -> jbyteArray? {
+    androidRun(env, cls, handle, input, options)
+}
+#endif
+#endif

--- a/Sources/Shapes/PencilKitInterop.swift
+++ b/Sources/Shapes/PencilKitInterop.swift
@@ -1,0 +1,14 @@
+#if canImport(PencilKit)
+import PencilKit
+
+public extension Shapes {
+    /// Recognize a PencilKit stroke. The stroke's control points are mapped
+    /// through its transform into canvas coordinates, then recognized. Returns
+    /// the snapped ``Shape``, or `nil` when rejected or degenerate.
+    func recognize(_ stroke: PKStroke, options: Options = .init()) async throws -> Shape? {
+        let transform = stroke.transform
+        let points = stroke.path.map { $0.location.applying(transform) }
+        return try await recognize(points: points, options: options)
+    }
+}
+#endif

--- a/Sources/Shapes/Point.swift
+++ b/Sources/Shapes/Point.swift
@@ -1,0 +1,14 @@
+/// A 2D point in the same coordinate space as the input stroke.
+///
+/// The cross-platform value type used throughout the public API. On Apple
+/// platforms `CoreGraphics` conveniences convert to and from `CGPoint` (see the
+/// `CGPoint` interop), so existing call sites keep working.
+public struct Point: Sendable, Equatable {
+    public var x: Double
+    public var y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}

--- a/Sources/Shapes/PreprocessConfig.swift
+++ b/Sources/Shapes/PreprocessConfig.swift
@@ -1,0 +1,49 @@
+/// Tunables + frozen constants for the stroke preprocessor.
+///
+/// The defaults match the trained model's `config.json` exactly. The SAME values
+/// must be used at training-data generation, training, and inference on every
+/// platform — any divergence silently destroys accuracy.
+struct PreprocessConfig: Sendable {
+    /// Arc-length spacing in normalized units (~0.02 -> ~50 points per stroke).
+    var spacing: Double
+    /// Frozen z-score mean for the distance channel.
+    var distMean: Double
+    /// Frozen z-score std for the distance channel.
+    var distStd: Double
+    /// Append the optional 4th turning-angle (curvature) channel.
+    var addCurvature: Bool
+    /// Reject strokes with fewer than this many unique points.
+    var minPoints: Int
+    /// Reject strokes whose total length is below this.
+    var minTotalLength: Double
+    /// Consecutive raw points closer than this are treated as duplicates.
+    var dedupeEpsilon: Double
+
+    init(
+        spacing: Double = 0.02,
+        distMean: Double = 0.01927179223622642,
+        distStd: Double = 0.0020772687597318262,
+        addCurvature: Bool = false,
+        minPoints: Int = 2,
+        minTotalLength: Double = 1e-6,
+        dedupeEpsilon: Double = 1e-9
+    ) {
+        self.spacing = spacing
+        self.distMean = distMean
+        self.distStd = distStd
+        self.addCurvature = addCurvature
+        self.minPoints = minPoints
+        self.minTotalLength = minTotalLength
+        self.dedupeEpsilon = dedupeEpsilon
+    }
+
+    /// Number of feature channels per point (3, or 4 with curvature).
+    var channelCount: Int { addCurvature ? 4 : 3 }
+}
+
+/// Raised when a stroke is too short / too small to be meaningful.
+struct DegenerateStrokeError: Error, CustomStringConvertible {
+    let message: String
+    init(_ message: String) { self.message = message }
+    var description: String { "DegenerateStrokeError: \(message)" }
+}

--- a/Sources/Shapes/Shape.swift
+++ b/Sources/Shapes/Shape.swift
@@ -1,0 +1,59 @@
+import RealModule
+
+/// A recognized, fitted shape in the same coordinate space as the input stroke.
+///
+/// Point coordinates are ``Point`` values. On Apple platforms `CoreGraphics`
+/// conveniences (`CGPoint`/`CGPath`) are provided for rendering.
+public enum Shape: Sendable, Equatable {
+    /// A straight line segment from `from` to `to`.
+    case line(from: Point, to: Point)
+    /// A rectangle given by its four corners, in order around the perimeter.
+    case rectangle(corners: [Point])
+    /// A triangle given by its three vertices.
+    case triangle(vertices: [Point])
+    /// An ellipse with the given center, semi-axes, and `rotation` (radians).
+    case ellipse(center: Point, semiMajor: Double, semiMinor: Double, rotation: Double)
+    /// A star alternating between `outerRadius` and `innerRadius` across
+    /// `pointCount` points, with `rotation` in radians.
+    case star(center: Point, outerRadius: Double, innerRadius: Double,
+              rotation: Double, pointCount: Int)
+
+    /// A closed (or, for a line, open) polyline outline suitable for rendering.
+    public func outline(samples: Int = 96) -> [Point] {
+        switch self {
+        case let .line(a, b):
+            return [a, b]
+        case let .rectangle(corners):
+            return corners
+        case let .triangle(verts):
+            return verts
+        case let .ellipse(center, major, minor, rotation):
+            let c = Double.cos(rotation), s = Double.sin(rotation)
+            return (0..<samples).map { i in
+                let t = 2 * Double.pi * Double(i) / Double(samples)
+                let x = major * Double.cos(t), y = minor * Double.sin(t)
+                return Point(x: center.x + x * c - y * s,
+                             y: center.y + x * s + y * c)
+            }
+        case let .star(center, outer, inner, rotation, pointCount):
+            var pts: [Point] = []
+            let steps = pointCount * 2
+            for i in 0..<steps {
+                let a = rotation - .pi / 2 + Double(i) * .pi / Double(pointCount)
+                let r = (i % 2 == 0) ? outer : inner
+                pts.append(Point(x: center.x + r * Double.cos(a),
+                                 y: center.y + r * Double.sin(a)))
+            }
+            return pts
+        }
+    }
+}
+
+/// Internal classifier label / gate key. Unlike public `Shape`, this has no fitted geometry.
+enum ShapeKind: String, CaseIterable, Sendable {
+    case line
+    case rectangle
+    case triangle
+    case ellipse
+    case star
+}

--- a/Sources/Shapes/ShapeMeta.swift
+++ b/Sources/Shapes/ShapeMeta.swift
@@ -1,0 +1,63 @@
+import JSON
+
+/// The model sidecar (`shapes_meta.json`): the class order the classifier emits,
+/// the calibrated per-class confidence/residual gates, and the frozen
+/// preprocessing constants. Shipped next to every artifact so the runtime uses
+/// exactly the values the model was trained and exported with, on every platform.
+struct ShapeMeta: Sendable {
+    /// One entry per classifier output index. `nil` marks a reject class (e.g.
+    /// "none") that is never accepted as a shape.
+    let classOrder: [ShapeKind?]
+    /// Per-class acceptance gate.
+    let gates: [ShapeKind: Gate]
+    /// The preprocessing configuration the model expects.
+    let config: PreprocessConfig
+
+    struct Gate: Sendable {
+        let conf: Float
+        let resid: Float
+    }
+
+    /// Parse the JSON sidecar with the platform's native decoder (Codable).
+    init(json: String) throws {
+        let raw = try JSONDecoder().decode(Raw.self, from: json)
+        classOrder = raw.classes.map { ShapeKind(rawValue: $0) }
+        var gates: [ShapeKind: Gate] = [:]
+        for (name, value) in raw.gates {
+            if let kind = ShapeKind(rawValue: name) {
+                gates[kind] = Gate(conf: Float(value.conf), resid: Float(value.resid))
+            }
+        }
+        self.gates = gates
+        config = PreprocessConfig(
+            spacing: raw.preprocess.spacing,
+            distMean: raw.preprocess.distMean,
+            distStd: raw.preprocess.distStd,
+            addCurvature: raw.preprocess.addCurvature)
+    }
+
+    private struct Raw: Decodable {
+        let classes: [String]
+        let gates: [String: RawGate]
+        let preprocess: RawPreprocess
+    }
+
+    private struct RawGate: Decodable {
+        let conf: Double
+        let resid: Double
+    }
+
+    private struct RawPreprocess: Decodable {
+        let spacing: Double
+        let distMean: Double
+        let distStd: Double
+        let addCurvature: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case spacing
+            case distMean = "dist_mean"
+            case distStd = "dist_std"
+            case addCurvature = "add_curvature"
+        }
+    }
+}

--- a/Sources/Shapes/ShapeSnapping.swift
+++ b/Sources/Shapes/ShapeSnapping.swift
@@ -1,0 +1,492 @@
+#if os(iOS) || os(visionOS)
+import PencilKit
+import UIKit
+
+/// Tunables for live shape snapping on a `PKCanvasView`.
+public struct ShapeSnappingConfiguration: Sendable {
+    /// How long the pen must pause (no significant movement) before a preview
+    /// appears, in seconds.
+    public var pauseDelay: TimeInterval = 0.3
+    /// Opacity of the faded preview shown while the pen is still down.
+    public var previewOpacity: Float = 0.5
+
+    /// Creates a configuration with default values.
+    public init() {}
+}
+
+public extension PKCanvasView {
+    /// Recognize and snap hand-drawn strokes to clean shapes, in one line.
+    ///
+    /// While drawing, pausing briefly shows a faded preview of the recognized
+    /// shape; lifting the pen replaces the raw stroke with the clean one. The
+    /// swap is registered with the canvas's undo manager, so undo/redo work.
+    /// Call again to update the recognizer or configuration;
+    /// ``disableShapeSnapping()`` to stop.
+    ///
+    /// - Parameter shapes: the recognizer to use. The default downloads the
+    ///   model on demand and caches it. For instant, offline snapping pass a
+    ///   recognizer over a directory you already populated,
+    ///   `Shapes(directory: myModelDir)`.
+    func enableShapeSnapping(using shapes: Shapes = Shapes(),
+                             configuration: ShapeSnappingConfiguration = .init()) {
+        disableShapeSnapping()
+        let snapper = ShapeSnapper(canvasView: self, shapes: shapes, configuration: configuration)
+        objc_setAssociatedObject(self, &shapeSnapperKey, snapper, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    /// Stop shape snapping and remove its observers and preview overlay.
+    func disableShapeSnapping() {
+        shapeSnapper?.detach()
+        objc_setAssociatedObject(self, &shapeSnapperKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    /// Whether shape snapping is currently enabled on this canvas.
+    var isShapeSnappingEnabled: Bool {
+        get { shapeSnapper != nil }
+        set { newValue ? enableShapeSnapping() : disableShapeSnapping() }
+    }
+
+    private var shapeSnapper: ShapeSnapper? {
+        objc_getAssociatedObject(self, &shapeSnapperKey) as? ShapeSnapper
+    }
+}
+
+// Only this variable's *address* is used, as the unique key an associated object
+// is filed under; its value is never read or written. There is therefore no
+// shared mutable state to protect, which `nonisolated(unsafe)` states - a `let`
+// would be the honest spelling but cannot be passed as the `inout` the ObjC
+// runtime's key parameter expects.
+private nonisolated(unsafe) var shapeSnapperKey: UInt8 = 0
+
+// MARK: - ShapeSnapper
+
+/// Watches a canvas for a draw → pause → lift gesture and snaps the stroke.
+///
+/// Recognition runs through the shared ``Shapes`` recognizer (the Core ML
+/// model). It is `async`, so results are delivered back on the main actor and
+/// guarded by a generation counter, and stale results from an earlier pen state
+/// are discarded.
+///
+/// Main-actor isolated: every member touches the canvas, the overlay, or UIKit
+/// touch state, and every entry point is already a main-thread callback (a
+/// gesture recognizer, a `PKCanvasViewDelegate` message, or a main-queue timer).
+@MainActor
+final class ShapeSnapper: NSObject {
+    private weak var canvas: PKCanvasView?
+    private let shapes: Shapes
+    private let configuration: ShapeSnappingConfiguration
+    // Read from `responds(to:)` and `forwardingTarget(for:)`, which NSObject
+    // declares `nonisolated` so an override cannot be isolated either. It is
+    // written only from attach/detach on the main thread, and read only while
+    // UIKit is delivering a delegate message, so the ObjC runtime's own
+    // messaging is the synchronization here.
+    private nonisolated(unsafe) weak var previousDelegate: PKCanvasViewDelegate?
+    private let overlay = PreviewOverlay()
+    private var observer: TouchObserver?
+
+    private var lastSignificant: CGPoint = .zero
+    private var strokeCountAtStart = 0
+    private var penDown = false
+    private var previewing = false
+    private var currentShape: Shape?
+    private var pendingSnap = false
+    private var isProgrammatic = false
+    private var pauseWork: DispatchWorkItem?
+    /// Bumped on every pen-down / significant move so stale async recognition
+    /// results are ignored.
+    private var generation = 0
+
+    /// Movement under this distance (points) doesn't reset the pause timer.
+    private static let movementTolerance: CGFloat = 6
+    /// Strokes whose bounding-box diagonal is smaller than this are ignored.
+    private static let minimumExtent: CGFloat = 24
+
+    init(canvasView: PKCanvasView, shapes: Shapes, configuration: ShapeSnappingConfiguration) {
+        self.shapes = shapes
+        self.configuration = configuration
+        canvas = canvasView
+        super.init()
+        // Warm the model so the first pause preview is instant.
+        Task { try? await shapes.download() }
+        attach()
+    }
+
+    func detach() {
+        cancelPause()
+        hidePreview()
+        overlay.removeFromSuperview()
+        if let canvas {
+            if let observer { canvas.removeGestureRecognizer(observer) }
+            if canvas.delegate === self { canvas.delegate = previousDelegate }
+        }
+        observer = nil
+    }
+
+    // MARK: Setup
+
+    private func attach() {
+        guard let canvas else { return }
+        previousDelegate = canvas.delegate
+        canvas.delegate = self
+
+        overlay.isUserInteractionEnabled = false
+        canvas.addSubview(overlay)
+
+        let obs = TouchObserver()
+        obs.delegate = self
+        obs.cancelsTouchesInView = false
+        obs.delaysTouchesBegan = false
+        obs.delaysTouchesEnded = false
+        obs.began = { [weak self] t in self?.began(t) }
+        obs.moved = { [weak self] t, e in self?.moved(t, e) }
+        obs.ended = { [weak self] in self?.ended() }
+        canvas.addGestureRecognizer(obs)
+        observer = obs
+    }
+
+    // MARK: Touch tracking
+
+    private func began(_ touch: UITouch) {
+        guard let canvas else { return }
+        penDown = true
+        previewing = false
+        pendingSnap = false
+        currentShape = nil
+        generation += 1
+        cancelPause()
+        hidePreview()
+        strokeCountAtStart = canvas.drawing.strokes.count
+        lastSignificant = touch.location(in: canvas)
+    }
+
+    private func moved(_ touch: UITouch, _ event: UIEvent) {
+        guard penDown, let canvas else { return }
+        let last = (event.coalescedTouches(for: touch)?.last ?? touch).location(in: canvas)
+        if hypot(last.x - lastSignificant.x, last.y - lastSignificant.y) > Self.movementTolerance {
+            lastSignificant = last
+            if previewing {
+                previewing = false
+                currentShape = nil
+                hidePreview()
+            }
+            generation += 1
+            schedulePause()
+        }
+    }
+
+    private func ended() {
+        penDown = false
+        cancelPause()
+        guard previewing, currentShape != nil else { return }
+        pendingSnap = true
+        Task { @MainActor [weak self] in self?.snapIfPending() }
+    }
+
+    private func schedulePause() {
+        cancelPause()
+        let work = DispatchWorkItem { [weak self] in
+            // The work item is only ever scheduled on the main queue below, so it
+            // runs where this class is isolated; `assumeIsolated` states that
+            // rather than hopping and letting the pause fire a turn late.
+            MainActor.assumeIsolated { self?.detectAndPreview() }
+        }
+        pauseWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + configuration.pauseDelay, execute: work)
+    }
+
+    private func cancelPause() {
+        pauseWork?.cancel()
+        pauseWork = nil
+    }
+
+    // MARK: Recognition + preview
+
+    private func detectAndPreview() {
+        guard penDown, canvas?.tool is PKInkingTool,
+              let stroke = inProgressStroke() else { return }
+        // Recognize from the live PencilKit stroke itself — same coordinate space
+        // as the ink, no separately accumulated points.
+        let pts = strokePoints(stroke)
+        guard pts.count >= 8 else { return }
+        let xs = pts.map(\.x), ys = pts.map(\.y)
+        let extent = hypot(xs.max()! - xs.min()!, ys.max()! - ys.min()!)
+        guard extent >= Self.minimumExtent else { return }
+
+        let token = generation
+        Task { [weak self, shapes] in
+            let shape = try? await shapes.recognize(points: pts)
+            await MainActor.run { self?.applyPreview(shape, token: token) }
+        }
+    }
+
+    private func applyPreview(_ shape: Shape?, token: Int) {
+        guard penDown, token == generation else { return }
+        guard let shape else {
+            previewing = false
+            currentShape = nil
+            hidePreview()
+            return
+        }
+        currentShape = shape
+        previewing = true
+        showPreview(shape)
+    }
+
+    private func showPreview(_ shape: Shape) {
+        guard let canvas else { return }
+        overlay.frame = canvas.bounds
+        canvas.bringSubviewToFront(overlay)
+
+        let stroke = makeStroke(shape, ink: currentInk(in: canvas), width: currentPreviewWidth())
+        let drawing = PKDrawing(strokes: [stroke])
+        let rect = CGRect(origin: canvas.contentOffset, size: canvas.bounds.size)
+        let traits = canvas.window?.traitCollection ?? canvas.traitCollection
+        let scale = traits.displayScale > 0 ? traits.displayScale : 2
+        var image: UIImage?
+        traits.performAsCurrent { image = drawing.image(from: rect, scale: scale) }
+        overlay.imageView.image = image
+
+        overlay.imageView.layer.removeAllAnimations()
+        let fade = CABasicAnimation(keyPath: "opacity")
+        fade.fromValue = 0
+        fade.toValue = configuration.previewOpacity
+        fade.duration = 0.12
+        overlay.imageView.layer.opacity = configuration.previewOpacity
+        overlay.imageView.layer.add(fade, forKey: "in")
+    }
+
+    private func hidePreview() {
+        overlay.imageView.layer.removeAllAnimations()
+        overlay.imageView.layer.opacity = 0
+        overlay.imageView.image = nil
+    }
+
+    // MARK: Snap (undo-preserving)
+
+    private func snapIfPending() {
+        guard pendingSnap, currentShape != nil, let canvas else { return }
+        guard canvas.drawing.strokes.count > strokeCountAtStart,
+              let last = canvas.drawing.strokes.last else { return }
+        pendingSnap = false
+
+        // Re-recognize from the committed stroke so the clean shape lands in the
+        // exact coordinate space of the ink it replaces.
+        let pts = strokePoints(last)
+        let token = generation
+        Task { [weak self, shapes] in
+            let shape = try? await shapes.recognize(points: pts)
+            await MainActor.run { self?.applySnap(shape, to: last, token: token) }
+        }
+    }
+
+    private func applySnap(_ shape: Shape?, to last: PKStroke, token: Int) {
+        guard token == generation, let canvas else { return }
+        guard let shape else {
+            previewing = false
+            currentShape = nil
+            hidePreview()
+            return
+        }
+        let perfect = makeStroke(shape, ink: last.ink, width: drawnWidth(of: last))
+
+        // Drop the raw stroke (coalesces with the user's draw in the undo stack),
+        // then replace it with the clean one as a single undoable change.
+        isProgrammatic = true
+        canvas.undoManager?.undo()
+        isProgrammatic = false
+        setDrawing(PKDrawing(strokes: canvas.drawing.strokes + [perfect]), on: canvas)
+
+        previewing = false
+        currentShape = nil
+        hidePreview()
+    }
+
+    private func setDrawing(_ drawing: PKDrawing, on canvas: PKCanvasView) {
+        let previous = canvas.drawing
+        canvas.undoManager?.registerUndo(withTarget: canvas) { [weak self] target in
+            self?.setDrawing(previous, on: target)
+        }
+        isProgrammatic = true
+        canvas.drawing = drawing
+        isProgrammatic = false
+    }
+
+    // MARK: Shape → PKStroke
+
+    private func makeStroke(_ shape: Shape, ink: PKInk, width: CGFloat) -> PKStroke {
+        let outline = shape.cgOutline(samples: 96)
+        // For closed shapes, start (and end) the loop at the midpoint of the first
+        // edge so the path seam lands on a straight section rather than a corner
+        // — otherwise that corner renders sharp while the spline rounds the others.
+        let isLine: Bool
+        if case .line = shape { isLine = true } else { isLine = false }
+        let loop = isLine ? outline : Self.closedLoopFromMidEdge(outline)
+        let pts = Self.densify(loop, maxSpacing: 6)
+        let n = pts.count
+        let sp = pts.enumerated().map { i, pt in
+            PKStrokePoint(location: pt,
+                          timeOffset: TimeInterval(i) / TimeInterval(max(n - 1, 1)),
+                          size: CGSize(width: width, height: width),
+                          opacity: 1, force: 1, azimuth: 0, altitude: .pi / 2)
+        }
+        let path = PKStrokePath(controlPoints: sp, creationDate: Date())
+        // The standalone SDK also carried over the source stroke's render state
+        // (grain-texture anchoring for pencil/crayon/marker) and its wet-ink
+        // group, through `PKStroke(ink:path:transform:renderGroupID:renderState:)`.
+        // That initializer is iOS 27 / visionOS 27, which this repo's pinned
+        // Xcode has no SDK for, so it cannot even be compiled behind an
+        // `#available` check here. Restore it when the toolchain moves.
+        return PKStroke(ink: ink, path: path, transform: .identity)
+    }
+
+    /// Reorders a closed polygon's vertices so the loop begins and ends at the
+    /// midpoint of the first edge: [mid(v0,v1), v1, v2, …, v0, mid(v0,v1)].
+    private static func closedLoopFromMidEdge(_ v: [CGPoint]) -> [CGPoint] {
+        guard v.count >= 2 else { return v }
+        let mid = CGPoint(x: (v[0].x + v[1].x) / 2, y: (v[0].y + v[1].y) / 2)
+        return [mid] + v.dropFirst() + [v[0], mid]
+    }
+
+    private static func densify(_ poly: [CGPoint], maxSpacing: CGFloat) -> [CGPoint] {
+        guard poly.count >= 2 else { return poly }
+        var out: [CGPoint] = []
+        for i in 0..<(poly.count - 1) {
+            let a = poly[i], b = poly[i + 1]
+            let steps = max(1, Int((hypot(b.x - a.x, b.y - a.y) / maxSpacing).rounded(.up)))
+            for j in 0..<steps {
+                let f = CGFloat(j) / CGFloat(steps)
+                out.append(CGPoint(x: a.x + (b.x - a.x) * f, y: a.y + (b.y - a.y) * f))
+            }
+        }
+        out.append(poly[poly.count - 1])
+        return out
+    }
+
+    private var currentToolWidth: CGFloat {
+        (canvas?.tool as? PKInkingTool)?.width ?? 7
+    }
+
+    /// Width for the live preview: the actual in-progress stroke's drawn width
+    /// (pressure-aware) when available, else the tool's nominal width.
+    private func currentPreviewWidth() -> CGFloat {
+        inProgressStrokeWidth() ?? currentToolWidth
+    }
+
+    private func inProgressStrokeWidth() -> CGFloat? {
+        guard let stroke = inProgressStroke() else { return nil }
+        let w = drawnWidth(of: stroke)
+        return (w.isFinite && w > 0.1 && w < 1000) ? w : nil
+    }
+
+    /// Path locations of a stroke in canvas coordinates.
+    private func strokePoints(_ stroke: PKStroke) -> [CGPoint] {
+        let t = stroke.transform
+        return stroke.path.map { $0.location.applying(t) }
+    }
+
+    /// The stroke PencilKit is currently capturing (private API), if any.
+    private func inProgressStroke() -> PKStroke? {
+        guard penDown, let canvas else { return nil }
+        let sel = NSSelectorFromString(["_", "current", "Stroke"].joined())
+        guard canvas.responds(to: sel),
+              let obj = canvas.perform(sel)?.takeUnretainedValue(),
+              let stroke = obj as? PKStroke else { return nil }
+        return stroke
+    }
+
+    private func currentInk(in canvas: PKCanvasView) -> PKInk {
+        (canvas.tool as? PKInkingTool)?.ink ?? PKInk(.pen, color: .label)
+    }
+
+    private func drawnWidth(of stroke: PKStroke) -> CGFloat {
+        let n = stroke.path.count
+        guard n > 0 else { return currentToolWidth }
+        var sizes = (0..<n).map { stroke.path[$0].size.width }
+        sizes.sort()
+        return sizes[n / 2]
+    }
+}
+
+// MARK: PKCanvasViewDelegate (transparent passthrough)
+
+extension ShapeSnapper: PKCanvasViewDelegate {
+    func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
+        if !isProgrammatic, pendingSnap {
+            Task { @MainActor [weak self] in self?.snapIfPending() }
+        }
+        previousDelegate?.canvasViewDrawingDidChange?(canvasView)
+    }
+
+    // The ObjC runtime asking which delegate messages this object handles, so
+    // the ones it does not handle can be forwarded to the delegate it replaced.
+    // NSObject declares both `nonisolated`; see `previousDelegate`.
+    override nonisolated func responds(to aSelector: Selector!) -> Bool {
+        super.responds(to: aSelector) || (previousDelegate?.responds(to: aSelector) ?? false)
+    }
+
+    override nonisolated func forwardingTarget(for aSelector: Selector!) -> Any? {
+        if let d = previousDelegate, d.responds(to: aSelector) { return d }
+        return super.forwardingTarget(for: aSelector)
+    }
+}
+
+// MARK: UIGestureRecognizerDelegate
+
+extension ShapeSnapper: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_: UIGestureRecognizer,
+                           shouldRecognizeSimultaneouslyWith _: UIGestureRecognizer) -> Bool { true }
+    func gestureRecognizer(_: UIGestureRecognizer, shouldReceive _: UITouch) -> Bool { true }
+}
+
+// MARK: - TouchObserver
+
+/// A non-interfering gesture recognizer that just reports the touch stream.
+private final class TouchObserver: UIGestureRecognizer {
+    var began: ((UITouch) -> Void)?
+    var moved: ((UITouch, UIEvent) -> Void)?
+    var ended: (() -> Void)?
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesBegan(touches, with: event)
+        if let t = touches.first { began?(t) }
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesMoved(touches, with: event)
+        if let t = touches.first { moved?(t, event) }
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesEnded(touches, with: event)
+        ended?()
+        state = .failed
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesCancelled(touches, with: event)
+        ended?()
+        state = .failed
+    }
+}
+
+// MARK: - PreviewOverlay
+
+private final class PreviewOverlay: UIView {
+    let imageView = UIImageView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        imageView.contentMode = .topLeft
+        imageView.layer.opacity = 0
+        addSubview(imageView)
+    }
+
+    @available(*, unavailable) required init?(coder _: NSCoder) { fatalError() }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        imageView.frame = bounds
+    }
+}
+#endif

--- a/Sources/Shapes/Shapes.swift
+++ b/Sources/Shapes/Shapes.swift
@@ -1,0 +1,118 @@
+import DesertAnt
+
+/// Options controlling recognition.
+public struct Options: Sendable {
+    /// Minimum classifier confidence, on top of each class's calibrated gate.
+    /// `0` (the default) applies only the model's own gates.
+    public var minimumConfidence: Double
+    /// Geometry regularization ("smart shape" snapping) applied to the fitted
+    /// output. Defaults to the standard snaps (axis-aligned lines, circles,
+    /// squares, equilateral/isosceles triangles).
+    var snap: SnapConfig
+
+    public init(minimumConfidence: Double = 0) {
+        self.minimumConfidence = minimumConfidence.isFinite
+            ? min(1, max(0, minimumConfidence))
+            : 0
+        self.snap = .standard
+    }
+}
+
+/// Errors thrown while loading or running the model. (`MessageError` is
+/// `LocalizedError` wherever Foundation exists, so `localizedDescription`
+/// shows `message`.)
+public enum ShapesError: MessageError, Sendable {
+    /// A model resource (model or metadata) could not be found.
+    case resourceMissing
+    /// On-device prediction failed or returned an unexpected output.
+    case predictionFailed
+
+    public var message: String {
+        switch self {
+        case .resourceMissing: "A Shapes model resource was not found."
+        case .predictionFailed: "On-device shape recognition failed."
+        }
+    }
+}
+
+/// On-device single-stroke shape recognition.
+///
+/// `Shapes` turns one hand-drawn stroke into a clean vector ``Shape`` (line,
+/// rectangle, triangle, ellipse, or star), fully on device. A small classifier
+/// proposes a shape through the shared inference session (Core ML on Apple,
+/// LiteRT elsewhere); a geometric fitter produces the clean parameters and a fit
+/// residual; the stroke is accepted only if it clears that class's calibrated
+/// confidence and residual gates. Create one once and reuse it.
+///
+/// ```swift
+/// let shapes = Shapes()
+/// if let shape = try await shapes.recognize(points: strokePoints) {
+///     // shape == .rectangle(corners: [...]) etc.
+/// }
+/// ```
+public final class Shapes: @unchecked Sendable {
+    // Resolving the files, loading once, sharing that load, and reporting
+    // availability are the same for every model, so they live in the core's
+    // `LoadedModel`; Shapes adds only how a resolved directory becomes its model.
+    private let model: LoadedModel<Model>
+
+    /// Creates a recognizer. Construction does no work and starts no download;
+    /// the model loads on the first ``recognize(points:options:)`` or
+    /// ``download(progress:)``, off your calling thread.
+    ///
+    /// `directory` is where the model lives. If it already contains the model
+    /// (you pre-downloaded or shipped it there) it is used offline; otherwise
+    /// the model is downloaded into it and reused offline afterward. With no
+    /// `directory` (the default), a managed cache location is used.
+    ///
+    /// Nothing is bundled with this package. To ship the model with your app,
+    /// point `directory` at a folder you populated with the model files: it is
+    /// used as-is, offline, and nothing is downloaded.
+    public convenience init(directory: String? = nil) {
+        self.init(directory: directory, cacheRoot: nil)
+    }
+
+    /// Binding entry point that also supplies the platform base cache root under
+    /// which the managed layout lives (the app cache dir on Android, node
+    /// `~/.cache` on the web). On Apple/Linux FileManager provides it, so the
+    /// public `init(directory:)` passes `nil`.
+    @_spi(ShapesBindings)
+    public init(directory: String?, cacheRoot: String?) {
+        model = LoadedModel(ShapesModel.self, directory: directory, cacheRoot: cacheRoot) { files in
+            try Model(assets: await .shapes(files: files))
+        }
+    }
+
+    /// Creates a recognizer from explicitly provided assets (used by the
+    /// wasm self-hosted and custom-deployment paths).
+    @_spi(ShapesBindings)
+    public init(assets: ModelAssets) {
+        model = LoadedModel { try Model(assets: assets) }
+    }
+
+    /// Whether the model is available for this recognizer with no network:
+    /// cached (for the managed location) or already present in `directory`.
+    public func isDownloaded() -> Bool { model.isDownloaded() }
+
+    /// Download and load the model ahead of time, so the first
+    /// ``recognize(points:options:)`` is instant. Reports download progress
+    /// `0...1`. Concurrent calls, and an implicit load from a recognition, share
+    /// one download. A no-op once loaded (see ``isDownloaded()``).
+    public func download(progress: @Sendable @escaping (Double) -> Void = { _ in }) async throws {
+        try await model.download(progress: progress)
+    }
+
+    /// Await model readiness. The bindings use this to surface load errors
+    /// eagerly; apps can just call ``recognize(points:options:)``.
+    @_spi(ShapesBindings)
+    public func waitUntilLoaded() async throws {
+        _ = try await model.value()
+    }
+
+    /// Recognize a stroke given as ordered ``Point`` values (canvas
+    /// coordinates). Returns the snapped ``Shape``, or `nil` when the stroke is
+    /// rejected or degenerate.
+    public func recognize(points: [Point], options: Options = .init()) async throws -> Shape? {
+        try await model.value().recognize(points: points, options: options)
+    }
+}

--- a/Sources/Shapes/Snapping.swift
+++ b/Sources/Shapes/Snapping.swift
@@ -1,0 +1,208 @@
+import RealModule
+
+/// Geometry regularization ("smart shape" snapping). After the fitter produces
+/// an accurate fit, these cheap snaps clean the output to nice axes, angles,
+/// circles, and squares.
+struct SnapConfig: Sendable {
+    /// Snap a line to the horizontal/vertical axis within this angle (degrees).
+    var lineAxisThresholdDeg: Double = 5
+    /// Snap an ellipse to a circle when `minAxis / maxAxis >= 1 - ratio`.
+    var ellipseCircleRatio: Double = 0.25
+    /// Snap ellipse rotation to multiples of this (degrees).
+    var ellipseRotationIncrementDeg: Double = 15
+    /// Snap a rectangle to a square when `minSide / maxSide >= 1 - ratio`.
+    var rectangleSquareRatio: Double = 0.25
+    /// Snap rectangle rotation to multiples of this (degrees).
+    var rectangleRotationIncrementDeg: Double = 15
+    /// Snap a triangle's base edge to the horizontal/vertical axis within this
+    /// angle (degrees).
+    var triangleAxisThresholdDeg: Double = 5
+    /// Snap a triangle to equilateral when `(maxSide - minSide) / maxSide <= ratio`.
+    var triangleEquilateralRatio: Double = 0.25
+    /// Snap a triangle to isosceles when its two most-equal legs are within this
+    /// ratio.
+    var triangleIsoscelesRatio: Double = 0.25
+
+    /// Standard defaults.
+    static let standard = SnapConfig()
+
+    /// No regularization (thresholds and increments disabled).
+    static let disabled = SnapConfig(
+        lineAxisThresholdDeg: 0, ellipseCircleRatio: 0, ellipseRotationIncrementDeg: 0,
+        rectangleSquareRatio: 0, rectangleRotationIncrementDeg: 0,
+        triangleAxisThresholdDeg: 0, triangleEquilateralRatio: 0, triangleIsoscelesRatio: 0
+    )
+}
+
+extension Fitter {
+    /// Apply regularization snapping to a fitted shape. Geometry-only cleanup;
+    /// the caller keeps the residual from the raw (pre-snap) fit for gating.
+    static func snap(_ shape: Shape, config c: SnapConfig) -> Shape {
+        switch shape {
+        case let .line(from, to):
+            return snapLine(from, to, c)
+        case let .rectangle(corners):
+            return snapRectangle(corners, c)
+        case let .triangle(verts):
+            return snapTriangle(verts, c)
+        case let .ellipse(center, major, minor, rotation):
+            return snapEllipse(center, major, minor, rotation, c)
+        case .star:
+            return shape  // template already regular
+        }
+    }
+
+    // MARK: Angle helpers
+
+    private static func snapToIncrement(_ angle: Double, incrementDeg: Double) -> Double {
+        guard incrementDeg > 0 else { return angle }
+        let inc = incrementDeg * .pi / 180
+        return (angle / inc).rounded() * inc
+    }
+
+    /// If `angle` is within `thresholdDeg` of the nearest multiple of 90°, return
+    /// that snapped angle; otherwise `nil`.
+    private static func snapToAxis(_ angle: Double, thresholdDeg: Double) -> Double? {
+        guard thresholdDeg > 0 else { return nil }
+        let quarter = Double.pi / 2
+        let nearest = (angle / quarter).rounded() * quarter
+        return abs(angle - nearest) <= thresholdDeg * .pi / 180 ? nearest : nil
+    }
+
+    private static func v2(_ p: Point) -> V2 { V2(p.x, p.y) }
+    private static func point(_ v: V2) -> Point { Point(x: v.x, y: v.y) }
+
+    // MARK: Line
+
+    private static func snapLine(_ from: Point, _ to: Point, _ c: SnapConfig) -> Shape {
+        let a = v2(from), b = v2(to)
+        let ang = Double.atan2(y: b.y - a.y, x: b.x - a.x)
+        guard let snapped = snapToAxis(ang, thresholdDeg: c.lineAxisThresholdDeg) else {
+            return .line(from: from, to: to)
+        }
+        let mid = (a + b) / 2
+        let half = (b - a).length / 2
+        let dir = V2(Double.cos(snapped), Double.sin(snapped))
+        return .line(from: point(mid - half * dir), to: point(mid + half * dir))
+    }
+
+    // MARK: Ellipse
+
+    private static func snapEllipse(
+        _ center: Point, _ major: Double, _ minor: Double, _ rotation: Double,
+        _ c: SnapConfig
+    ) -> Shape {
+        let maj = major, min_ = minor
+        let hi = Swift.max(maj, min_), lo = Swift.min(maj, min_)
+        if c.ellipseCircleRatio > 0, hi > 0, lo / hi >= 1 - c.ellipseCircleRatio {
+            let r = (maj + min_) / 2
+            return .ellipse(center: center, semiMajor: r, semiMinor: r, rotation: 0)
+        }
+        let rot = snapToIncrement(rotation, incrementDeg: c.ellipseRotationIncrementDeg)
+        return .ellipse(center: center, semiMajor: major, semiMinor: minor, rotation: rot)
+    }
+
+    // MARK: Rectangle
+
+    private static func snapRectangle(_ corners: [Point], _ c: SnapConfig) -> Shape {
+        guard corners.count == 4 else { return .rectangle(corners: corners) }
+        let p = corners.map(v2)
+        let center = (p[0] + p[1] + p[2] + p[3]) / 4
+        var w = (p[1] - p[0]).length
+        var h = (p[3] - p[0]).length
+        var ang = Double.atan2(y: (p[1] - p[0]).y, x: (p[1] - p[0]).x)
+
+        let hi = Swift.max(w, h), lo = Swift.min(w, h)
+        if c.rectangleSquareRatio > 0, hi > 0, lo / hi >= 1 - c.rectangleSquareRatio {
+            let s = (w + h) / 2
+            w = s; h = s
+        }
+        ang = snapToIncrement(ang, incrementDeg: c.rectangleRotationIncrementDeg)
+
+        let r = Mat2.rotation(ang)
+        let hw = w / 2, hh = h / 2
+        let local = [V2(-hw, -hh), V2(hw, -hh), V2(hw, hh), V2(-hw, hh)]
+        return .rectangle(corners: local.map { point(center + r * $0) })
+    }
+
+    // MARK: Triangle
+
+    private static func snapTriangle(_ verts: [Point], _ c: SnapConfig) -> Shape {
+        guard verts.count == 3 else { return .triangle(vertices: verts) }
+        var v = verts.map(v2)
+        let centroid = (v[0] + v[1] + v[2]) / 3
+
+        let lAB = (v[0] - v[1]).length
+        let lBC = (v[1] - v[2]).length
+        let lCA = (v[2] - v[0]).length
+        let sides = [lAB, lBC, lCA]
+        let mx = sides.max() ?? 0, mn = sides.min() ?? 0
+
+        if c.triangleEquilateralRatio > 0, mx > 0, (mx - mn) / mx <= c.triangleEquilateralRatio {
+            v = makeEquilateral(v, centroid: centroid)
+        } else if c.triangleIsoscelesRatio > 0 {
+            v = makeIsosceles(v, legs: [lAB, lBC, lCA], ratio: c.triangleIsoscelesRatio) ?? v
+        }
+
+        return alignTriangleToAxis(v, thresholdDeg: c.triangleAxisThresholdDeg)
+    }
+
+    private static func makeEquilateral(_ v: [V2], centroid c: V2) -> [V2] {
+        let r = ((v[0] - c).length + (v[1] - c).length + (v[2] - c).length) / 3
+        // Circular mean of (angle_i - i*120°) gives a stable base orientation.
+        var sx = 0.0, sy = 0.0
+        for i in 0..<3 {
+            let a = Double.atan2(y: v[i].y - c.y, x: v[i].x - c.x) - Double(i) * 2 * Double.pi / 3
+            sx += Double.cos(a); sy += Double.sin(a)
+        }
+        let base = Double.atan2(y: sy, x: sx)
+        return (0..<3).map { i in
+            let a = base + Double(i) * 2 * Double.pi / 3
+            return c + r * V2(Double.cos(a), Double.sin(a))
+        }
+    }
+
+    /// Equalize the two most-similar legs about their shared apex.
+    private static func makeIsosceles(_ v: [V2], legs: [Double], ratio: Double) -> [V2]? {
+        // Apex candidates: (apex, leg1, leg2) by vertex index.
+        let cand: [(apex: Int, b: Int, cc: Int, l1: Double, l2: Double)] = [
+            (0, 1, 2, legs[0], legs[2]),  // v0 between edges v0v1, v2v0
+            (1, 0, 2, legs[0], legs[1]),  // v1 between edges v0v1, v1v2
+            (2, 0, 1, legs[2], legs[1]),  // v2 between edges v2v0, v1v2
+        ]
+        let best = cand.min { rel($0.l1, $0.l2) < rel($1.l1, $1.l2) }!
+        guard rel(best.l1, best.l2) <= ratio else { return nil }
+        let apex = v[best.apex]
+        let avg = (best.l1 + best.l2) / 2
+        func leg(_ to: Int) -> V2 {
+            let d = v[to] - apex
+            let n = d.length
+            return apex + (n > 0 ? d / n : d) * avg
+        }
+        var out = v
+        out[best.b] = leg(best.b)
+        out[best.cc] = leg(best.cc)
+        return out
+    }
+
+    private static func rel(_ a: Double, _ b: Double) -> Double {
+        let m = Swift.max(a, b)
+        return m > 0 ? abs(a - b) / m : 0
+    }
+
+    /// Rotate the triangle about its centroid so its longest edge aligns to the
+    /// nearest axis, when within threshold.
+    private static func alignTriangleToAxis(_ v: [V2], thresholdDeg: Double) -> Shape {
+        let edges = [(v[0], v[1]), (v[1], v[2]), (v[2], v[0])]
+        let longest = edges.max { ($0.1 - $0.0).length < ($1.1 - $1.0).length }!
+        let dir = longest.1 - longest.0
+        let ang = Double.atan2(y: dir.y, x: dir.x)
+        guard let snapped = snapToAxis(ang, thresholdDeg: thresholdDeg) else {
+            return .triangle(vertices: v.map(point))
+        }
+        let centroid = (v[0] + v[1] + v[2]) / 3
+        let r = Mat2.rotation(snapped - ang)
+        let out = v.map { centroid + r * ($0 - centroid) }
+        return .triangle(vertices: out.map(point))
+    }
+}

--- a/Sources/Shapes/StrokePoint.swift
+++ b/Sources/Shapes/StrokePoint.swift
@@ -1,0 +1,27 @@
+/// A single preprocessed stroke point: the per-point feature vector fed to the
+/// model. Channel order is fixed everywhere: `[distance, cosTheta, sinTheta]`
+/// (plus `curvature` when enabled), matching the Python reference.
+struct StrokePoint: Equatable, Sendable {
+    /// Z-scored distance from the previous resampled point.
+    let distance: Float
+    /// Unit direction from the previous point: cosine component.
+    let cosTheta: Float
+    /// Unit direction from the previous point: sine component.
+    let sinTheta: Float
+    /// Turning angle (wrapped to (-pi, pi]); `0` when the curvature channel is disabled.
+    let curvature: Float
+
+    init(distance: Float, cosTheta: Float, sinTheta: Float, curvature: Float = 0) {
+        self.distance = distance
+        self.cosTheta = cosTheta
+        self.sinTheta = sinTheta
+        self.curvature = curvature
+    }
+
+    /// Channels in fixed model order. `count` is 3, or 4 with curvature.
+    func channels(curvature includeCurvature: Bool) -> [Float] {
+        includeCurvature
+            ? [distance, cosTheta, sinTheta, curvature]
+            : [distance, cosTheta, sinTheta]
+    }
+}

--- a/Sources/Shapes/StrokePreprocessor.swift
+++ b/Sources/Shapes/StrokePreprocessor.swift
@@ -1,0 +1,210 @@
+import RealModule
+
+/// Converts one raw pen-down…pen-up stroke into the model's `[N, C]` feature
+/// vectors. This is a 1:1 port of the Python reference (`preprocess.py`); the
+/// algorithm is the cross-platform source of truth, so it is kept deliberately
+/// simple and explicit. All math is done in `Double`; outputs are `Float`.
+///
+/// Pipeline:
+///   1. Reject degenerate input + drop duplicate consecutive points.
+///   2. Normalize position + scale (center; longer bbox side -> 1.0).
+///   3. Arc-length resample at fixed spacing.
+///   4. Per-point features `[dist, cos, sin]` (+ optional curvature).
+///   5. Z-score the distance channel with frozen mean/std.
+struct StrokePreprocessor {
+    let config: PreprocessConfig
+
+    init(config: PreprocessConfig = PreprocessConfig()) {
+        self.config = config
+    }
+
+    // MARK: Public entry point
+
+    /// Run the full pipeline on one stroke. Throws `DegenerateStrokeError` for
+    /// input that is too short / too small.
+    func process(points rawPoints: [Point]) throws -> [StrokePoint] {
+        let cleaned = dedupeConsecutive(rawPoints)
+
+        if cleaned.count < config.minPoints {
+            throw DegenerateStrokeError(
+                "stroke has \(cleaned.count) unique points (< \(config.minPoints))")
+        }
+        let total = totalLength(cleaned)
+        if total < config.minTotalLength {
+            throw DegenerateStrokeError(
+                "stroke total length \(total) < \(config.minTotalLength)")
+        }
+
+        let normalized = normalize(cleaned)
+        let resampled = resampleArcLength(normalized, spacing: config.spacing)
+        return computeFeatures(resampled)
+    }
+
+    // MARK: Step 1 — dedupe + length
+
+    private func dedupeConsecutive(_ points: [Point]) -> [Point] {
+        guard let first = points.first else { return [] }
+        var cleaned: [Point] = [Point(x: first.x, y: first.y)]
+        let epsSq = config.dedupeEpsilon * config.dedupeEpsilon
+        for i in 1..<Swift.max(points.count, 1) {
+            let x = points[i].x
+            let y = points[i].y
+            let last = cleaned[cleaned.count - 1]
+            let dx = x - last.x
+            let dy = y - last.y
+            if (dx * dx + dy * dy) > epsSq {
+                cleaned.append(Point(x: x, y: y))
+            }
+        }
+        return cleaned
+    }
+
+    private func totalLength(_ points: [Point]) -> Double {
+        var total = 0.0
+        if points.count < 2 { return 0.0 }
+        for i in 1..<points.count {
+            let dx = points[i].x - points[i - 1].x
+            let dy = points[i].y - points[i - 1].y
+            total += (dx * dx + dy * dy).squareRoot()
+        }
+        return total
+    }
+
+    // MARK: Step 2 — normalize position + scale
+
+    private func normalize(_ points: [Point]) -> [Point] {
+        guard let first = points.first else { return [] }
+        var minX = first.x, maxX = first.x
+        var minY = first.y, maxY = first.y
+        for p in points {
+            if p.x < minX { minX = p.x }
+            if p.x > maxX { maxX = p.x }
+            if p.y < minY { minY = p.y }
+            if p.y > maxY { maxY = p.y }
+        }
+        let width = maxX - minX
+        let height = maxY - minY
+        let centerX = (minX + maxX) * 0.5
+        let centerY = (minY + maxY) * 0.5
+        let longer = width > height ? width : height
+        let scale = longer > 0.0 ? 1.0 / longer : 1.0
+
+        var out: [Point] = []
+        out.reserveCapacity(points.count)
+        for p in points {
+            out.append(Point(x: (p.x - centerX) * scale, y: (p.y - centerY) * scale))
+        }
+        return out
+    }
+
+    // MARK: Step 3 — arc-length resampling
+
+    private func resampleArcLength(_ points: [Point], spacing: Double) -> [Point] {
+        let n = points.count
+        if n == 0 { return [] }
+        if n == 1 { return [points[0]] }
+
+        var resampled: [Point] = [points[0]]
+        var prevX = points[0].x
+        var prevY = points[0].y
+        var distSinceLast = 0.0
+
+        var i = 1
+        while i < n {
+            let curX = points[i].x
+            let curY = points[i].y
+            let segDx = curX - prevX
+            let segDy = curY - prevY
+            let segLen = (segDx * segDx + segDy * segDy).squareRoot()
+
+            if segLen <= 0.0 {
+                prevX = curX; prevY = curY
+                i += 1
+                continue
+            }
+
+            let needed = spacing - distSinceLast
+            if needed <= segLen {
+                let t = needed / segLen
+                let nx = prevX + segDx * t
+                let ny = prevY + segDy * t
+                resampled.append(Point(x: nx, y: ny))
+                prevX = nx; prevY = ny
+                distSinceLast = 0.0
+                // Do NOT advance i: more samples may fit in this segment.
+            } else {
+                distSinceLast += segLen
+                prevX = curX; prevY = curY
+                i += 1
+            }
+        }
+
+        // Ensure the exact last point is present.
+        let last = points[n - 1]
+        let rLast = resampled[resampled.count - 1]
+        let ddx = last.x - rLast.x
+        let ddy = last.y - rLast.y
+        if (ddx * ddx + ddy * ddy) > 1e-18 {
+            resampled.append(last)
+        }
+        return resampled
+    }
+
+    // MARK: Steps 4 + 5 — features + distance normalization
+
+    private func computeFeatures(_ points: [Point]) -> [StrokePoint] {
+        let n = points.count
+        let std = config.distStd > 0.0 ? config.distStd : 1.0
+        var features: [StrokePoint] = []
+        features.reserveCapacity(n)
+
+        var prevTheta = 0.0
+        var havePrevTheta = false
+
+        for i in 0..<n {
+            var dist = 0.0
+            var cosT = 0.0
+            var sinT = 0.0
+            if i > 0 {
+                let dx = points[i].x - points[i - 1].x
+                let dy = points[i].y - points[i - 1].y
+                dist = (dx * dx + dy * dy).squareRoot()
+                if dist > 0.0 {
+                    cosT = dx / dist
+                    sinT = dy / dist
+                }
+            }
+            let distNorm = (dist - config.distMean) / std
+
+            var curvature = 0.0
+            if config.addCurvature {
+                if i > 0 && (cosT != 0.0 || sinT != 0.0) {
+                    let theta = Double.atan2(y: sinT, x: cosT)
+                    if havePrevTheta {
+                        curvature = wrapPi(theta - prevTheta)
+                    }
+                    prevTheta = theta
+                    havePrevTheta = true
+                }
+            }
+
+            features.append(StrokePoint(
+                distance: Float(distNorm),
+                cosTheta: Float(cosT),
+                sinTheta: Float(sinT),
+                curvature: Float(curvature)))
+        }
+        return features
+    }
+
+    private func wrapPi(_ angle: Double) -> Double {
+        let twoPi = 2.0 * Double.pi
+        var a = angle.truncatingRemainder(dividingBy: twoPi)
+        if a <= -Double.pi {
+            a += twoPi
+        } else if a > Double.pi {
+            a -= twoPi
+        }
+        return a
+    }
+}

--- a/Sources/Shapes/Web/main.swift
+++ b/Sources/Shapes/Web/main.swift
@@ -1,0 +1,26 @@
+#if os(WASI)
+import DesertAnt
+import WasmBindings
+@_spi(ShapesBindings) import Shapes
+
+// Shapes' WebAssembly entry point.
+//
+// The exported surface is the shared, model-agnostic one in `WasmBindings`
+// (`Exports.swift`, generated into typed JS by BridgeJS), the wasm twin of the
+// `dal_*` C ABI: options and results cross as the FFI payloads
+// `Shapes/Binding.swift` already encodes, so nothing model-specific is repeated
+// here. The one exception is the `modelBaseUrl` path, where the JS host fetched
+// the files and compiled the model itself: only Shapes knows that its sidecar is
+// the meta JSON.
+//
+// `packages/shapes-node` wraps that surface in the public typed API.
+installWasmModel(
+    WasmModel(ShapesModel.self, binding: ShapesBinding.self) { sidecars, session in
+        guard let meta = sidecars[ShapesModel.meta] else {
+            throw ShapesError.resourceMissing
+        }
+        return Shapes(assets: ModelAssets(
+            metaJSON: String(decoding: meta, as: UTF8.self),
+            session: session))
+    })
+#endif

--- a/Tests/BindingsTests/ClearBindingTests.swift
+++ b/Tests/BindingsTests/ClearBindingTests.swift
@@ -5,6 +5,7 @@ import TestSupport
 @_spi(ClearBindings) @testable import Clear
 import Emo
 import Redact
+import Shapes
 
 /// The model-specific half of the cross-language binding: the payload schemas a
 /// host encodes and decodes. Each model owns its own adapter, so no model can
@@ -63,6 +64,7 @@ final class ClearBindingTests: XCTestCase {
         XCTAssertEqual(EmoBinding.id, "emo")
         XCTAssertEqual(RedactBinding.id, "redact")
         XCTAssertEqual(ClearBinding.id, "clear")
+        XCTAssertEqual(ShapesBinding.id, "shapes")
     }
 #endif
 }

--- a/Tests/BindingsTests/ShapesBindingTests.swift
+++ b/Tests/BindingsTests/ShapesBindingTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+import Foundation
+import DesertAnt
+import TestSupport
+@_spi(ShapesBindings) @testable import Shapes
+
+/// Shapes' half of the cross-language binding: the stroke payload a host encodes
+/// and the shape payload it decodes. Worth pinning on its own because shapes is
+/// the first model whose input is geometry rather than text or audio - proof that
+/// a new modality is a payload schema, not a new entry point in every language.
+final class ShapesBindingTests: XCTestCase {
+#if !os(WASI)
+    private func requireModelBacked() throws {
+        try XCTSkipUnless(runsModelBackedTests, "model-backed tests do not run on iOS or Android")
+    }
+
+    /// A recognizer over the cached model, reached through the binding only.
+    private func recognizer() -> Shapes { Shapes() }
+
+    /// `u32 count`, then `f64 x`, `f64 y` per point.
+    private func stroke(_ points: [Point]) -> FFIReader {
+        var w = FFIWriter()
+        w.u32(points.count)
+        for p in points {
+            w.f64(p.x)
+            w.f64(p.y)
+        }
+        return FFIReader(w.bytes)
+    }
+
+    private func options(minimumConfidence: Double) -> FFIReader {
+        var w = FFIWriter()
+        w.f64(minimumConfidence)
+        return FFIReader(w.bytes)
+    }
+
+    /// The geometry payload contract: a stroke in through the generic
+    /// `run(input:options:)` entry, a fitted shape out, decoded with the same
+    /// reader a host uses.
+    func testStrokePayloadRoundTrip() async throws {
+        try requireModelBacked()
+        guard let payload = await recognizer().run(
+            input: stroke(ShapesTestStrokes.circle()), options: FFIReader([])) else {
+            return XCTFail("the geometry binding returned no payload")
+        }
+        var reader = FFIReader(payload)
+        XCTAssertEqual(reader.u32(), 1, "expected a recognized shape")
+        XCTAssertEqual(reader.u32(), 4, "expected the ellipse kind")
+        XCTAssertEqual(reader.f64(), 100, accuracy: 8)   // center x
+        XCTAssertEqual(reader.f64(), 100, accuracy: 8)   // center y
+        XCTAssertEqual(reader.f64(), 80, accuracy: 12)   // semi-major
+        XCTAssertEqual(reader.f64(), 80, accuracy: 12)   // semi-minor
+        _ = reader.f64()                                 // rotation
+        XCTAssertTrue(reader.isAtEnd, "the ellipse payload is fully consumed")
+    }
+
+    /// A rejected stroke is a result, not a failure: the host gets a payload
+    /// whose `present` flag is 0 rather than a NULL buffer, which is how it tells
+    /// "no shape here" apart from "the model could not run".
+    func testRejectedStrokeIsAPayloadNotAFailure() async throws {
+        try requireModelBacked()
+        guard let payload = await recognizer().run(
+            input: stroke(ShapesTestStrokes.circle()),
+            options: options(minimumConfidence: 1)) else {
+            return XCTFail("a rejected stroke must still return a payload")
+        }
+        var reader = FFIReader(payload)
+        XCTAssertEqual(reader.u32(), 0)
+        XCTAssertTrue(reader.isAtEnd, "nothing follows a 0 present flag")
+    }
+
+    /// An empty options payload means the SDK defaults, which for shapes is
+    /// `minimumConfidence: 0` - the same stroke the explicit `1` above rejected.
+    func testEmptyOptionsMeansTheSDKDefaults() async throws {
+        try requireModelBacked()
+        guard let payload = await recognizer().run(
+            input: stroke(ShapesTestStrokes.circle()), options: FFIReader([])) else {
+            return XCTFail("the geometry binding returned no payload")
+        }
+        var reader = FFIReader(payload)
+        XCTAssertEqual(reader.u32(), 1)
+    }
+
+    /// A truncated buffer is untrusted foreign input. Every `FFIReader` read is
+    /// bounds-checked and yields a default on underflow, so a host that lies
+    /// about its point count gets a well-defined answer instead of a trap.
+    func testTruncatedStrokePayloadDoesNotTrap() async throws {
+        try requireModelBacked()
+        var w = FFIWriter()
+        w.u32(64)             // claims 64 points
+        w.f64(1)              // supplies half of one; the rest underflow to 0
+        guard let payload = await recognizer().run(
+            input: FFIReader(w.bytes), options: FFIReader([])) else {
+            return XCTFail("a malformed stroke must still return a payload")
+        }
+        var reader = FFIReader(payload)
+        XCTAssertTrue([0, 1].contains(reader.u32()), "present is a 0/1 flag")
+    }
+
+    /// An empty input payload is the degenerate case of the same rule: no points
+    /// at all is a rejected stroke, not a failed run.
+    func testEmptyStrokePayloadIsRejected() async throws {
+        try requireModelBacked()
+        guard let payload = await recognizer().run(
+            input: FFIReader([]), options: FFIReader([])) else {
+            return XCTFail("an empty stroke must still return a payload")
+        }
+        var reader = FFIReader(payload)
+        XCTAssertEqual(reader.u32(), 0)
+    }
+
+    func testShapesOwnsOnlyItsCatalogId() {
+        XCTAssertEqual(ShapesBinding.id, "shapes")
+    }
+#endif
+}
+
+/// Strokes for the binding suite. `ShapesTests` has its own copies in the Shapes
+/// test target, which this target cannot see.
+enum ShapesTestStrokes {
+    static func circle(center: Point = Point(x: 100, y: 100), radius: Double = 80,
+                       samples: Int = 64) -> [Point] {
+        (0...samples).map { i in
+            let t = 2 * Double.pi * Double(i) / Double(samples)
+            return Point(x: center.x + radius * cos(t), y: center.y + radius * sin(t))
+        }
+    }
+}

--- a/Tests/ModelCatalogTests/ModelCatalogTests.swift
+++ b/Tests/ModelCatalogTests/ModelCatalogTests.swift
@@ -8,6 +8,7 @@ import DesertAnt
 @testable import Gist
 @testable import Tongue
 @testable import Clips
+@testable import Shapes
 
 /// Every model in the monorepo. The list lives here rather than beside the
 /// `ModelDeclaration` protocol because each model's module depends on the
@@ -21,6 +22,7 @@ let catalog: [any ModelDeclaration.Type] = [
     GistModel.self,
     TongueModel.self,
     ClipModel.self,
+    ShapesModel.self,
 ]
 
 /// Invariants every catalog entry must hold, so a malformed declaration fails
@@ -114,6 +116,8 @@ struct ModelCatalogTests {
         #expect(RedactModel.artifact(for: .apple) == RedactModel.coreML)
         #expect(EmoModel.artifact(for: .android) == EmoModel.tflite)
         #expect(EmoModel.supports(.web))
+        #expect(ShapesModel.artifact(for: .apple) == ShapesModel.coreML)
+        #expect(ShapesModel.files[.linux] == [ShapesModel.tflite, ShapesModel.meta])
     }
 }
 

--- a/Tests/ShapesTests/FitterTests.swift
+++ b/Tests/ShapesTests/FitterTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import XCTest
+@testable import Shapes
+
+/// Exercises the geometric fitters directly (no model): min-area rectangle,
+/// moment-fit ellipse, and pose+template star. Uses the portable ``Point``.
+final class FitterTests: XCTestCase {
+    private func angleModPi(_ a: Double) -> Double {
+        var x = a.truncatingRemainder(dividingBy: .pi)
+        if x < 0 { x += .pi }
+        return x
+    }
+
+    func testMomentEllipseRecoversAxesAndRotation() {
+        let a = 100.0, b = 40.0, rot = 30.0 * .pi / 180
+        let c = Point(x: 250, y: 180)
+        let pts = (0..<200).map { i -> Point in
+            let t = 2 * Double.pi * Double(i) / 200
+            let x = a * cos(t), y = b * sin(t)
+            return Point(x: c.x + x * cos(rot) - y * sin(rot),
+                         y: c.y + x * sin(rot) + y * cos(rot))
+        }
+        let (shape, residual) = Fitter.fit(.ellipse, points: pts, snap: .disabled)
+        guard case let .ellipse(center, major, minor, rotation) = shape else { return XCTFail() }
+        XCTAssertEqual(center.x, 250, accuracy: 2)
+        XCTAssertEqual(center.y, 180, accuracy: 2)
+        XCTAssertEqual(major, a, accuracy: 3)
+        XCTAssertEqual(minor, b, accuracy: 3)
+        XCTAssertEqual(angleModPi(rotation), angleModPi(rot), accuracy: 0.03)
+        XCTAssertLessThan(residual, 0.02)
+    }
+
+    func testMinAreaRectangleRecoversCornersAndOrientation() {
+        let w = 120.0, h = 60.0, rot = 20.0 * .pi / 180
+        let cx = 200.0, cy = 200.0
+        let local = [(-w / 2, -h / 2), (w / 2, -h / 2), (w / 2, h / 2), (-w / 2, h / 2)]
+        let world = local.map { v in
+            (cx + v.0 * cos(rot) - v.1 * sin(rot), cy + v.0 * sin(rot) + v.1 * cos(rot))
+        }
+        var pts: [Point] = []
+        for k in 0..<4 {
+            let p = world[k], q = world[(k + 1) % 4]
+            for s in 0..<40 {
+                let t = Double(s) / 40
+                pts.append(Point(x: p.0 + (q.0 - p.0) * t, y: p.1 + (q.1 - p.1) * t))
+            }
+        }
+        let (shape, residual) = Fitter.fit(.rectangle, points: pts, snap: .disabled)
+        guard case let .rectangle(corners) = shape else { return XCTFail() }
+        XCTAssertEqual(corners.count, 4)
+        let side0 = hypot(corners[1].x - corners[0].x, corners[1].y - corners[0].y)
+        let side1 = hypot(corners[3].x - corners[0].x, corners[3].y - corners[0].y)
+        let (long, short) = side0 > side1 ? (side0, side1) : (side1, side0)
+        XCTAssertEqual(long, w, accuracy: 3)
+        XCTAssertEqual(short, h, accuracy: 3)
+        XCTAssertLessThan(residual, 0.02)
+    }
+
+    func testStarPoseRecoversRotationAndRadius() {
+        let outer = 100.0, inner = 40.0, rot = 12.0 * .pi / 180
+        let cx = 160.0, cy = 160.0
+        let verts = (0..<10).map { i -> (Double, Double) in
+            let aa = rot - .pi / 2 + Double(i) * .pi / 5
+            let r = i % 2 == 0 ? outer : inner
+            return (cx + r * cos(aa), cy + r * sin(aa))
+        }
+        var pts: [Point] = []
+        for k in 0..<10 {
+            let p = verts[k], q = verts[(k + 1) % 10]
+            for s in 0..<20 {
+                let t = Double(s) / 20
+                pts.append(Point(x: p.0 + (q.0 - p.0) * t, y: p.1 + (q.1 - p.1) * t))
+            }
+        }
+        let (shape, residual) = Fitter.fit(.star, points: pts, snap: .disabled)
+        guard case let .star(center, outerR, _, rotation, count) = shape else { return XCTFail() }
+        XCTAssertEqual(count, 5)
+        XCTAssertEqual(center.x, 160, accuracy: 3)
+        XCTAssertEqual(outerR, outer, accuracy: 12)
+        // Star rotation is periodic in 72°.
+        let drot = abs((rotation - rot).truncatingRemainder(dividingBy: 2 * .pi / 5))
+        XCTAssertTrue(min(drot, 2 * .pi / 5 - drot) < 0.06, "rotation off by \(drot)")
+        XCTAssertLessThan(residual, 0.05)
+    }
+}

--- a/Tests/ShapesTests/HubDownloadTests.swift
+++ b/Tests/ShapesTests/HubDownloadTests.swift
@@ -1,0 +1,24 @@
+#if !os(WASI)
+import XCTest
+import TestSupport
+@testable import Shapes
+
+final class HubDownloadTests: XCTestCase {
+    func testDownloadThenRecognize() async throws {
+        try await HubDownloadScenario.run(
+            ShapesModel.self,
+            make: { Shapes(directory: $0) },
+            isDownloaded: { $0.isDownloaded() },
+            download: { try await $0.download(progress: $1) }
+        ) { shapes, cached in
+            guard case .ellipse = try await shapes.recognize(points: ShapesTests.circle()) else {
+                return XCTFail("expected an ellipse from a traced circle")
+            }
+            // The second recognizer reads the same directory with no network.
+            guard case .line = try await cached.recognize(points: ShapesTests.diagonal()) else {
+                return XCTFail("expected a line from the cached model")
+            }
+        }
+    }
+}
+#endif

--- a/Tests/ShapesTests/ShapesTests.swift
+++ b/Tests/ShapesTests/ShapesTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import XCTest
+import DesertAnt
+import TestSupport
+@testable import Shapes
+
+/// End-to-end recognition through the downloaded model. On Apple this runs the
+/// Core ML artifact; on Linux/Windows the LiteRT artifact (via LiteRT). Both
+/// exports come from the same checkpoint and share one fixed-window signature, so
+/// the results match.
+final class ShapesTests: XCTestCase {
+    // The model-backed tests are wasm-guarded because the shared fixture does not
+    // exist there (the model store's filesystem and transport come from the JS host
+    // the app installs, which the bare test harness never does), and skipped off
+    // iOS/Android by `requireModelBacked`.
+#if !os(WASI)
+    /// Skip unless this is a platform where model-backed tests run.
+    private func requireModelBacked() throws {
+        try XCTSkipUnless(runsModelBackedTests, "model-backed tests do not run on iOS or Android")
+    }
+
+    /// A recognizer over the cached model (offline after the fixture's download).
+    private func makeShapes() -> Shapes { Shapes() }
+
+    func testRecognizesCircleAsEllipseWithFit() async throws {
+        try requireModelBacked()
+        let recognized = try await makeShapes().recognize(points: Self.circle())
+        let shape = try XCTUnwrap(recognized)
+        guard case let .ellipse(center, major, minor, _) = shape else {
+            return XCTFail("expected ellipse geometry, got \(shape)")
+        }
+        XCTAssertEqual(center.x, 100, accuracy: 8)
+        XCTAssertEqual(center.y, 100, accuracy: 8)
+        XCTAssertEqual(major, 80, accuracy: 12)
+        XCTAssertEqual(minor, 80, accuracy: 12)
+    }
+
+    func testRecognizesLineWithEndpoints() async throws {
+        try requireModelBacked()
+        let recognized = try await makeShapes().recognize(points: Self.diagonal())
+        let shape = try XCTUnwrap(recognized)
+        guard case let .line(a, b) = shape else {
+            return XCTFail("expected line geometry, got \(shape)")
+        }
+        XCTAssertGreaterThan(hypot(a.x - b.x, a.y - b.y), 100)
+    }
+
+    func testRecognizesTriangle() async throws {
+        try requireModelBacked()
+        let traced = Self.polygon([
+            Point(x: 0, y: 0), Point(x: 100, y: 0), Point(x: 50, y: 90),
+        ])
+        let recognized = try await makeShapes().recognize(points: traced)
+        let shape = try XCTUnwrap(recognized)
+        guard case let .triangle(vertices) = shape else {
+            return XCTFail("expected triangle geometry, got \(shape)")
+        }
+        XCTAssertEqual(vertices.count, 3)
+    }
+
+    /// A stroke too short to mean anything is rejected before the model runs.
+    func testDegenerateReturnsNil() async throws {
+        try requireModelBacked()
+        let result = try await makeShapes().recognize(points: [Point(x: 1, y: 1)])
+        XCTAssertNil(result)
+    }
+
+    /// `minimumConfidence` raises the bar on top of each class's calibrated gate,
+    /// so `1` rejects everything the model could ever propose.
+    func testMinimumConfidenceRejects() async throws {
+        try requireModelBacked()
+        let options = Options(minimumConfidence: 1)
+        let result = try await makeShapes().recognize(points: Self.circle(), options: options)
+        XCTAssertNil(result)
+    }
+
+    /// A model directory the user populated is adopted offline, with no download.
+    func testPrepopulatedDirectoryIsAdopted() async throws {
+        try requireModelBacked()
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("shapes-local-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try await ModelFixture.populate(ShapesModel.self, into: directory)
+
+        let shapes = Shapes(directory: directory.path)
+        XCTAssertTrue(shapes.isDownloaded())
+        guard case .ellipse = try await shapes.recognize(points: Self.circle()) else {
+            return XCTFail("expected an ellipse from the adopted directory")
+        }
+    }
+#endif
+
+    // MARK: strokes
+
+    /// A traced circle, dense enough to look hand-drawn to the preprocessor.
+    static func circle(center: Point = Point(x: 100, y: 100), radius: Double = 80,
+                       samples: Int = 64) -> [Point] {
+        (0...samples).map { i in
+            let t = 2 * Double.pi * Double(i) / Double(samples)
+            return Point(x: center.x + radius * cos(t), y: center.y + radius * sin(t))
+        }
+    }
+
+    static func diagonal() -> [Point] {
+        (0...40).map { Point(x: Double($0) * 5, y: Double($0) * 2) }
+    }
+
+    /// Trace a closed polygon densely.
+    static func polygon(_ vertices: [Point], per: Int = 24) -> [Point] {
+        var points: [Point] = []
+        let loop = vertices + [vertices[0]]
+        for k in 0..<(loop.count - 1) {
+            let a = loop[k], b = loop[k + 1]
+            for s in 0..<per {
+                let t = Double(s) / Double(per)
+                points.append(Point(x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t))
+            }
+        }
+        return points
+    }
+}

--- a/Tests/ShapesTests/SnappingTests.swift
+++ b/Tests/ShapesTests/SnappingTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import XCTest
+@testable import Shapes
+
+final class SnappingTests: XCTestCase {
+    func testLineSnapsToHorizontalAxis() {
+        // 3° off horizontal — within the 5° threshold.
+        let a = Point(x: 0, y: 0)
+        let b = Point(x: 100, y: 100 * tan(3 * Double.pi / 180))
+        guard case let .line(from, to) = Fitter.snap(.line(from: a, to: b), config: .standard) else {
+            return XCTFail("expected line")
+        }
+        XCTAssertEqual(from.y, to.y, accuracy: 1e-6)  // now horizontal
+        let len = hypot(to.x - from.x, to.y - from.y)
+        XCTAssertEqual(len, hypot(b.x - a.x, b.y - a.y), accuracy: 1e-6)  // length preserved
+    }
+
+    func testLineBeyondThresholdNotSnapped() {
+        let a = Point(x: 0, y: 0)
+        let b = Point(x: 100, y: 100 * tan(20 * Double.pi / 180))  // 20° > 5°
+        guard case let .line(_, to) = Fitter.snap(.line(from: a, to: b), config: .standard) else {
+            return XCTFail("expected line")
+        }
+        XCTAssertEqual(to.y, b.y, accuracy: 1e-6)
+    }
+
+    func testEllipseSnapsToCircle() {
+        let s = Fitter.snap(.ellipse(center: Point(x: 0, y: 0), semiMajor: 100, semiMinor: 82,
+                                     rotation: 0.3), config: .standard)
+        guard case let .ellipse(_, major, minor, rotation) = s else { return XCTFail() }
+        XCTAssertEqual(major, minor)             // circle
+        XCTAssertEqual(major, 91, accuracy: 1e-6)
+        XCTAssertEqual(rotation, 0)
+    }
+
+    func testEllipseRotationSnapsTo15Degrees() {
+        // 82/100 = 0.82 > 0.75 would snap to circle, so use a clearly elongated ellipse.
+        let s = Fitter.snap(.ellipse(center: Point(x: 0, y: 0), semiMajor: 100, semiMinor: 40,
+                                     rotation: 17 * Double.pi / 180), config: .standard)
+        guard case let .ellipse(_, _, _, rotation) = s else { return XCTFail() }
+        XCTAssertEqual(rotation * 180 / Double.pi, 15, accuracy: 1e-6)
+    }
+
+    func testRectangleSnapsToSquareAndAxis() {
+        // Axis-aligned-ish rectangle, sides 100 x 84 (ratio 0.84 > 0.75) tilted 2°.
+        let a = 2 * Double.pi / 180
+        let r = Mat2.rotation(a)
+        let local = [V2(-50, -42), V2(50, -42), V2(50, 42), V2(-50, 42)]
+        let corners = local.map { v -> Point in
+            let p = r * v
+            return Point(x: p.x, y: p.y)
+        }
+        guard case let .rectangle(out) = Fitter.snap(.rectangle(corners: corners), config: .standard)
+        else { return XCTFail() }
+        let w = hypot(out[1].x - out[0].x, out[1].y - out[0].y)
+        let h = hypot(out[3].x - out[0].x, out[3].y - out[0].y)
+        XCTAssertEqual(w, h, accuracy: 1e-6)                    // square
+        XCTAssertEqual(out[0].y, out[1].y, accuracy: 1e-6)      // axis aligned
+    }
+
+    func testTriangleSnapsToEquilateral() {
+        let verts = [Point(x: 0, y: 0), Point(x: 100, y: 4), Point(x: 48, y: 88)]
+        guard case let .triangle(v) = Fitter.snap(.triangle(vertices: verts), config: .standard)
+        else { return XCTFail() }
+        let s0 = hypot(v[0].x - v[1].x, v[0].y - v[1].y)
+        let s1 = hypot(v[1].x - v[2].x, v[1].y - v[2].y)
+        let s2 = hypot(v[2].x - v[0].x, v[2].y - v[0].y)
+        XCTAssertEqual(s0, s1, accuracy: 1e-6)
+        XCTAssertEqual(s1, s2, accuracy: 1e-6)
+    }
+
+    func testTriangleAlignsLongestEdgeToAxis() {
+        let cfg = SnapConfig(
+            lineAxisThresholdDeg: 0, ellipseCircleRatio: 0, ellipseRotationIncrementDeg: 0,
+            rectangleSquareRatio: 0, rectangleRotationIncrementDeg: 0,
+            triangleAxisThresholdDeg: 5, triangleEquilateralRatio: 0, triangleIsoscelesRatio: 0
+        )
+        let dy = 120 * tan(3 * Double.pi / 180)
+        let verts = [Point(x: 0, y: 0), Point(x: 120, y: dy), Point(x: 55, y: 70)]
+        guard case let .triangle(v) = Fitter.snap(.triangle(vertices: verts), config: cfg)
+        else { return XCTFail() }
+        XCTAssertEqual(v[0].y, v[1].y, accuracy: 1e-6)
+    }
+
+    func testDisabledConfigLeavesGeometryUntouched() {
+        let a = Point(x: 0, y: 0)
+        let b = Point(x: 100, y: 100 * tan(3 * Double.pi / 180))
+        guard case let .line(_, to) = Fitter.snap(.line(from: a, to: b), config: .disabled) else {
+            return XCTFail()
+        }
+        XCTAssertEqual(to.y, b.y, accuracy: 1e-6)
+    }
+}

--- a/Tests/ShapesTests/StrokePreprocessorTests.swift
+++ b/Tests/ShapesTests/StrokePreprocessorTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+@testable import Shapes
+
+final class StrokePreprocessorTests: XCTestCase {
+    let pre = StrokePreprocessor()
+
+    // Cross-language parity: reference values produced by the Python
+    // `preprocess.py` for this exact input with the frozen config.
+    func testMatchesPythonReference() throws {
+        let stroke = [
+            Point(x: 0, y: 0), Point(x: 10, y: 0), Point(x: 10, y: 8),
+            Point(x: 2, y: 8), Point(x: 2, y: 3),
+        ]
+        let f = try pre.process(points: stroke)
+
+        XCTAssertEqual(f.count, 156)
+
+        let sumDist = f.reduce(0.0) { $0 + Double($1.distance) }
+        let sumCos = f.reduce(0.0) { $0 + Double($1.cosTheta) }
+        let sumSin = f.reduce(0.0) { $0 + Double($1.sinTheta) }
+        XCTAssertEqual(sumDist, 45.059365, accuracy: 1e-3)
+        XCTAssertEqual(sumCos, 10.0, accuracy: 1e-3)
+        XCTAssertEqual(sumSin, 15.0, accuracy: 1e-3)
+
+        assertPoint(f[0], -9.277467, 0.0, 0.0)
+        assertPoint(f[1], 0.35056, 1.0, 0.0)
+        assertPoint(f[2], 0.35056, 1.0, 0.0)
+        assertPoint(f[154], 0.35056, 0.0, -1.0)
+        assertPoint(f[155], 0.35056, 0.0, -1.0)
+    }
+
+    func testFirstPointIsZeroDirection() throws {
+        let f = try pre.process(points: [Point(x: 0, y: 0), Point(x: 5, y: 0)])
+        XCTAssertEqual(f[0].cosTheta, 0)
+        XCTAssertEqual(f[0].sinTheta, 0)
+    }
+
+    func testStraightLineHasConstantDirection() throws {
+        let pts = (0...20).map { Point(x: Double($0), y: 0) }
+        let f = try pre.process(points: pts)
+        for p in f.dropFirst() {
+            XCTAssertEqual(p.cosTheta, 1.0, accuracy: 1e-5)
+            XCTAssertEqual(p.sinTheta, 0.0, accuracy: 1e-5)
+        }
+    }
+
+    func testCircleDirectionRotatesFullTurn() throws {
+        var pts: [Point] = []
+        let n = 200
+        for i in 0...n {
+            let t = 2.0 * Double.pi * Double(i) / Double(n)
+            pts.append(Point(x: cos(t), y: sin(t)))
+        }
+        let f = try pre.process(points: pts)
+        // Direction angle should sweep close to a full 2π around the circle.
+        var total = 0.0
+        var prev = atan2(Double(f[1].sinTheta), Double(f[1].cosTheta))
+        for p in f.dropFirst(2) {
+            let a = atan2(Double(p.sinTheta), Double(p.cosTheta))
+            var d = a - prev
+            if d > Double.pi { d -= 2 * Double.pi }
+            if d < -Double.pi { d += 2 * Double.pi }
+            total += d
+            prev = a
+        }
+        XCTAssertEqual(abs(total), 2 * Double.pi, accuracy: 0.2)
+    }
+
+    func testCurvatureChannelEnabled() throws {
+        let cfg = PreprocessConfig(addCurvature: true)
+        let p = StrokePreprocessor(config: cfg)
+        let pts = (0...20).map { Point(x: Double($0), y: 0) }
+        let f = try p.process(points: pts)
+        // A straight line has ~zero turning angle everywhere.
+        for pt in f { XCTAssertEqual(pt.curvature, 0, accuracy: 1e-5) }
+    }
+
+    func testRejectsTooFewPoints() {
+        XCTAssertThrowsError(try pre.process(points: [Point(x: 1, y: 1)]))
+    }
+
+    func testRejectsDuplicatePointsAsDegenerate() {
+        let dup = [Point(x: 3, y: 3), Point(x: 3, y: 3), Point(x: 3, y: 3)]
+        XCTAssertThrowsError(try pre.process(points: dup))
+    }
+
+    private func assertPoint(_ p: StrokePoint, _ d: Float, _ c: Float, _ s: Float,
+                             file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(p.distance, d, accuracy: 1e-3, file: file, line: line)
+        XCTAssertEqual(p.cosTheta, c, accuracy: 1e-3, file: file, line: line)
+        XCTAssertEqual(p.sinTheta, s, accuracy: 1e-3, file: file, line: line)
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,10 @@
       "resolved": "packages/redact-node",
       "link": true
     },
+    "node_modules/@desert-ant-labs/shapes": {
+      "resolved": "packages/shapes-node",
+      "link": true
+    },
     "node_modules/@desert-ant-labs/tongue": {
       "resolved": "packages/tongue-node",
       "link": true
@@ -67,7 +71,7 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@litertjs/core/-/core-2.5.3.tgz",
       "integrity": "sha512-PlGmbMOq9WitX7FO0jhbdJw9GthatsyuCQXjTt/wJZo0FLaw48q4tz8IwqgqCIkviYGr9OFDL1kCnN4nzWoyJQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@litertjs/wasm-utils": "^2.5.3"
@@ -77,7 +81,7 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@litertjs/wasm-utils/-/wasm-utils-2.5.3.tgz",
       "integrity": "sha512-4fJiw6tBQnIs+0jH/OQ16nYOiSl8/+zZnn5h2ul8aTKHi05sVqZW580Tmk78pC2kT39A9OYBVdFawteZ/sI1kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@types/node": {
@@ -240,6 +244,29 @@
     },
     "packages/redact-node": {
       "name": "@desert-ant-labs/redact",
+      "version": "3.0.0",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bjorn3/browser_wasi_shim": "^0.3.0",
+        "@desert-ant-labs/core": "^3.0.0"
+      },
+      "devDependencies": {
+        "@litertjs/core": "^2.5.2"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@litertjs/core": ">=2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@litertjs/core": {
+          "optional": true
+        }
+      }
+    },
+    "packages/shapes-node": {
+      "name": "@desert-ant-labs/shapes",
       "version": "3.0.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {

--- a/packages/shapes-kotlin/build.gradle.kts
+++ b/packages/shapes-kotlin/build.gradle.kts
@@ -1,0 +1,11 @@
+// Android library (AAR) for Shapes: ai.desertant:shapes. Everything structural -
+// AGP, Kotlin, publishing, the ai.desertant:core dependency, and the Swift JNI
+// cross-compile - lives in the shared ai.desertant.model-sdk convention plugin
+// (gradle-plugin/). The version comes from VERSION at the repo root, so the only
+// thing left here is what is genuinely Shapes'.
+plugins { id("ai.desertant.model-sdk") }
+
+desertAntSdk {
+    description = "On-device single-stroke shape recognition for Android: turns one hand-drawn stroke " +
+        "into a clean line, rectangle, triangle, ellipse, or star, fully on device."
+}

--- a/packages/shapes-kotlin/src/androidTest/kotlin/ai/desertant/shapes/ShapesTest.kt
+++ b/packages/shapes-kotlin/src/androidTest/kotlin/ai/desertant/shapes/ShapesTest.kt
@@ -1,0 +1,62 @@
+package ai.desertant.shapes
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Instrumented tests for the Android binding, exercising the real on-device path
+ * via JNI: platform JSON via CHostBridge, LiteRT inference, and the
+ * static-stdlib runtime. No model ships with the AAR, so the model is downloaded
+ * into the instrumentation app's cache on the first run and reused afterward.
+ */
+@RunWith(AndroidJUnit4::class)
+class ShapesTest {
+    private lateinit var shapes: Shapes
+
+    @Before fun setUp() {
+        shapes = Shapes(ApplicationProvider.getApplicationContext())
+        runBlocking { shapes.download() }   // fetch once up front; cached afterward
+    }
+    // Null-safe: if setUp() throws, an unguarded close() replaces the real
+    // failure with UninitializedPropertyAccessException and hides the cause.
+    @After fun tearDown() { if (::shapes.isInitialized) shapes.close() }
+
+    private fun circle() = (0..64).map {
+        val t = 2.0 * Math.PI * it / 64.0
+        Point(100 + 80 * cos(t), 100 + 80 * sin(t))
+    }
+
+    @Test fun recognizesCircleAsEllipseWithFit() = runTest {
+        val shape = shapes.recognize(circle())
+        assertNotNull(shape)
+        assertTrue("expected ellipse, got $shape", shape is Shape.Ellipse)
+        val ellipse = shape as Shape.Ellipse
+        assertTrue("center ${ellipse.center}", abs(ellipse.center.x - 100) < 8)
+        assertTrue("semiMajor ${ellipse.semiMajor}", abs(ellipse.semiMajor - 80) < 12)
+    }
+
+    @Test fun recognizesLine() = runTest {
+        val shape = shapes.recognize((0..40).map { Point(it * 5.0, it * 2.0) })
+        assertTrue("expected line, got $shape", shape is Shape.Line)
+    }
+
+    @Test fun degenerateReturnsNull() = runTest {
+        assertNull(shapes.recognize(listOf(Point(1.0, 1.0))))
+    }
+
+    @Test fun minimumConfidenceRejects() = runTest {
+        assertNull(shapes.recognize(circle(), Options(minimumConfidence = 1.0)))
+    }
+}

--- a/packages/shapes-kotlin/src/main/AndroidManifest.xml
+++ b/packages/shapes-kotlin/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Needed for the on-demand model download; a directory you pre-populate uses no network. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/packages/shapes-kotlin/src/main/kotlin/ai/desertant/shapes/Shape.kt
+++ b/packages/shapes-kotlin/src/main/kotlin/ai/desertant/shapes/Shape.kt
@@ -1,0 +1,39 @@
+package ai.desertant.shapes
+
+/** A 2D point in the same coordinate space as the input stroke. */
+data class Point(val x: Double, val y: Double)
+
+/**
+ * A recognized, fitted shape in the same coordinate space as the input stroke.
+ * Mirrors the Swift/TypeScript `Shape` types.
+ */
+sealed class Shape {
+    /** A straight line segment from [from] to [to]. */
+    data class Line(val from: Point, val to: Point) : Shape()
+
+    /** A rectangle given by its four corners, in order around the perimeter. */
+    data class Rectangle(val corners: List<Point>) : Shape()
+
+    /** A triangle given by its three vertices. */
+    data class Triangle(val vertices: List<Point>) : Shape()
+
+    /** An ellipse with the given [center], semi-axes, and [rotation] (radians). */
+    data class Ellipse(
+        val center: Point,
+        val semiMajor: Double,
+        val semiMinor: Double,
+        val rotation: Double,
+    ) : Shape()
+
+    /**
+     * A star alternating between [outerRadius] and [innerRadius] across
+     * [pointCount] points, with [rotation] in radians.
+     */
+    data class Star(
+        val center: Point,
+        val outerRadius: Double,
+        val innerRadius: Double,
+        val rotation: Double,
+        val pointCount: Int,
+    ) : Shape()
+}

--- a/packages/shapes-kotlin/src/main/kotlin/ai/desertant/shapes/Shapes.kt
+++ b/packages/shapes-kotlin/src/main/kotlin/ai/desertant/shapes/Shapes.kt
@@ -1,0 +1,106 @@
+package ai.desertant.shapes
+
+import ai.desertant.core.FfiReader
+import ai.desertant.core.FfiWriter
+import ai.desertant.core.LoadedModel
+
+/** The catalog id, which is how the shared native layer is asked for Shapes. */
+private const val MODEL_ID = "shapes"
+private const val MODEL_NAME = "Shapes"
+
+/** Options controlling recognition. */
+data class Options(
+    /**
+     * Minimum classifier confidence, on top of each class's calibrated gate.
+     * `0.0` (the default) applies only the model's own gates.
+     */
+    val minimumConfidence: Double = 0.0,
+)
+
+/** Thrown when the model cannot be created, loaded, or run. */
+class ShapesException(message: String) : Exception(message)
+
+/**
+ * On-device single-stroke shape recognition. Mirrors the iOS/Swift SDK: create
+ * one `Shapes` and reuse it; the model loads lazily on the first [recognize]
+ * (or eagerly via [download]).
+ *
+ * ```kotlin
+ * val shapes = Shapes(context)                 // download on demand, cached
+ * val shape = shapes.recognize(strokePoints)   // Shape? (null if rejected)
+ * when (shape) {
+ *     is Shape.Rectangle -> shape.corners
+ *     is Shape.Ellipse -> shape.center
+ *     else -> {}
+ * }
+ * shapes.close()
+ * ```
+ *
+ * Creating, downloading, running, and releasing the model are the shared
+ * `ai.desertant:core` shell ([LoadedModel]); what lives here is Shapes' API and
+ * its payload schemas.
+ *
+ * @param directory the model's home. Files already there are adopted (so an app
+ *   that ships the model just points at the folder it unpacked it into),
+ *   otherwise the model is downloaded into it. Omit to use the app cache.
+ */
+class Shapes(
+    context: android.content.Context,
+    directory: String? = null,
+) : AutoCloseable {
+    private val model = LoadedModel(MODEL_ID, MODEL_NAME, context, directory, ::ShapesException, ShapesNative)
+
+    companion object
+
+    /** Whether the model is available for this recognizer with no network. */
+    fun isDownloaded(): Boolean = model.isDownloaded()
+
+    /**
+     * Download the model ahead of time so the first [recognize] is instant. A
+     * no-op once available (see [isDownloaded]). Suspends on a background
+     * dispatcher.
+     */
+    suspend fun download() = model.download()
+
+    /**
+     * Recognize a stroke given as ordered [points] (canvas coordinates). Returns
+     * the snapped [Shape], or `null` when the stroke is rejected or degenerate.
+     * Loads the model lazily on first call.
+     */
+    suspend fun recognize(points: List<Point>, options: Options = Options()): Shape? {
+        // Fewer than two points cannot be a stroke, so it is answered here rather
+        // than by waking the model.
+        if (points.size < 2) return null
+        // Input payload: an int point count, then an x and a y per point. Options
+        // payload: the f64 minimum confidence. Result payload: a 0/1 present
+        // flag, then the shape's kind and that kind's fields. All three must
+        // match Sources/Shapes/Binding.swift.
+        val input = FfiWriter().int(points.size)
+        for (p in points) input.double(p.x).double(p.y)
+        val opts = FfiWriter().double(options.minimumConfidence).done()
+        return model.run(input.done(), opts, failureMessage = "recognition failed", decode = ::decodeShape)
+    }
+
+    /** Release the native model. The recognizer is unusable afterwards; calling
+     *  this again is a no-op. */
+    @Synchronized override fun close() = model.close()
+}
+
+/** Decode the result payload Sources/Shapes/Binding.swift writes. */
+private fun decodeShape(r: FfiReader): Shape? {
+    if (r.int() == 0) return null
+    return when (r.int()) {
+        1 -> Shape.Line(r.point(), r.point())
+        2 -> Shape.Rectangle(r.points())
+        3 -> Shape.Triangle(r.points())
+        4 -> Shape.Ellipse(r.point(), r.double(), r.double(), r.double())
+        5 -> Shape.Star(r.point(), r.double(), r.double(), r.double(), r.int())
+        // A kind this SDK does not know is a core newer than the AAR. Report it
+        // as "no shape" rather than half-decoding a payload we cannot read.
+        else -> null
+    }
+}
+
+private fun FfiReader.point(): Point = Point(double(), double())
+
+private fun FfiReader.points(): List<Point> = List(int()) { point() }

--- a/packages/shapes-kotlin/src/main/kotlin/ai/desertant/shapes/ShapesNative.kt
+++ b/packages/shapes-kotlin/src/main/kotlin/ai/desertant/shapes/ShapesNative.kt
@@ -1,0 +1,13 @@
+package ai.desertant.shapes
+
+import ai.desertant.core.NativeLibraries
+import ai.desertant.core.NativeModelApi
+
+internal object ShapesNative : NativeModelApi {
+    override fun ensureLoaded() = NativeLibraries.loadModel("ShapesAndroid")
+    override external fun create(modelId: ByteArray, cacheRoot: ByteArray?, directory: ByteArray?): Long
+    override external fun destroy(handle: Long)
+    override external fun isDownloaded(handle: Long): Int
+    override external fun download(handle: Long): Int
+    override external fun run(handle: Long, input: ByteArray, options: ByteArray?): ByteArray?
+}

--- a/packages/shapes-node/README.md
+++ b/packages/shapes-node/README.md
@@ -1,0 +1,96 @@
+# @desert-ant-labs/shapes
+
+On-device single-stroke shape recognition for JavaScript that runs in the browser and in Node. Give Shapes one hand-drawn stroke and it returns a clean vector shape: a line, rectangle, triangle, ellipse, or star. Strokes stay local.
+
+A small classifier proposes a shape, a geometric fitter produces the clean parameters, and the stroke is accepted only if it clears that class's calibrated confidence and residual gates. The result snaps to nice axes, circles, squares, and 15 degree rotations.
+
+Two entries share one `Shapes` API:
+
+- **`@desert-ant-labs/shapes`** (default): a WebAssembly pipeline with [LiteRT.js](https://www.npmjs.com/package/@litertjs/core) inference, for the **browser**. It has no native dependencies, so a single import builds cleanly for every target of a multi-target bundler (Next.js, Remix, SvelteKit, Nuxt), including the browser bundle and the Client-Component SSR pass those frameworks render in Node. It is safe to *import* during server-side rendering, but LiteRT.js needs a browser (or Web Worker) to initialize, so `Shapes.load()` runs inference only in the browser; calling it in plain Node throws an actionable error pointing you to `/native`.
+- **`@desert-ant-labs/shapes/native`**: a prebuilt native core, Core ML on macOS and LiteRT on Linux, for **server-side inference** in Node. No `@litertjs/core`, no build tools, no flags. Import it from server-only code (API routes, server actions, plain Node scripts). Do not import it from a component that also renders in the browser.
+
+```bash
+# Browser (default entry):
+npm i @desert-ant-labs/shapes @litertjs/core
+
+# Server-side inference in Node (/native entry) needs no extra install:
+npm i @desert-ant-labs/shapes
+```
+
+The model is downloaded from the Hugging Face Hub on first use at the SDK's pinned tag, then cached. Nothing model-sized is shipped in the npm tarball.
+
+```js
+import { Shapes } from "@desert-ant-labs/shapes";
+
+const shapes = await Shapes.load();
+const shape = await shapes.recognize(points);   // [{x, y}, ...] or [x0, y0, ...]
+// { kind: "ellipse", center: {x, y}, semiMajor, semiMinor, rotation }
+
+shapes.dispose(); // release the model (both builds)
+```
+
+Server-only code that wants the native core imports the same API from the
+`/native` subpath:
+
+```js
+import { Shapes } from "@desert-ant-labs/shapes/native"; // server only
+```
+
+## Shapes
+
+`recognize` returns `null` when the stroke is rejected or degenerate, otherwise one of these, discriminated by `kind`:
+
+- `line` - `from`, `to`
+- `rectangle` - `corners`, four points around the perimeter
+- `triangle` - `vertices`, three points
+- `ellipse` - `center`, `semiMajor`, `semiMinor`, `rotation` (radians)
+- `star` - `center`, `outerRadius`, `innerRadius`, `rotation` (radians), `pointCount`
+
+The kinds and field names are identical in Swift and Kotlin, so a stroke recognized on one platform describes itself the same way on every other.
+
+`recognize(points, { minimumConfidence })` raises the classifier threshold on top of each class's calibrated gate; the default `0` applies only the model's own gates.
+
+## Loading the model
+
+By default `Shapes.load()` downloads the model files from the Hugging Face Hub ([`desert-ant-labs/shapes`](https://huggingface.co/desert-ant-labs/shapes)) at the SDK's pinned tag, verifies them, and caches them. The browser build fetches the `.tflite` for LiteRT.js and caches it in the browser. The native build (`/native`) fetches the `.tflite` on Linux or the `.mlmodelc/` on macOS and caches it under the OS cache dir.
+
+To self-host or run fully offline, opt out of the Hub:
+
+- `directory`: an explicit model directory (native build, or the browser build under Node). Files already there are used offline, otherwise the model is downloaded into it.
+- `modelBaseUrl`: a base URL you serve the model files from, for example `"/assets/shapes/"` (browser build).
+
+`Shapes.load()` also accepts:
+
+- `cacheRoot`: base directory for the managed on-disk cache, default `~/.cache` (native build, or the browser build under Node).
+- `onProgress`: load or download progress callback, fraction in `[0, 1]`.
+
+Browser-build-only options:
+
+- `litert`: a bring-your-own `@litertjs/core` module.
+- `litertWasmDir`: URL or path to the LiteRT.js Wasm directory.
+- `accelerator`: one of `"wasm"`, `"webgpu"`, or `"webnn"`.
+
+## Bundlers and SSR
+
+The default `@desert-ant-labs/shapes` import is safe to use directly in components:
+it is pure JavaScript + WebAssembly with no native modules, so bundlers can build
+it for the browser and for the Node SSR pass from the same module graph with no
+configuration.
+
+The `@desert-ant-labs/shapes/native` subpath loads a native addon (via `koffi`) and
+is for server-only code. If you import it inside a framework that bundles server
+code (for example a Next.js Route Handler or Server Action), mark it external so
+the bundler does not try to bundle the native binary. In Next.js:
+
+```js
+// next.config.js
+module.exports = { serverExternalPackages: ["@desert-ant-labs/shapes"] };
+```
+
+## Platforms
+
+The native server build (`/native`) ships for linux-x64, linux-arm64, and darwin-arm64. Other Node platforms throw a clear error at `load()`; use the default WebAssembly build, the Swift package, or a browser for those.
+
+## License
+
+[Desert Ant Labs Source-Available License 1.0](./LICENSE.md): free below 100,000 monthly active devices per platform. Above that a commercial license is required. Full terms: https://license.desertant.com/1.0

--- a/packages/shapes-node/browser.js
+++ b/packages/shapes-node/browser.js
@@ -1,0 +1,27 @@
+// On-device shape recognition for JavaScript: the universal entry. It runs in
+// the browser and, via the platform seam, server-side in Node (the
+// Client-Component SSR pass frameworks render in Node), both on the same
+// WebAssembly + @litertjs/core (LiteRT.js) pipeline: XNNPACK-accelerated CPU
+// ("wasm") by default, with optional WebGPU in the browser.
+//
+// There is nothing model-specific left in the wiring: @desert-ant-labs/core owns
+// the LiteRT.js session, the Hub download, and the `modelBaseUrl` opt-out, and
+// the public API is `shapes.js` (shared with the native entry). For a prebuilt
+// native server core (no @litertjs/core, best server throughput), import
+// `@desert-ant-labs/shapes/native`.
+//
+// All node-only code lives behind the `#platform` import, which bundlers resolve
+// at build time by condition (browser -> platform-browser.js, otherwise
+// platform-node.js), so this file never references `node:*` and one import
+// builds cleanly for every target of a multi-target bundler.
+import * as platform from "#platform";
+import { createWasmSdk } from "@desert-ant-labs/core";
+import { PACKAGE_NAME } from "./codec.js";
+import { makeShapes } from "./shapes.js";
+
+// The wasm core instantiates at import time (top-level await); the model is only
+// wired in Shapes.load().
+export const Shapes = makeShapes(await createWasmSdk({
+  platform,
+  packageName: PACKAGE_NAME,
+}));

--- a/packages/shapes-node/codec.js
+++ b/packages/shapes-node/codec.js
@@ -1,0 +1,83 @@
+// Shapes' FFI payload schemas: the stroke a run takes, the options beside it,
+// and the shape it returns.
+//
+// These are the only model-specific part of talking to the core, and both cores
+// speak the same payloads - the native `dal_run` (node.js) and the WebAssembly
+// `run` (browser.js) - so they live here once instead of in each entry point.
+// Mirrors the reader/writer in Sources/Shapes/Binding.swift.
+import { FfiWriter } from "@desert-ant-labs/core";
+
+/** The catalog id: how both cores are asked for Shapes, and the key its
+ *  WebAssembly exports are registered under. */
+export const MODEL_ID = "shapes";
+
+export const PACKAGE_NAME = "@desert-ant-labs/shapes";
+
+/** Shape kinds, in the wire order Sources/Shapes/Binding.swift writes. Index 0
+ *  is unused: a `kind` is 1-based, because 0 is the "no shape" flag. */
+const KINDS = [null, "line", "rectangle", "triangle", "ellipse", "star"];
+
+/**
+ * Normalize the two accepted stroke spellings into a flat [x0, y0, x1, y1, ...]
+ * sequence: an array of `{x, y}` points, or an already-flat array of numbers.
+ * Both are common in canvas code, and accepting either here keeps the check out
+ * of the API surface.
+ */
+export function flattenPoints(points) {
+  const list = Array.from(points ?? []);
+  if (list.length === 0) return [];
+  if (typeof list[0] === "number") return list.map(Number);
+  const flat = [];
+  for (const p of list) {
+    flat.push(Number(p?.x ?? 0), Number(p?.y ?? 0));
+  }
+  return flat;
+}
+
+/** Input payload: `u32 count`, then that many `f64 x`, `f64 y` pairs. Mirrors
+ *  Shapes' `run(input:options:)` in Sources/Shapes/Binding.swift. */
+export function encodeInput(flat) {
+  const w = new FfiWriter().u32(Math.floor(flat.length / 2));
+  for (const value of flat) w.f64(value);
+  return w.done();
+}
+
+/** Options payload: `f64 minimumConfidence`. */
+export function encodeOptions({ minimumConfidence }) {
+  return new FfiWriter().f64(minimumConfidence).done();
+}
+
+/**
+ * Result payload: `u32 present` (0 when the stroke was rejected or degenerate,
+ * and nothing follows), else `u32 kind` and that kind's fields. `r` is an
+ * FfiReader already positioned at the payload.
+ */
+export function decodeShape(r) {
+  if (r.u32() === 0) return null;
+  const kind = KINDS[r.u32()];
+  const point = () => ({ x: r.f64(), y: r.f64() });
+  const points = () => Array.from({ length: r.u32() }, point);
+  switch (kind) {
+    case "line":
+      return { kind, from: point(), to: point() };
+    case "rectangle":
+      return { kind, corners: points() };
+    case "triangle":
+      return { kind, vertices: points() };
+    case "ellipse":
+      return { kind, center: point(), semiMajor: r.f64(), semiMinor: r.f64(), rotation: r.f64() };
+    case "star":
+      return {
+        kind,
+        center: point(),
+        outerRadius: r.f64(),
+        innerRadius: r.f64(),
+        rotation: r.f64(),
+        pointCount: r.u32(),
+      };
+    default:
+      // A kind this SDK does not know is a core newer than the package. Report
+      // it as "no shape" rather than half-decoding a payload we cannot read.
+      return null;
+  }
+}

--- a/packages/shapes-node/index.d.ts
+++ b/packages/shapes-node/index.d.ts
@@ -1,0 +1,126 @@
+// The model-specific half of this package's types. Everything that is the same
+// for every model - how a model is loaded, how a call is billed and attributed -
+// comes from @desert-ant-labs/core, so it is documented in one place.
+import type { CallOptions, ModelLoadOptions } from "@desert-ant-labs/core";
+
+/** A 2D point, in the same coordinate space as the input stroke. */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** A straight line segment. */
+export interface LineShape {
+  kind: "line";
+  from: Point;
+  to: Point;
+}
+
+/** A rectangle, as four corners in order around the perimeter. */
+export interface RectangleShape {
+  kind: "rectangle";
+  corners: Point[];
+}
+
+/** A triangle, as its three vertices. */
+export interface TriangleShape {
+  kind: "triangle";
+  vertices: Point[];
+}
+
+/** An ellipse with semi-axes and a rotation in radians. */
+export interface EllipseShape {
+  kind: "ellipse";
+  center: Point;
+  semiMajor: number;
+  semiMinor: number;
+  rotation: number;
+}
+
+/** A star alternating between `outerRadius` and `innerRadius`. */
+export interface StarShape {
+  kind: "star";
+  center: Point;
+  outerRadius: number;
+  innerRadius: number;
+  /** Rotation in radians. */
+  rotation: number;
+  pointCount: number;
+}
+
+/**
+ * A recognized, fitted shape, discriminated by `kind`. The field names and kinds
+ * are identical in Swift and Kotlin, so a stroke recognized on one platform
+ * describes itself the same way on every other.
+ */
+export type Shape =
+  | LineShape
+  | RectangleShape
+  | TriangleShape
+  | EllipseShape
+  | StarShape;
+
+/** Options for a single recognition call. */
+export interface RecognizeOptions extends CallOptions {
+  /**
+   * Minimum classifier confidence, on top of each class's calibrated gate
+   * (default `0`, which applies only the model's own gates).
+   */
+  minimumConfidence?: number;
+}
+
+/**
+ * How the model is loaded, from `@desert-ant-labs/core`: `directory` (Node) or
+ * `modelBaseUrl` (browser) adopt self-hosted files, `onProgress` reports the
+ * download, and the `litert*` / `accelerator` options tune the browser runtime.
+ * Model-agnostic, so it is declared once in core rather than restated per model.
+ */
+export type LoadOptions = ModelLoadOptions;
+
+/**
+ * On-device single-stroke shape recognition for JavaScript. The default
+ * `@desert-ant-labs/shapes` import is the browser WebAssembly + LiteRT.js build:
+ * it has no native dependencies, so it builds cleanly for every target of a
+ * multi-target bundler (Next, Remix, SvelteKit, Nuxt) and is safe to import
+ * during server-side rendering. LiteRT.js initializes only in a browser or Web
+ * Worker, so `Shapes.load()` runs inference in the browser; in plain Node it
+ * throws and directs you to the native build. For server-side inference in Node
+ * import `@desert-ant-labs/shapes/native` (a prebuilt native core, no
+ * `@litertjs/core`) from server-only code. Both expose this same `Shapes` API.
+ * Create one with `await Shapes.load(...)` and reuse it.
+ *
+ * ```ts
+ * const shapes = await Shapes.load();
+ * const shape = await shapes.recognize(points);   // Shape | null
+ * if (shape?.kind === "ellipse") shape.center;
+ * ```
+ */
+export declare class Shapes {
+  /** Use Shapes.load(); the constructor is internal. */
+  private constructor();
+  /**
+   * Load the model and return a ready recognizer. Downloads from the Hugging
+   * Face Hub at the pinned revision and caches by default; pass `directory`
+   * (Node) or `modelBaseUrl` (browser) to adopt self-hosted files instead.
+   */
+  static load(options?: LoadOptions): Promise<Shapes>;
+  /**
+   * Recognize one hand-drawn stroke, given either as `{x, y}` points or as a
+   * flat `[x0, y0, x1, y1, ...]` sequence. Returns the fitted shape, or `null`
+   * when the stroke is rejected or degenerate.
+   */
+  recognize(
+    points: readonly Point[] | readonly number[],
+    options?: RecognizeOptions,
+  ): Promise<Shape | null>;
+  /** Whether the model is usable with no network. */
+  isDownloaded(): boolean;
+  /**
+   * Run `body` with a fresh call-group id, so every `recognize({ group })`
+   * inside it bills as a single usage call. The group is released when `body`
+   * settles.
+   */
+  withCallGroup<T>(body: (group: string) => Promise<T>): Promise<T>;
+  /** Release the model. The recognizer is unusable afterwards. Both builds. */
+  dispose(): void;
+}

--- a/packages/shapes-node/node.js
+++ b/packages/shapes-node/node.js
@@ -1,0 +1,24 @@
+// On-device shape recognition for JavaScript, server-side (Node). This is the
+// `node` conditional-exports entry: the same Shapes API as the browser build,
+// but natively via the prebuilt Swift core (LiteRT/Core ML under the hood)
+// instead of WebAssembly + LiteRT.js. Consumers just `import { Shapes }` - Node
+// resolves this file, browsers resolve `browser.js`. No flags, no setup.
+//
+// The koffi harness (resolve native/<platform>-<arch>, load the runtime, bind
+// the generic `dal_*` C ABI, run blocking calls off the event loop) lives in
+// @desert-ant-labs/core/node, and the public API is `shapes.js`, shared with the
+// browser entry; this file only binds the two together.
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { createNativeSdk } from "@desert-ant-labs/core/node";
+import { MODEL_ID, PACKAGE_NAME } from "./codec.js";
+import { makeShapes } from "./shapes.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const Shapes = makeShapes(createNativeSdk({
+  here: HERE,
+  packageName: PACKAGE_NAME,
+  modelId: MODEL_ID,
+  coreName: "ShapesNode",
+}));

--- a/packages/shapes-node/package.json
+++ b/packages/shapes-node/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "@desert-ant-labs/shapes",
+  "version": "3.0.0",
+  "description": "On-device single-stroke shape recognition for JavaScript. Runs in the browser (WebAssembly + LiteRT.js) and server-side in Node (native), from one import.",
+  "type": "module",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "homepage": "https://desertant.com/models/shapes/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Desert-Ant-Labs/desert-ant-core.git",
+    "directory": "packages/shapes-node"
+  },
+  "keywords": [
+    "shape-recognition",
+    "smart-shapes",
+    "ink",
+    "stroke",
+    "on-device",
+    "wasm",
+    "litert",
+    "isomorphic"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./browser.js",
+  "browser": "./browser.js",
+  "types": "./index.d.ts",
+  "scripts": {
+    "test": "node --test test/shapes.test.mjs"
+  },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./browser.js"
+    },
+    "./native": {
+      "types": "./index.d.ts",
+      "default": "./node.js"
+    },
+    "./browser": {
+      "types": "./index.d.ts",
+      "default": "./browser.js"
+    },
+    "./wasm": "./dist/ShapesWeb.wasm"
+  },
+  "imports": {
+    "#platform": {
+      "browser": "./platform-browser.js",
+      "default": "./platform-node.js"
+    }
+  },
+  "files": [
+    "browser.js",
+    "codec.js",
+    "shapes.js",
+    "node.js",
+    "platform-browser.js",
+    "platform-node.js",
+    "index.d.ts",
+    "dist",
+    "native",
+    "LICENSE.md",
+    "README.md"
+  ],
+  "dependencies": {
+    "@bjorn3/browser_wasi_shim": "^0.3.0",
+    "@desert-ant-labs/core": "^3.0.0"
+  },
+  "optionalDependencies": {
+    "koffi": "^2.9.0"
+  },
+  "peerDependencies": {
+    "@litertjs/core": ">=2.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@litertjs/core": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@litertjs/core": "^2.5.2"
+  }
+}

--- a/packages/shapes-node/platform-browser.js
+++ b/packages/shapes-node/platform-browser.js
@@ -1,0 +1,16 @@
+// Browser half of the platform seam for the universal WebAssembly entry
+// (browser.js). Bundlers resolve this file through the "browser" import
+// condition of `#platform` (see package.json "imports"), so none of the
+// node-only code in platform-node.js ever enters the browser module graph.
+// This is what lets one `@desert-ant-labs/shapes` import build cleanly for the
+// browser target of multi-target bundlers (Next, Remix, SvelteKit, Nuxt). The
+// shared instantiation logic lives in @desert-ant-labs/core.
+import { browserSetup, browserWasmDir, browserReadModelSource, browserCacheRoot } from "@desert-ant-labs/core";
+
+export function setupCore() {
+  return browserSetup({ init: () => import("./dist/index.js") });
+}
+
+export const defaultWasmDir = browserWasmDir;
+export const readModelSource = browserReadModelSource;
+export const defaultCacheRoot = browserCacheRoot;

--- a/packages/shapes-node/platform-node.js
+++ b/packages/shapes-node/platform-node.js
@@ -1,0 +1,23 @@
+// Node half of the platform seam for the universal WebAssembly entry
+// (browser.js) when it runs server-side, e.g. the Client-Component SSR pass a
+// framework renders in Node. The node-only work (WASI instantiate + node fs
+// seam) lives in @desert-ant-labs/core/platform-node; this file binds it to
+// Shapes' host/exports globals and dist entry points. Bundlers resolve this file
+// only through the non-browser ("default") condition of `#platform`, so the
+// browser bundle never sees `node:*`.
+//
+// This imports the koffi-free "/platform-node" entry, never "/node": the native
+// loader behind "/node" drags koffi's native addons into the SSR chunk, which
+// bundlers cannot place in ESM output.
+import { nodeSetup, nodeWasmDir, nodeReadModelSource, nodeCacheRoot } from "@desert-ant-labs/core/platform-node";
+
+export function setupCore() {
+  return nodeSetup({
+    instantiate: () => import("./dist/instantiate.js"),
+    nodePlatform: () => import("./dist/platforms/node.js"),
+  });
+}
+
+export const defaultWasmDir = nodeWasmDir;
+export const readModelSource = nodeReadModelSource;
+export const defaultCacheRoot = nodeCacheRoot;

--- a/packages/shapes-node/shapes.js
+++ b/packages/shapes-node/shapes.js
@@ -1,0 +1,73 @@
+// Shapes' public API, over whichever core the entry point bound: the browser's
+// WebAssembly + LiteRT.js core (browser.js) or the prebuilt native core
+// (node.js). Both expose the same ABI, and @desert-ant-labs/core turns either
+// one into the same `LoadedModel`, so the API is written once here instead of
+// once per runtime.
+import { decodeShape, encodeInput, encodeOptions, flattenPoints } from "./codec.js";
+
+/**
+ * Build the `Shapes` class over a bound SDK (`createWasmSdk` / `createNativeSdk`).
+ * The entry points do nothing but call this.
+ */
+export function makeShapes(sdk) {
+  /**
+   * On-device single-stroke shape recognition. Create one with
+   * `await Shapes.load(...)` and reuse it, mirroring the Swift SDK.
+   *
+   * ```js
+   * const shapes = await Shapes.load();          // downloads the model on first use, cached
+   * const shape = await shapes.recognize(points); // { kind: "ellipse", ... } | null
+   * shapes.dispose();
+   * ```
+   */
+  return class Shapes {
+    #model;
+    constructor(model) { this.#model = model; }
+
+    /**
+     * Load the model and return a ready recognizer. By default the model is
+     * downloaded from the Hugging Face Hub at the pinned revision, verified, and
+     * cached (the filesystem under Node, the runtime's cache in the browser).
+     * Pass `directory` (Node) or `modelBaseUrl` (browser) to use files you host
+     * yourself. The repo and revision are pinned to the SDK.
+     */
+    static async load(options = {}) {
+      return new Shapes(await sdk.open(options));
+    }
+
+    /**
+     * Recognize one hand-drawn stroke and return the fitted shape, or `null`
+     * when the stroke is rejected or too short to mean anything. `points` is
+     * either `[{x, y}, ...]` or a flat `[x0, y0, x1, y1, ...]`.
+     *
+     * `options.minimumConfidence` (default `0`) raises the classifier threshold
+     * on top of each class's calibrated gate. `options.deviceId` (a string or a
+     * zero-arg function returning one) attributes usage to a specific end-user
+     * device; it is collected per call, so it is safe for concurrent
+     * multi-tenant hosts. `options.group` (an id from {@link withCallGroup})
+     * bills several calls as one.
+     */
+    async recognize(points, options = {}) {
+      const flat = flattenPoints(points);
+      if (flat.length < 4) return null;   // fewer than two points is degenerate
+      const payload = encodeOptions({
+        minimumConfidence: Number(options.minimumConfidence ?? 0),
+      });
+      return decodeShape(
+        await this.#model.run(encodeInput(flat), payload, options));
+    }
+
+    /** Whether the model is usable with no network. */
+    isDownloaded() { return this.#model.isDownloaded(); }
+
+    /**
+     * Run `body(group)` with a fresh call-group id, so every
+     * `recognize({ group })` inside it bills as a single usage call. The group
+     * is released when `body` settles.
+     */
+    withCallGroup(body) { return this.#model.withCallGroup(body); }
+
+    /** Release the model. The recognizer is unusable afterwards. */
+    dispose() { this.#model.dispose(); }
+  };
+}

--- a/packages/shapes-node/test/browser-case.js
+++ b/packages/shapes-node/test/browser-case.js
@@ -1,0 +1,42 @@
+// Shapes' case for the browser inference harness (js/test/browser/run.mjs).
+//
+// `run` executes inside headless Chromium against the real browser entry: the
+// Swift -> WebAssembly core plus LiteRT.js on shapes.tflite, with the model
+// downloaded from the Hub exactly as a consumer's first page load does. It must
+// return something structured-cloneable, since the harness reads it back out of
+// the page. `check` then runs in Node.
+
+export async function run({ Shapes }, { litert, litertWasmDir }) {
+  const shapes = await Shapes.load({ litert, litertWasmDir });
+  try {
+    const circle = Array.from({ length: 65 }, (_, i) => {
+      const t = (2 * Math.PI * i) / 64;
+      return { x: 100 + 80 * Math.cos(t), y: 100 + 80 * Math.sin(t) };
+    });
+    const drag = Array.from({ length: 41 }, (_, i) => ({ x: i * 5, y: i * 2 }));
+    return {
+      circle: await shapes.recognize(circle),
+      line: await shapes.recognize(drag),
+      degenerate: await shapes.recognize([{ x: 1, y: 1 }]),
+    };
+  } finally {
+    shapes.dispose();
+  }
+}
+
+export function check(result) {
+  // The same expectations the Swift and Kotlin suites assert, so "works in the
+  // browser" means the same thing it means everywhere else.
+  if (result.circle?.kind !== "ellipse") {
+    throw new Error(`expected an ellipse from a traced circle, got ${JSON.stringify(result.circle)}`);
+  }
+  if (Math.abs(result.circle.center.x - 100) > 8 || Math.abs(result.circle.semiMajor - 80) > 12) {
+    throw new Error(`ellipse geometry is off: ${JSON.stringify(result.circle)}`);
+  }
+  if (result.line?.kind !== "line") {
+    throw new Error(`expected a line from a straight drag, got ${JSON.stringify(result.line)}`);
+  }
+  if (result.degenerate !== null) {
+    throw new Error(`expected null for a one-point stroke, got ${JSON.stringify(result.degenerate)}`);
+  }
+}

--- a/packages/shapes-node/test/browser-in-node.test.mjs
+++ b/packages/shapes-node/test/browser-in-node.test.mjs
@@ -1,0 +1,42 @@
+// Proves the default entry (browser.js, the browser WebAssembly build) fails
+// loudly and helpfully when someone calls Shapes.load() in plain Node. LiteRT.js
+// can only initialize in a browser or Web Worker, so server-side inference must
+// go through the native build. We import the default entry in a child Node
+// process (no DOM), call Shapes.load, and assert it rejects with guidance pointing
+// at `@desert-ant-labs/shapes/native`. This is the Node-observable contract; the
+// browser-only "install @litertjs/core" hint is covered by the browser example.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgDir = path.resolve(here, "..");
+const browserUrl = new URL("../browser.js", import.meta.url).href;
+
+const child = `
+const { Shapes } = await import(${JSON.stringify(browserUrl)});
+try {
+  await Shapes.load({});
+  console.log("NO_ERROR");
+} catch (e) {
+  console.log("ERR:" + e.message);
+}`;
+
+test("default entry redirects to /native when Shapes.load() runs in Node", () => {
+  const res = spawnSync(process.execPath, ["--input-type=module", "-e", child],
+    { cwd: pkgDir, encoding: "utf8", timeout: 120000 });
+  const out = (res.stdout || "") + (res.stderr || "");
+  assert.ok(out.includes("ERR:"), `expected a thrown error, got:\n${out}`);
+  assert.ok(/@desert-ant-labs\/shapes\/native/.test(out),
+    `expected a redirect to the native build, got:\n${out}`);
+});
+
+test("default entry imports cleanly in Node (SSR-safe)", () => {
+  const res = spawnSync(process.execPath,
+    ["--input-type=module", "-e", `await import(${JSON.stringify(browserUrl)}); console.log("IMPORTED_OK");`],
+    { cwd: pkgDir, encoding: "utf8", timeout: 120000 });
+  const out = (res.stdout || "") + (res.stderr || "");
+  assert.ok(out.includes("IMPORTED_OK"), `expected a clean import, got:\n${out}`);
+});

--- a/packages/shapes-node/test/shapes.test.mjs
+++ b/packages/shapes-node/test/shapes.test.mjs
@@ -1,0 +1,94 @@
+// The shapes-node test suite. Runs server-side in Node against the native core
+// (the `@desert-ant-labs/shapes/native` entry, i.e. node.js). The default
+// universal WebAssembly + LiteRT.js entry is exercised by the headless-Chromium
+// example.
+//
+// The npm package does not bundle the model: `Shapes.load()` downloads it from
+// the Hugging Face Hub at the pinned revision and caches it. We cover both load
+// paths: the default HF download (hits the network, skipped when offline) and an
+// explicit `directory` that adopts self-hosted files from an offline fixture
+// (test/fixtures/model), so the offline/self-hosted story stays green with no
+// network.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { Shapes } from "../node.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.join(HERE, "fixtures", "model");
+
+/** A traced circle, dense enough to look hand-drawn to the preprocessor. */
+function circle({ cx = 100, cy = 100, r = 80, samples = 64 } = {}) {
+  return Array.from({ length: samples + 1 }, (_, i) => {
+    const t = (2 * Math.PI * i) / samples;
+    return { x: cx + r * Math.cos(t), y: cy + r * Math.sin(t) };
+  });
+}
+
+/** The same circle as a flat [x0, y0, ...] sequence, the other accepted spelling. */
+function flatCircle() {
+  return circle().flatMap((p) => [p.x, p.y]);
+}
+
+// Prefer the offline fixture so the suite is hermetic; fall back to the default
+// HF download when the fixture is unavailable. Both exercise the same native
+// inference; only the resolve/adopt path differs.
+let shapes;
+let loadError;
+try {
+  shapes = await Shapes.load({ directory: FIXTURE_DIR });
+} catch (e) {
+  loadError = e;
+}
+const modelOpts = shapes ? {} : { skip: `native model unavailable: ${String(loadError).slice(0, 120)}` };
+
+test("recognizes a traced circle as a fitted ellipse", modelOpts, async () => {
+  const shape = await shapes.recognize(circle());
+  assert.equal(shape?.kind, "ellipse", `got ${JSON.stringify(shape)}`);
+  assert.ok(Math.abs(shape.center.x - 100) < 8, `center.x ${shape.center.x}`);
+  assert.ok(Math.abs(shape.center.y - 100) < 8, `center.y ${shape.center.y}`);
+  assert.ok(Math.abs(shape.semiMajor - 80) < 12, `semiMajor ${shape.semiMajor}`);
+  assert.ok(Math.abs(shape.semiMinor - 80) < 12, `semiMinor ${shape.semiMinor}`);
+});
+
+test("accepts a flat [x0, y0, ...] stroke too", modelOpts, async () => {
+  const shape = await shapes.recognize(flatCircle());
+  assert.equal(shape?.kind, "ellipse", `got ${JSON.stringify(shape)}`);
+});
+
+test("recognizes a straight drag as a line with endpoints", modelOpts, async () => {
+  const stroke = Array.from({ length: 41 }, (_, i) => ({ x: i * 5, y: i * 2 }));
+  const shape = await shapes.recognize(stroke);
+  assert.equal(shape?.kind, "line", `got ${JSON.stringify(shape)}`);
+  assert.ok(Math.hypot(shape.from.x - shape.to.x, shape.from.y - shape.to.y) > 100);
+});
+
+test("a degenerate stroke returns null", modelOpts, async () => {
+  assert.equal(await shapes.recognize([{ x: 1, y: 1 }]), null);
+  assert.equal(await shapes.recognize([]), null);
+});
+
+test("minimumConfidence rejects on top of the calibrated gates", modelOpts, async () => {
+  assert.equal(await shapes.recognize(circle(), { minimumConfidence: 1 }), null);
+});
+
+test.after(() => shapes?.dispose());
+
+// The default path downloads from the Hugging Face Hub at the pinned revision
+// and caches it. It needs network on a cold cache, so it is opt-in via
+// SHAPES_TEST_NETWORK=1 to keep the default suite hermetic.
+const networkOpts = process.env.SHAPES_TEST_NETWORK === "1"
+  ? {}
+  : { skip: "set SHAPES_TEST_NETWORK=1 to exercise the Hugging Face download path" };
+
+test("downloads from the Hugging Face Hub by default and caches", networkOpts, async () => {
+  const downloaded = await Shapes.load();
+  try {
+    const shape = await downloaded.recognize(circle());
+    assert.equal(shape?.kind, "ellipse", "expected a shape from the downloaded model");
+  } finally {
+    downloaded.dispose();
+  }
+});


### PR DESCRIPTION
Migrates the standalone `shapes` SDK into desert-ant-core, so it is built, tested, and released with every other model instead of on its own.

## What moves unchanged

The recognition pipeline: `StrokePreprocessor`, `Fitter`, `Snapping`, `Geometry`, the `ShapeMeta` sidecar parser, the Core ML/LiteRT tensor layout, and the Apple ergonomics (`CGPoint`/`CGPath` interop, `PKStroke`, and one-line PencilKit live snapping). Its unit tests come with it, including the preprocessor's Python-parity check.

## What becomes the shared shell

| Was | Now |
|---|---|
| a private `distribution()` helper, `modelRepo`/`modelRevision` constants | `Catalog.swift` (`ShapesModel: ModelDeclaration`) |
| a hand-written `LazyLoader`, three initializers, two availability helpers | `LoadedModel` |
| `CABI.swift` + `AndroidJNI.swift`: `shapes_run`, `shapes_create_bundled*`, `ShapesNative_*`, little-endian point marshalling | `Binding.swift` (payload schemas) + `Native.swift` (symbol names only) |
| hand-built `__ShapesExports` / `__ShapesHost` globals | one `installWasmModel` call over the generated BridgeJS surface |
| per-package loaders and wiring | the shared `ai.desertant:core` / `@desert-ant-labs/core` shells |

Shapes is the first model whose input is geometry rather than text or audio, and it needed no new entry point in any language: a stroke is `u32 count` then `f64 x, f64 y` pairs in the model's own payload, which is the argument `docs/development.md` already makes for the generic `run(input:options:)`. `Tests/BindingsTests/ShapesBindingTests.swift` pins that, including the distinction the old ABI blurred: a rejected stroke is a payload with `present = 0`, not a NULL buffer.

Nothing in `mise-tasks/`, `Tools/dal.sh`, `settings.gradle.kts`, or `.github/workflows/` changed. Every one of them discovers models from the filesystem, so `Sources/Shapes/Catalog.swift` plus the two package directories is the whole registration.

## Behaviour change: no bundled model

The standalone SDK bundled its artifact by default (a SwiftPM `BundledModel` trait, `ShapesCoreMLResources`/`ShapesTFLiteResources` targets, and a second `ai.desertant:shapes-tflite-resources` Maven artifact). That is dropped: the model downloads and caches like every other model, and shipping it with an app is pointing `directory` at a folder you populated. `Shapes(bundle:)` and `Shapes.bundled()` are gone; `ShapesError.resourceMissing` and every other public name is unchanged.

`sdkVersion` is `1.0.5`, matching the repo's `VERSION`, so shapes joins the single release train (npm `0.7.x` / Maven `0.4.6` are left behind).

## Verified

CI is green on all six jobs (`apple`, `linux`, `js`, `android`, `darwin-native`, `checks`), so every platform this repo ships runs the model.

Locally, before that:

- **Linux (LiteRT)** - the full `test:swift` suite, plus `test:wasi`, `test:node` (native core through koffi), `test:browser` (real headless Chromium, wasm + LiteRT.js), `test:bundles` (9 bundler/SSR scenarios), `check:types`, `check:isolation`, `check:swift-floor`.
- **Apple (Core ML)** - a traced circle through `Shapes(directory:)` on an M3 Ultra fits to `center=(100.024, 100.0) major=79.976 minor=79.976`, the same geometry LiteRT.js produced in Chromium, to the digit. Lines, triangles, degenerate strokes, and the `minimumConfidence` gate agree too.
- **Android** - both ABIs cross-compiled and the release AAR built; the instrumented suite ran on CI (no KVM on the dev box).

## Fixes found on the way

The Apple-only `ShapeSnapping.swift` (PencilKit live snapping) had never been compiled under this repo's Swift 6 settings, and did not build for iOS:

- `shapeSnapperKey` is a global whose *address* is the associated-object key and whose value is never read or written, now spelled `nonisolated(unsafe)`.
- `ShapeSnapper` is now `@MainActor`. Every member touches the canvas, the overlay, or UIKit touch state, and every entry point is already a main-thread callback; `previousDelegate` stays `nonisolated(unsafe)` because `responds(to:)` and `forwardingTarget(for:)` are `nonisolated` on NSObject and so cannot be overridden as isolated.
- The stroke builder used `PKStroke(ink:path:transform:renderGroupID:renderState:)` to carry grain-texture anchoring and wet-ink grouping across the swap. That initializer is iOS 27 / visionOS 27, which this repo's pinned Xcode has no SDK for, so it cannot be compiled even behind an `#available` check; it is removed with a note to restore it when the toolchain moves.