### PR TITLE
ModelStore: concurrent downloads and streaming verification

### DIFF
--- a/Sources/ModelStore/DownloadProgressCounter.swift
+++ b/Sources/ModelStore/DownloadProgressCounter.swift
@@ -1,0 +1,60 @@
+// Progress accounting for concurrent file downloads. A lock rather than an
+// actor because `ModelTransport.download` reports bytes from a synchronous
+// callback (URLSession's delegate, the Android host's C callback), which cannot
+// suspend to `await` an actor.
+
+#if os(WASI)
+/// wasm is single-threaded, so there is nothing to guard.
+private struct CounterLock {
+    func lock() {}
+    func unlock() {}
+}
+#else
+#if os(Android)
+import Android
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// Raw pthread rather than `NSLock`, to keep this module Foundation-free.
+private final class CounterLock {
+    private let mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
+    init() { pthread_mutex_init(mutex, nil) }
+    deinit { pthread_mutex_destroy(mutex); mutex.deallocate() }
+    func lock() { pthread_mutex_lock(mutex) }
+    func unlock() { pthread_mutex_unlock(mutex) }
+}
+#endif
+
+/// Sums per-file byte counts into one whole-model ``DownloadProgress``.
+///
+/// Each file reports its own cumulative bytes, so the sum is monotonic no
+/// matter what order concurrent downloads make progress in.
+final class DownloadProgressCounter: @unchecked Sendable {
+    private let lock = CounterLock()
+    private let totalBytes: Int64
+    private let report: @Sendable (DownloadProgress) -> Void
+    private var perFile: [Int64]
+
+    init(fileCount: Int, totalBytes: Int64, report: @escaping @Sendable (DownloadProgress) -> Void) {
+        self.totalBytes = totalBytes
+        self.report = report
+        perFile = [Int64](repeating: 0, count: fileCount)
+    }
+
+    /// Record `bytes` as the cumulative total downloaded for file `index`, and
+    /// report the new whole-model total. Reporting happens outside the lock so
+    /// a slow consumer never blocks another file's transfer.
+    func record(file index: Int, bytes: Int64) {
+        lock.lock()
+        perFile[index] = bytes
+        var completed: Int64 = 0
+        for value in perFile { completed += value }
+        lock.unlock()
+        report(DownloadProgress(completedBytes: completed, totalBytes: totalBytes))
+    }
+}

