### PR TITLE
Add manifest.json, the model registry every surface reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       # One version across the repo is only a property if something checks it
       # before release day.
       - run: mise run check:version
+      - run: mise run check:manifest
       # The .d.ts files are the API every TypeScript consumer sees, and they are
       # hand-written. This job has no built core, so it checks that they compile;
       # the js job runs the same task after build:wasm, where it also proves the

--- a/README.md
+++ b/README.md
@@ -42,11 +42,16 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 | **Align** | Word-timestamp refinement for Apple's `SpeechAnalyzer` pipeline, 9 languages | `Align` | Apple-only | Apple-only | [Hugging Face](https://huggingface.co/desert-ant-labs/align) |
 | **Tongue** | Language identification for short text, 84 languages | `Tongue` | `ai.desertant:tongue` | `@desert-ant-labs/tongue` | Bundled (2 MB) |
 | **Shapes** | Single-stroke shape recognition: one hand-drawn stroke to clean vector geometry | `Shapes` | `ai.desertant:shapes` | `@desert-ant-labs/shapes` | [Hugging Face](https://huggingface.co/desert-ant-labs/shapes) |
+| **Uhm** | Filler-word detection: frame-precise "uh"/"um"/"hmm" spans | `Uhm` | Apple-only | Apple-only | [Hugging Face](https://huggingface.co/desert-ant-labs/uhm) |
 
 Each model behaves the same on every platform, so you can build a feature once
-and ship it everywhere. New models are added regularly; the current set is always
-this table, and the weights live on [Hugging
-Face](https://huggingface.co/desert-ant-labs).
+and ship it everywhere. New models are added regularly, and the weights live on
+[Hugging Face](https://huggingface.co/desert-ant-labs).
+
+[`manifest.json`](manifest.json) is the machine-readable version of this table,
+covering every Desert Ant Labs model rather than only the ones built here: what
+each one is called, which SDKs are live, where its weights are, and which
+languages it covers. Tooling should read it instead of hard-coding a list.
 
 ## Swift
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,503 @@
+{
+  "schemaVersion": 1,
+  "sdkVersion": "3.0.0",
+  "org": {
+    "name": "Desert Ant Labs",
+    "site": "https://desertant.com",
+    "github": "https://github.com/Desert-Ant-Labs",
+    "hub": "https://huggingface.co/desert-ant-labs",
+    "npmScope": "@desert-ant-labs",
+    "mavenGroup": "ai.desertant"
+  },
+  "license": {
+    "id": "desert-ant-labs-source-available-1.0",
+    "url": "https://license.desertant.com/1.0"
+  },
+  "models": [
+    {
+      "id": "align",
+      "name": "Align",
+      "summary": "Word-timestamp refinement for Apple's SpeechAnalyzer pipeline.",
+      "category": "Word timestamps",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Align", "platforms": ["apple"] },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/align",
+        "url": "https://huggingface.co/desert-ant-labs/align",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": null,
+      "demo": null
+    },
+    {
+      "id": "clear",
+      "name": "Clear",
+      "summary": "On-device speech enhancement: denoise, dereverb, and loudness-normalize.",
+      "category": "Speech enhancement",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Clear", "platforms": ["apple", "linux", "windows"] },
+        "kotlin": { "status": "live", "package": "ai.desertant:clear", "platforms": ["android"] },
+        "js": { "status": "live", "package": "@desert-ant-labs/clear", "platforms": ["web", "node"] }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/clear",
+        "url": "https://huggingface.co/desert-ant-labs/clear",
+        "revision": "v0.3.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml", "litert"],
+      "variants": [
+        { "id": "clear-studio", "default": true, "note": "Aggressive denoise and dereverb." },
+        { "id": "clear-natural", "default": false, "note": "Lighter touch, keeps more of the room." }
+      ],
+      "languages": null,
+      "demo": {
+        "space": "desert-ant-labs/clear-demo",
+        "embed": "https://desert-ant-labs-clear-demo.static.hf.space",
+        "page": "https://desertant.com/models/clear/"
+      }
+    },
+    {
+      "id": "clips",
+      "name": "Clips",
+      "summary": "On-device clip selection: a transcript's best non-overlapping moments, ranked.",
+      "category": "Clip selection",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Clips", "platforms": ["apple", "linux", "windows"] },
+        "kotlin": { "status": "planned" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/clips",
+        "url": "https://huggingface.co/desert-ant-labs/clips",
+        "revision": "v0.1.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml", "litert"],
+      "variants": [],
+      "languages": {
+        "count": null,
+        "codes": null,
+        "basis": "inherited",
+        "source": "https://huggingface.co/desert-ant-labs/clips"
+      },
+      "demo": null
+    },
+    {
+      "id": "emo",
+      "name": "Emo",
+      "summary": "Multilingual on-device emoji suggestion.",
+      "category": "Emoji suggestions",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Emo", "platforms": ["apple", "linux", "windows"] },
+        "kotlin": { "status": "live", "package": "ai.desertant:emo", "platforms": ["android"] },
+        "js": { "status": "live", "package": "@desert-ant-labs/emo", "platforms": ["web", "node"] }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/emo",
+        "url": "https://huggingface.co/desert-ant-labs/emo",
+        "revision": "v0.7.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml", "litert"],
+      "variants": [],
+      "languages": {
+        "count": 22,
+        "codes": ["ar", "cs", "da", "de", "en", "es", "fr", "hi", "id", "it", "ja", "ko", "nl", "pl", "pt", "ru", "sv", "th", "tr", "uk", "vi", "zh"],
+        "basis": "declared",
+        "source": "https://huggingface.co/desert-ant-labs/emo"
+      },
+      "demo": {
+        "space": "desert-ant-labs/emo-demo",
+        "embed": null,
+        "page": "https://desertant.com/models/emo/"
+      }
+    },
+    {
+      "id": "gist",
+      "name": "Gist",
+      "summary": "Multilingual on-device content topic tagging across a 36-topic taxonomy.",
+      "category": "Content topic tagging",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Gist", "platforms": ["apple", "linux", "windows"] },
+        "kotlin": { "status": "live", "package": "ai.desertant:gist", "platforms": ["android"] },
+        "js": { "status": "live", "package": "@desert-ant-labs/gist", "platforms": ["web", "node"] }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/gist",
+        "url": "https://huggingface.co/desert-ant-labs/gist",
+        "revision": "v2.2.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml", "litert"],
+      "variants": [
+        { "id": "multilingual", "default": true, "note": "36 topics, 101 languages, ~74 MB." },
+        { "id": "english", "default": false, "note": "Same 36 topics, English/Latin only, ~15 MB." }
+      ],
+      "languages": {
+        "count": 101,
+        "codes": null,
+        "basis": "inherited",
+        "source": "https://huggingface.co/minishlab/potion-multilingual-128M"
+      },
+      "demo": {
+        "space": "desert-ant-labs/gist-demo",
+        "embed": null,
+        "page": "https://desertant.com/models/gist/"
+      }
+    },
+    {
+      "id": "redact",
+      "name": "Redact",
+      "summary": "Multilingual on-device PII detection and redaction.",
+      "category": "PII redaction",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Redact", "platforms": ["apple", "linux", "windows"] },
+        "kotlin": { "status": "live", "package": "ai.desertant:redact", "platforms": ["android"] },
+        "js": { "status": "live", "package": "@desert-ant-labs/redact", "platforms": ["web", "node"] }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/redact",
+        "url": "https://huggingface.co/desert-ant-labs/redact",
+        "revision": "v0.4.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml", "litert"],
+      "variants": [],
+      "languages": {
+        "count": 27,
+        "codes": ["bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "ga", "hr", "hu", "is", "it", "lt", "lv", "mt", "nb", "nl", "nn", "pl", "pt", "ro", "sk", "sl", "sv"],
+        "basis": "declared",
+        "source": "https://huggingface.co/desert-ant-labs/redact"
+      },
+      "demo": {
+        "space": "desert-ant-labs/redact-demo",
+        "embed": "https://desert-ant-labs-redact-demo.static.hf.space",
+        "page": "https://desertant.com/models/redact/"
+      }
+    },
+    {
+      "id": "shapes",
+      "name": "Shapes",
+      "summary": "On-device single-stroke shape recognition.",
+      "category": "Shape recognition",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Shapes", "platforms": ["apple", "linux", "windows"] },
+        "kotlin": { "status": "live", "package": "ai.desertant:shapes", "platforms": ["android"] },
+        "js": { "status": "live", "package": "@desert-ant-labs/shapes", "platforms": ["web", "node"] }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/shapes",
+        "url": "https://huggingface.co/desert-ant-labs/shapes",
+        "revision": "v0.3.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml", "litert"],
+      "variants": [],
+      "languages": null,
+      "demo": {
+        "space": "desert-ant-labs/shapes-demo",
+        "embed": "https://desert-ant-labs-shapes-demo.static.hf.space",
+        "page": "https://desertant.com/models/shapes/"
+      }
+    },
+    {
+      "id": "title",
+      "name": "Title",
+      "summary": "On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text.",
+      "category": "Titles and descriptions",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Title", "platforms": ["apple"] },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/title",
+        "url": "https://huggingface.co/desert-ant-labs/title",
+        "revision": "v0.1.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["mlx"],
+      "variants": [],
+      "languages": {
+        "count": null,
+        "codes": null,
+        "basis": "inherited",
+        "source": "https://huggingface.co/desert-ant-labs/title"
+      },
+      "demo": null
+    },
+    {
+      "id": "tongue",
+      "name": "Tongue",
+      "summary": "On-device language identification for short text across 84 languages.",
+      "category": "Language identification",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Tongue", "platforms": ["apple", "linux", "windows"] },
+        "kotlin": { "status": "live", "package": "ai.desertant:tongue", "platforms": ["android"] },
+        "js": { "status": "live", "package": "@desert-ant-labs/tongue", "platforms": ["web", "node"] }
+      },
+      "weights": {
+        "source": "bundled",
+        "repo": "desert-ant-labs/tongue",
+        "url": "https://huggingface.co/desert-ant-labs/tongue",
+        "revision": "v1.0.0",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["pure"],
+      "variants": [],
+      "languages": {
+        "count": 84,
+        "codes": ["af", "am", "ar", "as", "az", "be", "bg", "bn", "bo", "ca", "chr", "cs", "cy", "da", "de", "dv", "el", "en", "eo", "es", "et", "eu", "fa", "fi", "fr", "ga", "gl", "gu", "he", "hi", "hr", "hu", "hy", "id", "is", "it", "ja", "ka", "kk", "km", "kn", "ko", "ku", "ky", "la", "lo", "lt", "lv", "mk", "ml", "mn", "mr", "ms", "my", "ne", "nl", "no", "or", "pa", "pl", "pt", "ro", "ru", "si", "sk", "sl", "sq", "sr", "st", "sv", "sw", "syr", "ta", "te", "th", "tl", "tr", "ug", "uk", "ur", "vi", "xh", "yo", "zh"],
+        "basis": "derived",
+        "source": "Sources/Tongue/Resources/tongue_meta.json"
+      },
+      "demo": {
+        "space": "desert-ant-labs/tongue-demo",
+        "embed": null,
+        "page": "https://desertant.com/models/tongue/"
+      }
+    },
+    {
+      "id": "uhm",
+      "name": "Uhm",
+      "summary": "On-device filler-word detection: frame-precise \"uh\"/\"um\"/\"hmm\" spans.",
+      "category": "Filler-word detection",
+      "lifecycle": "stable",
+      "visibility": "public",
+      "home": "desert-ant-core",
+      "sdks": {
+        "swift": { "status": "live", "package": "Uhm", "platforms": ["apple"] },
+        "kotlin": { "status": "planned" },
+        "js": { "status": "planned" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/uhm",
+        "url": "https://huggingface.co/desert-ant-labs/uhm",
+        "revision": "612592c10ad7b2a51f3237725448a1aad212480b",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [
+        { "id": "high", "default": true, "note": "DistilHuBERT. The base tier is unpublished." }
+      ],
+      "languages": {
+        "count": 5,
+        "codes": ["de", "en", "es", "fr", "nl"],
+        "basis": "declared",
+        "source": "https://huggingface.co/desert-ant-labs/uhm"
+      },
+      "demo": {
+        "space": "desert-ant-labs/uhm-demo",
+        "embed": "https://desert-ant-labs-uhm-demo.static.hf.space",
+        "page": "https://desertant.com/models/uhm/"
+      }
+    },
+    {
+      "id": "moderator",
+      "name": "Moderator",
+      "summary": "On-device NSFW image detection, trained only on licensed and synthetic data.",
+      "category": "Content moderation",
+      "lifecycle": "beta",
+      "visibility": "public",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/moderator",
+        "url": "https://huggingface.co/desert-ant-labs/moderator",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": null,
+      "demo": null
+    },
+    {
+      "id": "schemer",
+      "name": "Schemer",
+      "summary": "On-device structured extraction into a caller-supplied JSON schema.",
+      "category": "Structured extraction",
+      "lifecycle": "beta",
+      "visibility": "public",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/schemer",
+        "url": "https://huggingface.co/desert-ant-labs/schemer",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": {
+        "count": 13,
+        "codes": ["da", "de", "en", "es", "fr", "it", "ja", "nl", "no", "pl", "pt", "sv", "zh"],
+        "basis": "declared",
+        "source": "https://huggingface.co/desert-ant-labs/schemer"
+      },
+      "demo": {
+        "space": "desert-ant-labs/schemer-demo",
+        "embed": "https://desert-ant-labs-schemer-demo.static.hf.space",
+        "page": "https://desertant.com/models/schemer/"
+      }
+    },
+    {
+      "id": "eye",
+      "name": "Eye",
+      "summary": "On-device frame scoring: which shot to keep from a burst or a clip.",
+      "category": "Image and video scoring",
+      "lifecycle": "beta",
+      "visibility": "internal",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/eye",
+        "url": "https://huggingface.co/desert-ant-labs/eye",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": null,
+      "demo": null
+    },
+    {
+      "id": "face",
+      "name": "Face",
+      "summary": "On-device face matching across a photo library or through a video.",
+      "category": "Face matching",
+      "lifecycle": "beta",
+      "visibility": "internal",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/face",
+        "url": "https://huggingface.co/desert-ant-labs/face",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": null,
+      "demo": null
+    },
+    {
+      "id": "who",
+      "name": "Who",
+      "summary": "On-device speaker labeling: per-person turns with timestamps.",
+      "category": "Speaker diarization",
+      "lifecycle": "beta",
+      "visibility": "internal",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/who",
+        "url": "https://huggingface.co/desert-ant-labs/who",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": null,
+      "demo": null
+    },
+    {
+      "id": "toxic",
+      "name": "Toxic",
+      "summary": "On-device hate-speech triage for European languages.",
+      "category": "Hate speech triage",
+      "lifecycle": "experimental",
+      "visibility": "public",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "none" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/toxic",
+        "url": "https://huggingface.co/desert-ant-labs/toxic",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml", "litert"],
+      "variants": [],
+      "languages": {
+        "count": 23,
+        "codes": ["bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "ga", "hr", "hu", "it", "lt", "lv", "nl", "pl", "pt", "ro", "sk", "sl", "sv"],
+        "basis": "declared",
+        "source": "https://huggingface.co/desert-ant-labs/toxic"
+      },
+      "demo": null
+    }
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -136,6 +136,56 @@
       }
     },
     {
+      "id": "eye",
+      "name": "Eye",
+      "summary": "On-device frame scoring: which shot to keep from a burst or a clip.",
+      "category": "Image and video scoring",
+      "lifecycle": "beta",
+      "visibility": "internal",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/eye",
+        "url": "https://huggingface.co/desert-ant-labs/eye",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": null,
+      "demo": null
+    },
+    {
+      "id": "face",
+      "name": "Face",
+      "summary": "On-device face matching across a photo library or through a video.",
+      "category": "Face matching",
+      "lifecycle": "beta",
+      "visibility": "internal",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/face",
+        "url": "https://huggingface.co/desert-ant-labs/face",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": null,
+      "demo": null
+    },
+    {
       "id": "gist",
       "name": "Gist",
       "summary": "Multilingual on-device content topic tagging across a 36-topic taxonomy.",
@@ -173,6 +223,31 @@
       }
     },
     {
+      "id": "moderator",
+      "name": "Moderator",
+      "summary": "On-device NSFW image detection, trained only on licensed and synthetic data.",
+      "category": "Content moderation",
+      "lifecycle": "beta",
+      "visibility": "public",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/moderator",
+        "url": "https://huggingface.co/desert-ant-labs/moderator",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": null,
+      "demo": null
+    },
+    {
       "id": "redact",
       "name": "Redact",
       "summary": "Multilingual on-device PII detection and redaction.",
@@ -204,6 +279,40 @@
         "space": "desert-ant-labs/redact-demo",
         "embed": "https://desert-ant-labs-redact-demo.static.hf.space",
         "page": "https://desertant.com/models/redact/"
+      }
+    },
+    {
+      "id": "schemer",
+      "name": "Schemer",
+      "summary": "On-device structured extraction into a caller-supplied JSON schema.",
+      "category": "Structured extraction",
+      "lifecycle": "beta",
+      "visibility": "public",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "planned" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/schemer",
+        "url": "https://huggingface.co/desert-ant-labs/schemer",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml"],
+      "variants": [],
+      "languages": {
+        "count": 13,
+        "codes": ["da", "de", "en", "es", "fr", "it", "ja", "nl", "no", "pl", "pt", "sv", "zh"],
+        "basis": "declared",
+        "source": "https://huggingface.co/desert-ant-labs/schemer"
+      },
+      "demo": {
+        "space": "desert-ant-labs/schemer-demo",
+        "embed": "https://desert-ant-labs-schemer-demo.static.hf.space",
+        "page": "https://desertant.com/models/schemer/"
       }
     },
     {
@@ -300,6 +409,36 @@
       }
     },
     {
+      "id": "toxic",
+      "name": "Toxic",
+      "summary": "On-device hate-speech triage for European languages.",
+      "category": "Hate speech triage",
+      "lifecycle": "experimental",
+      "visibility": "public",
+      "home": null,
+      "sdks": {
+        "swift": { "status": "none" },
+        "kotlin": { "status": "none" },
+        "js": { "status": "none" }
+      },
+      "weights": {
+        "source": "hub",
+        "repo": "desert-ant-labs/toxic",
+        "url": "https://huggingface.co/desert-ant-labs/toxic",
+        "revision": "main",
+        "license": "desert-ant-labs-source-available-1.0"
+      },
+      "runtime": ["coreml", "litert"],
+      "variants": [],
+      "languages": {
+        "count": 23,
+        "codes": ["bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "ga", "hr", "hu", "it", "lt", "lv", "nl", "pl", "pt", "ro", "sk", "sl", "sv"],
+        "basis": "declared",
+        "source": "https://huggingface.co/desert-ant-labs/toxic"
+      },
+      "demo": null
+    },
+    {
       "id": "uhm",
       "name": "Uhm",
       "summary": "On-device filler-word detection: frame-precise \"uh\"/\"um\"/\"hmm\" spans.",
@@ -336,115 +475,6 @@
       }
     },
     {
-      "id": "moderator",
-      "name": "Moderator",
-      "summary": "On-device NSFW image detection, trained only on licensed and synthetic data.",
-      "category": "Content moderation",
-      "lifecycle": "beta",
-      "visibility": "public",
-      "home": null,
-      "sdks": {
-        "swift": { "status": "planned" },
-        "kotlin": { "status": "none" },
-        "js": { "status": "none" }
-      },
-      "weights": {
-        "source": "hub",
-        "repo": "desert-ant-labs/moderator",
-        "url": "https://huggingface.co/desert-ant-labs/moderator",
-        "revision": "main",
-        "license": "desert-ant-labs-source-available-1.0"
-      },
-      "runtime": ["coreml"],
-      "variants": [],
-      "languages": null,
-      "demo": null
-    },
-    {
-      "id": "schemer",
-      "name": "Schemer",
-      "summary": "On-device structured extraction into a caller-supplied JSON schema.",
-      "category": "Structured extraction",
-      "lifecycle": "beta",
-      "visibility": "public",
-      "home": null,
-      "sdks": {
-        "swift": { "status": "planned" },
-        "kotlin": { "status": "none" },
-        "js": { "status": "none" }
-      },
-      "weights": {
-        "source": "hub",
-        "repo": "desert-ant-labs/schemer",
-        "url": "https://huggingface.co/desert-ant-labs/schemer",
-        "revision": "main",
-        "license": "desert-ant-labs-source-available-1.0"
-      },
-      "runtime": ["coreml"],
-      "variants": [],
-      "languages": {
-        "count": 13,
-        "codes": ["da", "de", "en", "es", "fr", "it", "ja", "nl", "no", "pl", "pt", "sv", "zh"],
-        "basis": "declared",
-        "source": "https://huggingface.co/desert-ant-labs/schemer"
-      },
-      "demo": {
-        "space": "desert-ant-labs/schemer-demo",
-        "embed": "https://desert-ant-labs-schemer-demo.static.hf.space",
-        "page": "https://desertant.com/models/schemer/"
-      }
-    },
-    {
-      "id": "eye",
-      "name": "Eye",
-      "summary": "On-device frame scoring: which shot to keep from a burst or a clip.",
-      "category": "Image and video scoring",
-      "lifecycle": "beta",
-      "visibility": "internal",
-      "home": null,
-      "sdks": {
-        "swift": { "status": "planned" },
-        "kotlin": { "status": "none" },
-        "js": { "status": "none" }
-      },
-      "weights": {
-        "source": "hub",
-        "repo": "desert-ant-labs/eye",
-        "url": "https://huggingface.co/desert-ant-labs/eye",
-        "revision": "main",
-        "license": "desert-ant-labs-source-available-1.0"
-      },
-      "runtime": ["coreml"],
-      "variants": [],
-      "languages": null,
-      "demo": null
-    },
-    {
-      "id": "face",
-      "name": "Face",
-      "summary": "On-device face matching across a photo library or through a video.",
-      "category": "Face matching",
-      "lifecycle": "beta",
-      "visibility": "internal",
-      "home": null,
-      "sdks": {
-        "swift": { "status": "planned" },
-        "kotlin": { "status": "none" },
-        "js": { "status": "none" }
-      },
-      "weights": {
-        "source": "hub",
-        "repo": "desert-ant-labs/face",
-        "url": "https://huggingface.co/desert-ant-labs/face",
-        "revision": "main",
-        "license": "desert-ant-labs-source-available-1.0"
-      },
-      "runtime": ["coreml"],
-      "variants": [],
-      "languages": null,
-      "demo": null
-    },
-    {
       "id": "who",
       "name": "Who",
       "summary": "On-device speaker labeling: per-person turns with timestamps.",
@@ -467,36 +497,6 @@
       "runtime": ["coreml"],
       "variants": [],
       "languages": null,
-      "demo": null
-    },
-    {
-      "id": "toxic",
-      "name": "Toxic",
-      "summary": "On-device hate-speech triage for European languages.",
-      "category": "Hate speech triage",
-      "lifecycle": "experimental",
-      "visibility": "public",
-      "home": null,
-      "sdks": {
-        "swift": { "status": "none" },
-        "kotlin": { "status": "none" },
-        "js": { "status": "none" }
-      },
-      "weights": {
-        "source": "hub",
-        "repo": "desert-ant-labs/toxic",
-        "url": "https://huggingface.co/desert-ant-labs/toxic",
-        "revision": "main",
-        "license": "desert-ant-labs-source-available-1.0"
-      },
-      "runtime": ["coreml", "litert"],
-      "variants": [],
-      "languages": {
-        "count": 23,
-        "codes": ["bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "ga", "hr", "hu", "it", "lt", "lv", "nl", "pl", "pt", "ro", "sk", "sl", "sv"],
-        "basis": "declared",
-        "source": "https://huggingface.co/desert-ant-labs/toxic"
-      },
       "demo": null
     }
   ]