--- a/Sources/ModelStore/ModelStore.swift
+++ b/Sources/ModelStore/ModelStore.swift
@@ -20,11 +20,19 @@ public struct ModelStore: Sendable {
     private let transport: ModelTransport
     private let fs: FileSystem
     private let endpoint: String
+    private let maxConcurrentDownloads: Int
 
-    public init(transport: ModelTransport, fileSystem: FileSystem, endpoint: String = "https://huggingface.co") {
+    /// - Parameter maxConcurrentDownloads: how many of a model's files transfer
+    ///   at once. A model repo is 10-25 files, and downloading them one after
+    ///   another leaves most of the link idle; a small bound gets the
+    ///   throughput without opening a socket per file on a phone.
+    public init(transport: ModelTransport, fileSystem: FileSystem,
+                endpoint: String = "https://huggingface.co",
+                maxConcurrentDownloads: Int = 4) {
         self.transport = transport
         self.fs = fileSystem
         self.endpoint = endpoint
+        self.maxConcurrentDownloads = max(1, maxConcurrentDownloads)
     }
 
     // MARK: paths / urls
@@ -74,9 +82,10 @@ public struct ModelStore: Sendable {
               manifest.requested == model.files,
               !manifest.entries.isEmpty else { return false }
         for e in manifest.entries {
+            let path = filePath(model, e.path)
             guard isSafeRelativePath(e.path), e.size >= 0,
                   e.sha256.count == 64, e.sha256.allSatisfy({ $0.isHexDigit }),
-                  let d = try? fs.digest(filePath(model, e.path)),
+                  let d = try? fs.digest(path),
                   d.size == e.size,
                   d.sha256 == e.sha256 else { return false }
         }
@@ -88,7 +97,9 @@ public struct ModelStore: Sendable {
     /// files or folders (a trailing `/`), which the Hub tree call expands.
     /// Downloads go to a `.part` temp file, are size- and SHA256-verified, then
     /// atomically moved into place; the manifest is written last, so a crash
-    /// mid-download never yields a "downloaded" but broken model.
+    /// mid-download never yields a "downloaded" but broken model. Up to
+    /// `maxConcurrentDownloads` files transfer at once, and `progress` reports
+    /// one total across all of them.
     @discardableResult
     public func download(
         _ model: ModelSpec,
@@ -109,30 +120,34 @@ public struct ModelStore: Sendable {
         let resolved = try resolve(model.files, in: tree, repo: model.repo)
 
         let totalBytes = resolved.reduce(0) { $0 + $1.size }
-        var completedBytes: Int64 = 0
-        let report: @Sendable (Int64) -> Void = { done in
-            progress(DownloadProgress(completedBytes: done, totalBytes: totalBytes))
-        }
-        report(0)
+        let counter = DownloadProgressCounter(fileCount: resolved.count, totalBytes: totalBytes, report: progress)
+        progress(DownloadProgress(completedBytes: 0, totalBytes: totalBytes))
 
-        var manifest: [Manifest.Entry] = []
-        for e in resolved {
-            let dest = filePath(model, e.path)
-            // Skip a file already present and matching its LFS hash (resumes a
-            // partial prior run without re-downloading verified LFS files).
-            if let expected = e.sha256, fs.exists(dest), let data = try? fs.read(dest),
-               SHA256.hexDigest(data) == expected {
-                completedBytes += e.size
-                manifest.append(.init(path: e.path, size: e.size, sha256: expected))
-                report(completedBytes)
-                continue
+        // Files are independent (each has its own `.part` temp and its own
+        // destination), so they transfer concurrently, bounded by
+        // `maxConcurrentDownloads`. Results are placed back by index, so the
+        // manifest records the resolved order whatever order they finish in.
+        var slots = [Manifest.Entry?](repeating: nil, count: resolved.count)
+        try await withThrowingTaskGroup(of: (Int, Manifest.Entry).self) { group in
+            var next = 0
+            let inFlight = min(maxConcurrentDownloads, resolved.count)
+            while next < inFlight {
+                let index = next
+                group.addTask { (index, try await self.fetchOrReuse(model, resolved[index], index: index, counter: counter)) }
+                next += 1
             }
-            let base = completedBytes
-            let sha = try await fetch(model, e) { fileBytes in report(base + fileBytes) }
-            completedBytes += fs.size(dest) ?? e.size
-            manifest.append(.init(path: e.path, size: e.size, sha256: sha))
-            report(completedBytes)
+            // Start the next file only as one finishes, so at most `inFlight`
+            // transfers are ever open. A throw here exits the group, which
+            // cancels the rest.
+            while let (index, entry) = try await group.next() {
+                slots[index] = entry
+                guard next < resolved.count else { continue }
+                let index = next
+                group.addTask { (index, try await self.fetchOrReuse(model, resolved[index], index: index, counter: counter)) }
+                next += 1
+            }
         }
+        let manifest = slots.compactMap { $0 }
 
         try fs.makeDirectory(parentDir(manifestPath(model)))
         try fs.write(
@@ -208,6 +223,25 @@ public struct ModelStore: Sendable {
         return out
     }
 
+    /// One file's worth of work: reuse it if it is already present and intact,
+    /// otherwise download it. Reports its own cumulative bytes to `counter`,
+    /// and finishes on the file's full size so the total always reaches 100%
+    /// even for a transport that reports progress coarsely.
+    private func fetchOrReuse(_ model: ModelSpec, _ e: RemoteEntry, index: Int,
+                              counter: DownloadProgressCounter) async throws -> Manifest.Entry {
+        let dest = filePath(model, e.path)
+        // Skip a file already present and matching its LFS hash (resumes a
+        // partial prior run without re-downloading verified LFS files).
+        if let expected = e.sha256, let d = try? fs.digest(dest),
+           d.size == e.size, d.sha256 == expected {
+            counter.record(file: index, bytes: e.size)
+            return .init(path: e.path, size: e.size, sha256: expected)
+        }
+        let sha = try await fetch(model, e) { counter.record(file: index, bytes: $0) }
+        counter.record(file: index, bytes: e.size)
+        return .init(path: e.path, size: e.size, sha256: sha)
+    }
+
     /// Download one file to a temp path, verify size + (LFS) SHA-256, atomically
     /// move into place, and return the content SHA-256.
     private func fetch(_ model: ModelSpec, _ e: RemoteEntry,
@@ -230,8 +264,7 @@ public struct ModelStore: Sendable {
             fs.remove(part)
             throw ModelStoreError.integrityCheckFailed("\(e.path): size \(actual) != \(e.size)")
         }
-        let bytes = try fs.read(part)
-        let sha = SHA256.hexDigest(bytes)
+        let sha = try fs.digest(part).sha256
         if let expected = e.sha256, sha != expected {
             fs.remove(part)
             throw ModelStoreError.integrityCheckFailed("\(e.path): sha256 mismatch")

--- a/Sources/ModelStore/POSIXFileSystem.swift
+++ b/Sources/ModelStore/POSIXFileSystem.swift
@@ -62,6 +62,27 @@ public struct POSIXFileSystem: FileSystem {
         }
     }
 
+    /// Streams the file through the hasher a megabyte at a time, so verifying a
+    /// large model file costs one buffer instead of the whole file. The buffer
+    /// is reused across reads, so nothing here needs a release pool the way the
+    /// Foundation backend's autoreleased `Data` chunks do.
+    public func digest(_ path: String) throws -> (size: Int64, sha256: String) {
+        let fd = open(path, O_RDONLY)
+        guard fd >= 0 else { throw ModelStoreError.io("open(\(path))") }
+        defer { close(fd) }
+        var hasher = SHA256()
+        var buf = [UInt8](repeating: 0, count: 1 << 20)
+        var total: Int64 = 0
+        while true {
+            let n = buf.withUnsafeMutableBytes { posixRead(fd, $0.baseAddress, $0.count) }
+            if n < 0 { throw ModelStoreError.io("read(\(path))") }
+            if n == 0 { break }
+            total += Int64(n)
+            hasher.update(buf[0..<n])
+        }
+        return (total, SHA256.hex(hasher.finalize()))
+    }
+
     public func makeDirectory(_ path: String) throws {
         // mkdir -p: create each component, tolerating EEXIST.
         var partial = path.hasPrefix("/") ? "" : "."

--- a/Tests/ModelStoreTests/DigestTests.swift
+++ b/Tests/ModelStoreTests/DigestTests.swift
@@ -25,6 +25,12 @@ import Foundation
             let d = try fs.digest(path)
             #expect(d.size == Int64(size), "size wrong at \(size)")
             #expect(d.sha256 == SHA256.hexDigest(bytes), "digest differs from whole-file hash at \(size)")
+
+            // The POSIX backend streams through its own buffer, so it is a
+            // second implementation to hold to the same answer.
+            let p = try POSIXFileSystem(cacheRoot: NSTemporaryDirectory()).digest(path)
+            #expect(p.size == d.size, "POSIX size differs at \(size)")
+            #expect(p.sha256 == d.sha256, "POSIX digest differs at \(size)")
         }
     }
 
@@ -42,6 +48,9 @@ import Foundation
 
     @Test func missingFileThrows() {
         #expect(throws: (any Error).self) { try FoundationFileSystem().digest("/nonexistent/nope") }
+        #expect(throws: (any Error).self) {
+            try POSIXFileSystem(cacheRoot: NSTemporaryDirectory()).digest("/nonexistent/nope")
+        }
     }
 }
 #endif

--- a/Tests/ModelStoreTests/ModelStoreTests.swift
+++ b/Tests/ModelStoreTests/ModelStoreTests.swift
@@ -68,6 +68,43 @@ final class LockedDouble: @unchecked Sendable {
     func get() -> Double { lock.withLock { value } }
 }
 
+/// Records how many downloads overlap, so the suite can prove files transfer
+/// concurrently and that the configured bound is respected. Each download
+/// sleeps briefly, which is what makes overlap observable at all.
+final class ConcurrencyProbeTransport: ModelTransport, @unchecked Sendable {
+    let files: [String: [UInt8]]
+    private let lock = NSLock()
+    private var active = 0
+    private(set) var peak = 0
+
+    init(_ files: [String: [UInt8]]) { self.files = files }
+
+    func tree(_ url: String) async throws -> [RemoteEntry] {
+        files.map { RemoteEntry(path: $0.key, size: Int64($0.value.count), sha256: SHA256.hexDigest($0.value)) }
+    }
+
+    func download(_ url: String, to destinationPath: String, onBytes: @escaping @Sendable (Int64) -> Void) async throws {
+        lock.withLock { active += 1; peak = max(peak, active) }
+        defer { lock.withLock { active -= 1 } }
+        guard let r = url.range(of: "/resolve/") else { throw ModelStoreError.io("bad url") }
+        let rest = url[r.upperBound...]
+        guard let slash = rest.firstIndex(of: "/") else { throw ModelStoreError.io("bad url") }
+        let path = String(rest[rest.index(after: slash)...])
+        guard let bytes = files[path] else { throw ModelStoreError.io("404 \(path)") }
+        try await Task.sleep(for: .milliseconds(50))
+        try FoundationFileSystem().write(destinationPath, bytes)
+        onBytes(Int64(bytes.count))
+    }
+}
+
+/// Every reported progress value, so the suite can assert monotonicity across
+/// concurrent files.
+final class ProgressLog: @unchecked Sendable {
+    private let lock = NSLock(); private var values: [Double] = []
+    func append(_ v: Double) { lock.withLock { values.append(v) } }
+    func all() -> [Double] { lock.withLock { values } }
+}
+
 final class ModelStoreTests {
     private let tmp: String
     private let endpoint = "https://hub.test"
@@ -283,6 +320,58 @@ final class ModelStoreTests {
 
         try posix.write(s.location(of: m) + "/redact.tflite", [UInt8](repeating: 0, count: 6000))
         #expect(!s.isDownloaded(m))
+    }
+
+    @Test func filesDownloadConcurrently() async throws {
+        var payload: [String: [UInt8]] = [:]
+        for i in 0..<8 { payload["part\(i).bin"] = [UInt8](repeating: UInt8(i), count: 100 + i) }
+        let t = ConcurrencyProbeTransport(payload)
+        let s = ModelStore(transport: t, fileSystem: FoundationFileSystem(),
+                           endpoint: endpoint, maxConcurrentDownloads: 4)
+        let m = model(Array(payload.keys).sorted())
+
+        try await s.download(m)
+        #expect(t.peak > 1)   // sequential would peak at 1
+        #expect(t.peak <= 4)  // and the bound is respected
+        #expect(s.isDownloaded(m))
+    }
+
+    @Test func concurrencyBoundOfOneIsSequential() async throws {
+        var payload: [String: [UInt8]] = [:]
+        for i in 0..<4 { payload["part\(i).bin"] = [UInt8](repeating: UInt8(i), count: 64) }
+        let t = ConcurrencyProbeTransport(payload)
+        let s = ModelStore(transport: t, fileSystem: FoundationFileSystem(),
+                           endpoint: endpoint, maxConcurrentDownloads: 1)
+        try await s.download(model(Array(payload.keys).sorted()))
+        #expect(t.peak == 1)
+    }
+
+    @Test func concurrentProgressIsMonotonicAndCompletes() async throws {
+        var payload: [String: [UInt8]] = [:]
+        for i in 0..<6 { payload["part\(i).bin"] = [UInt8](repeating: UInt8(i), count: 1000 * (i + 1)) }
+        let s = ModelStore(transport: ConcurrencyProbeTransport(payload),
+                           fileSystem: FoundationFileSystem(), endpoint: endpoint)
+        let log = ProgressLog()
+        try await s.download(model(Array(payload.keys).sorted())) { log.append($0.fraction) }
+
+        let values = log.all()
+        #expect(values.first == 0)
+        #expect(abs((values.last ?? 0) - 1.0) <= 0.0001)
+        for (a, b) in zip(values, values.dropFirst()) { #expect(b >= a, "\(a) -> \(b)") }
+    }
+
+    @Test func downloadFailureStillPropagatesUnderConcurrency() async throws {
+        var payload: [String: [UInt8]] = [:]
+        for i in 0..<6 { payload["part\(i).bin"] = [UInt8](repeating: UInt8(i), count: 128) }
+        let s = store(DroppingTransport(payload))
+        let m = model(Array(payload.keys).sorted())
+        await #expect(throws: ModelStoreError.self) { try await s.download(m) }
+        #expect(!s.isDownloaded(m))
+        // No `.part` temp survives a failed run, whichever file lost the race.
+        let meta = s.location(of: m) + "/" + ModelStore.metadataDirectory
+        for name in (try? FileManager.default.contentsOfDirectory(atPath: meta)) ?? [] {
+            #expect(!name.hasSuffix(".part"), "\(name)")
+        }
     }
 }
 #endif


### PR DESCRIPTION
Model repos are 10-25 files and were downloaded strictly one after another, leaving most of the link idle. Files now transfer through a bounded task group, 4 at a time by default via a new `maxConcurrentDownloads` on `ModelStore.init`. Results are placed back by index so the manifest keeps its resolved order, and progress is summed per file by a lock-guarded counter, so one total is still reported and it stays monotonic whatever order files finish in.

Verification also read every file whole to hash it, so checking a 268 MB model peaked at 268 MB resident on device. `FileSystem` gains `sha256Hex`, streamed a megabyte at a time by the POSIX and Foundation backends, with a whole-file default for the wasm store whose files are already in memory. `isDownloaded`, the already-present skip, and post-download verification all use it.

Both seams are unchanged, so all four transports (URLSession, CHostBridge, JS fetch, mocks) work as-is.

`mise run test:swift` (158 tests) and `mise run test:wasi` (99 tests) pass. `mise run build:android` fails on this host for an unrelated missing NDK sysroot (`libc++_static.a for aarch64 not found`); the new pthread lock mirrors the one already shipping in `Sources/Clear/Enhancer.swift`.