--- a/mise-tasks/check/manifest
+++ b/mise-tasks/check/manifest
@@ -37,6 +37,7 @@ eq("manifest.json", manifest.sdkVersion, version, "sdkVersion");
 const models = manifest.models;
 const ids = models.map((m) => m.id);
 if (new Set(ids).size !== ids.length) fail("manifest.json", "duplicate model ids");
+if (String(ids) !== String([...ids].sort())) fail("manifest.json", "models must be ordered by id, A-Z");
 
 for (const m of models) {
   const at = `${m.id}`;

--- a/mise-tasks/check/manifest
+++ b/mise-tasks/check/manifest
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#MISE description="Verify manifest.json agrees with the catalog, the packages, and VERSION"
+#MISE dir="{{config_root}}"
+#MISE tools={node="22"}
+source "$MISE_PROJECT_ROOT/Tools/dal.sh"
+
+# manifest.json is the registry every other surface reads, so nothing in it may
+# be a second, hand-kept copy of a fact this repo already states. Models homed
+# here are checked field by field against Sources/<Product>/Catalog.swift, the
+# packages/ directory, and VERSION.
+
+export DAL_MODELS="$(dal_models | tr '\n' ' ')"
+
+node --input-type=module <<'NODE'
+import { readFileSync, existsSync } from "node:fs";
+
+const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
+const version = readFileSync("VERSION", "utf8").trim();
+
+let bad = 0;
+const fail = (where, message) => { console.error(`  ${where}: ${message}`); bad = 1; };
+const eq = (where, found, want, what) => {
+  if (found !== want) fail(where, `${what} is ${JSON.stringify(found)}, expected ${JSON.stringify(want)}`);
+};
+
+const LIFECYCLE = ["stable", "beta", "experimental", "deprecated"];
+const VISIBILITY = ["public", "internal"];
+const STATUS = ["live", "planned", "none"];
+const PLATFORMS = ["apple", "android", "linux", "windows", "web", "node"];
+const SOURCE = ["hub", "bundled", "none"];
+const RUNTIME = ["coreml", "litert", "mlx", "pure"];
+const BASIS = ["derived", "declared", "inherited"];
+
+eq("manifest.json", manifest.schemaVersion, 1, "schemaVersion");
+eq("manifest.json", manifest.sdkVersion, version, "sdkVersion");
+
+const models = manifest.models;
+const ids = models.map((m) => m.id);
+if (new Set(ids).size !== ids.length) fail("manifest.json", "duplicate model ids");
+
+for (const m of models) {
+  const at = `${m.id}`;
+  if (m.id !== m.id.toLowerCase() || !m.id) fail(at, "id must be lowercase and non-empty");
+  if (m.name?.[0] !== m.name?.[0]?.toUpperCase()) fail(at, "name must be capitalized");
+  if (!m.summary?.endsWith(".")) fail(at, "summary must be one sentence ending in a period");
+  if (!LIFECYCLE.includes(m.lifecycle)) fail(at, `lifecycle ${m.lifecycle}`);
+  if (!VISIBILITY.includes(m.visibility)) fail(at, `visibility ${m.visibility}`);
+  if (!m.runtime.every((r) => RUNTIME.includes(r))) fail(at, `runtime ${m.runtime}`);
+  if (!SOURCE.includes(m.weights.source)) fail(at, `weights.source ${m.weights.source}`);
+  if (m.weights.repo && m.weights.url !== `https://huggingface.co/${m.weights.repo}`)
+    fail(at, "weights.url does not match weights.repo");
+
+  for (const [sdk, decl] of Object.entries(m.sdks)) {
+    if (!STATUS.includes(decl.status)) fail(`${at}/${sdk}`, `status ${decl.status}`);
+    if (decl.status === "none" && decl.package) fail(`${at}/${sdk}`, "status none but a package is named");
+    if (decl.status === "live" && !decl.package) fail(`${at}/${sdk}`, "status live but no package");
+    if (decl.platforms && !decl.platforms.every((p) => PLATFORMS.includes(p)))
+      fail(`${at}/${sdk}`, `platforms ${decl.platforms}`);
+  }
+
+  // A model this repo does not build carries its own SDK version; one built
+  // here must not, because VERSION already governs it.
+  const ownVersion = Object.values(m.sdks).some((s) => s.version);
+  if (m.home === "desert-ant-core" && ownVersion) fail(at, "homed here, so it must not pin its own sdks.*.version");
+  if (m.home !== "desert-ant-core" && m.sdks.swift.status === "live" && !ownVersion)
+    fail(at, "not homed here, so each live SDK needs its own version");
+
+  const langs = m.languages;
+  if (langs) {
+    if (!BASIS.includes(langs.basis)) fail(at, `languages.basis ${langs.basis}`);
+    if (langs.basis === "inherited") {
+      if (langs.codes !== null) fail(at, "inherited coverage must not enumerate codes");
+    } else {
+      if (!Array.isArray(langs.codes)) fail(at, `languages.basis ${langs.basis} requires codes`);
+      else {
+        eq(at, langs.count, langs.codes.length, "languages.count");
+        const sorted = [...langs.codes].sort();
+        if (String(sorted) !== String(langs.codes)) fail(at, "languages.codes must be sorted");
+        if (new Set(langs.codes).size !== langs.codes.length) fail(at, "duplicate language codes");
+      }
+    }
+  }
+}
+
+// Models built here: the manifest must name every one of them, and only them.
+const here = new Set(models.filter((m) => m.home === "desert-ant-core").map((m) => m.id));
+const built = process.env.DAL_MODELS.split(" ").filter(Boolean);
+for (const id of built) if (!here.has(id)) fail(id, "has a Catalog.swift but no manifest entry");
+for (const id of here) if (!built.includes(id)) fail(id, "claims home desert-ant-core but has no Catalog.swift");
+
+for (const id of built.filter((id) => here.has(id))) {
+  const m = models.find((x) => x.id === id);
+  const product = id[0].toUpperCase() + id.slice(1);
+  const swift = readFileSync(`Sources/${product}/Catalog.swift`, "utf8");
+  // A declared string is one or more literals joined by `+` (title's summary
+  // wraps across lines), and a literal may escape its own quotes (uhm's has
+  // three). Collect every literal in the statement and unescape.
+  const declared = (field) => {
+    const statement = swift.match(new RegExp(`${field} =((?:\\s*\\+?\\s*"(?:[^"\\\\]|\\\\.)*")+)`));
+    if (!statement) return undefined;
+    return [...statement[1].matchAll(/"((?:[^"\\]|\\.)*)"/g)]
+      .map((literal) => literal[1].replace(/\\(.)/g, "$1"))
+      .join("");
+  };
+
+  eq(id, m.name, declared("product"), "name");
+  eq(id, m.summary, declared("summary"), "summary");
+  eq(id, m.weights.revision, declared("revision"), "weights.revision");
+  eq(id, m.weights.repo, `desert-ant-labs/${id}`, "weights.repo");
+  eq(id, m.sdks.swift.package, product, "sdks.swift.package");
+
+  for (const [sdk, dir, name] of [
+    ["js", `packages/${id}-node`, `@desert-ant-labs/${id}`],
+    ["kotlin", `packages/${id}-kotlin`, `ai.desertant:${id}`],
+  ]) {
+    const ships = existsSync(dir);
+    if (ships && m.sdks[sdk].status !== "live") fail(`${id}/${sdk}`, `${dir} exists but status is ${m.sdks[sdk].status}`);
+    if (!ships && m.sdks[sdk].status === "live") fail(`${id}/${sdk}`, `status live but ${dir} does not exist`);
+    if (ships) eq(`${id}/${sdk}`, m.sdks[sdk].package, name, "package");
+  }
+}
+
+// Tongue's coverage is not a claim: the head's labels plus the script-decisive
+// codes are exactly what it can return.
+const meta = JSON.parse(readFileSync("Sources/Tongue/Resources/tongue_meta.json", "utf8"));
+const derived = [...new Set([...meta.labels, ...Object.values(meta.script_decisive)])].sort();
+const tongue = models.find((m) => m.id === "tongue").languages;
+if (String(tongue.codes) !== String(derived))
+  fail("tongue", `languages.codes disagree with tongue_meta.json (${derived.length} derived, ${tongue.codes.length} listed)`);
+
+if (bad) {
+  console.error("error: manifest.json disagrees with the repo");
+  process.exit(1);
+}
+console.log(`${models.length} models, ${here.size} built here`);
+NODE

--- a/mise-tasks/check/version
+++ b/mise-tasks/check/version
@@ -13,6 +13,7 @@ check() { # <found> <where>
 }
 
 check "$(node -p 'require("./js/package.json").version')" "js/package.json"
+check "$(node -p 'require("./manifest.json").sdkVersion')" "manifest.json"
 
 for model in $(dal_models); do
     product=$(dal_product "$model")

--- a/mise-tasks/set-version
+++ b/mise-tasks/set-version
@@ -14,6 +14,11 @@ grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' <<<"$version" \
 # cannot reference a file and therefore has to be rewritten.
 echo "$version" > VERSION
 
+# manifest.json restates it for consumers that read the registry alone. Edited
+# in place rather than reserialized, so the hand-formatted file keeps its shape.
+sed -i.bak -E 's|("sdkVersion": ")[0-9]+\.[0-9]+\.[0-9]+|\1'"$version"'|' \
+    manifest.json && rm -f manifest.json.bak
+
 # npm keeps package.json and its lockfile in sync.
 ( cd js && npm version "$version" --no-git-tag-version --allow-same-version > /dev/null )
 
@@ -48,4 +53,5 @@ sed -i.bak -E \
     README.md && rm -f README.md.bak
 
 mise run check:version > /dev/null
+mise run check:manifest > /dev/null
 echo "everything set to $version"


### PR DESCRIPTION
`manifest.json` at the repo root: one file naming every Desert Ant Labs model — 16 of them, not just the 10 built here — so the website, docs and tooling can stop hard-coding lists and synthesising coordinates from slugs. Per model: name, summary, category, lifecycle, visibility, home repo, per-SDK status and package coordinate, weights source/repo/revision/license, runtime, variants, languages, demo links.

`check:manifest` runs in CI and holds it to the repo, so nothing in it is a second hand-kept copy: SDK versions stay out because `VERSION` already governs them (the manifest mirrors it once, written by `set-version`), while weights revisions do vary per model and are checked against the Swift catalog. Language codes are enumerated only where they are knowable — derived from an artifact we ship (tongue's 84, recomputed on every run), or declared on the model card. Coverage inherited from a base model's pretraining carries no codes, so gist does not publish 101 codes it cannot stand behind.

Also adds Uhm to the README model table, which was missing it. Two things worth a look: emo is listed as 22 language codes, because its card says "23 languages" but lists 22, counting Chinese Simplified and Traditional separately; and clips and title say nothing about languages beyond `multilingual`, so both are `inherited` with a null count.