### PR TITLE
manifest: add taglines, fill in verified links, check they resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       # before release day.
       - run: mise run check:version
       - run: mise run check:manifest
+      - run: mise run check:links
       # The .d.ts files are the API every TypeScript consumer sees, and they are
       # hand-written. This job has no built core, so it checks that they compile;
       # the js job runs the same task after build:wasm, where it also proves the

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
     {
       "id": "align",
       "name": "Align",
+      "tagline": "Timestamps that land on the word.",
       "summary": "Word-timestamp refinement for Apple's SpeechAnalyzer pipeline.",
       "category": "Word timestamps",
       "lifecycle": "stable",
@@ -42,6 +43,7 @@
     {
       "id": "clear",
       "name": "Clear",
+      "tagline": "Studio sound, no cloud bill.",
       "summary": "On-device speech enhancement: denoise, dereverb, and loudness-normalize.",
       "category": "Speech enhancement",
       "lifecycle": "stable",
@@ -74,6 +76,7 @@
     {
       "id": "clips",
       "name": "Clips",
+      "tagline": "Find the moment worth posting.",
       "summary": "On-device clip selection: a transcript's best non-overlapping moments, ranked.",
       "category": "Clip selection",
       "lifecycle": "stable",
@@ -104,6 +107,7 @@
     {
       "id": "emo",
       "name": "Emo",
+      "tagline": "Faster than you can type.",
       "summary": "Multilingual on-device emoji suggestion.",
       "category": "Emoji suggestions",
       "lifecycle": "stable",
@@ -138,6 +142,7 @@
     {
       "id": "eye",
       "name": "Eye",
+      "tagline": "Forty shots. One keeper.",
       "summary": "On-device frame scoring: which shot to keep from a burst or a clip.",
       "category": "Image and video scoring",
       "lifecycle": "beta",
@@ -158,11 +163,16 @@
       "runtime": ["coreml"],
       "variants": [],
       "languages": null,
-      "demo": null
+      "demo": {
+        "space": null,
+        "embed": null,
+        "page": "https://desertant.com/models/eye/"
+      }
     },
     {
       "id": "face",
       "name": "Face",
+      "tagline": "People search, no server.",
       "summary": "On-device face matching across a photo library or through a video.",
       "category": "Face matching",
       "lifecycle": "beta",
@@ -183,11 +193,16 @@
       "runtime": ["coreml"],
       "variants": [],
       "languages": null,
-      "demo": null
+      "demo": {
+        "space": null,
+        "embed": null,
+        "page": "https://desertant.com/models/face/"
+      }
     },
     {
       "id": "gist",
       "name": "Gist",
+      "tagline": "Know what any text is about.",
       "summary": "Multilingual on-device content topic tagging across a 36-topic taxonomy.",
       "category": "Content topic tagging",
       "lifecycle": "stable",
@@ -225,6 +240,7 @@
     {
       "id": "moderator",
       "name": "Moderator",
+      "tagline": "Flag nudity before upload.",
       "summary": "On-device NSFW image detection, trained only on licensed and synthetic data.",
       "category": "Content moderation",
       "lifecycle": "beta",
@@ -245,11 +261,16 @@
       "runtime": ["coreml"],
       "variants": [],
       "languages": null,
-      "demo": null
+      "demo": {
+        "space": null,
+        "embed": null,
+        "page": "https://desertant.com/models/moderator/"
+      }
     },
     {
       "id": "redact",
       "name": "Redact",
+      "tagline": "Personal data, gone before it moves.",
       "summary": "Multilingual on-device PII detection and redaction.",
       "category": "PII redaction",
       "lifecycle": "stable",
@@ -284,6 +305,7 @@
     {
       "id": "schemer",
       "name": "Schemer",
+      "tagline": "Typed JSON, no validation layer.",
       "summary": "On-device structured extraction into a caller-supplied JSON schema.",
       "category": "Structured extraction",
       "lifecycle": "beta",
@@ -318,6 +340,7 @@
     {
       "id": "shapes",
       "name": "Shapes",
+      "tagline": "Rough sketch. Perfect shape.",
       "summary": "On-device single-stroke shape recognition.",
       "category": "Shape recognition",
       "lifecycle": "stable",
@@ -347,6 +370,7 @@
     {
       "id": "title",
       "name": "Title",
+      "tagline": "Names what you just wrote.",
       "summary": "On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text.",
       "category": "Titles and descriptions",
       "lifecycle": "stable",
@@ -377,6 +401,7 @@
     {
       "id": "tongue",
       "name": "Tongue",
+      "tagline": "Name the language from three words.",
       "summary": "On-device language identification for short text across 84 languages.",
       "category": "Language identification",
       "lifecycle": "stable",
@@ -411,6 +436,7 @@
     {
       "id": "toxic",
       "name": "Toxic",
+      "tagline": "Catch hate speech before it posts.",
       "summary": "On-device hate-speech triage for European languages.",
       "category": "Hate speech triage",
       "lifecycle": "experimental",
@@ -436,11 +462,16 @@
         "basis": "declared",
         "source": "https://huggingface.co/desert-ant-labs/toxic"
       },
-      "demo": null
+      "demo": {
+        "space": "desert-ant-labs/toxic-demo",
+        "embed": null,
+        "page": "https://desertant.com/models/toxic/"
+      }
     },
     {
       "id": "uhm",
       "name": "Uhm",
+      "tagline": "An hour of audio in twelve seconds.",
       "summary": "On-device filler-word detection: frame-precise \"uh\"/\"um\"/\"hmm\" spans.",
       "category": "Filler-word detection",
       "lifecycle": "stable",
@@ -477,6 +508,7 @@
     {
       "id": "who",
       "name": "Who",
+      "tagline": "An interview, ready to cut.",
       "summary": "On-device speaker labeling: per-person turns with timestamps.",
       "category": "Speaker diarization",
       "lifecycle": "beta",
@@ -497,7 +529,11 @@
       "runtime": ["coreml"],
       "variants": [],
       "languages": null,
-      "demo": null
+      "demo": {
+        "space": null,
+        "embed": null,
+        "page": "https://desertant.com/models/who/"
+      }
     }
   ]
 }

--- a/mise-tasks/check/links
+++ b/mise-tasks/check/links
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#MISE description="Verify every URL manifest.json publishes actually resolves"
+#MISE dir="{{config_root}}"
+#MISE tools={node="22"}
+source "$MISE_PROJECT_ROOT/Tools/dal.sh"
+
+# Split from check:manifest because this one needs the network. The manifest is
+# about to be rendered into 16 Hub cards and two model tables, so one dead URL
+# here becomes a dead URL everywhere.
+
+node --input-type=module <<'NODE'
+import { readFileSync } from "node:fs";
+
+const models = JSON.parse(readFileSync("manifest.json", "utf8")).models;
+
+const targets = [];
+for (const m of models) {
+  // A gated repo answers 401 to anonymous requests, which is correct rather
+  // than broken, so it is not something this can check.
+  if (m.weights?.url && m.visibility !== "internal") targets.push([m.id, "weights.url", m.weights.url]);
+  if (m.demo?.page) targets.push([m.id, "demo.page", m.demo.page]);
+  if (m.demo?.embed) targets.push([m.id, "demo.embed", m.demo.embed]);
+  if (m.demo?.space) targets.push([m.id, "demo.space", `https://huggingface.co/spaces/${m.demo.space}`]);
+  if (m.languages?.source?.startsWith("http")) targets.push([m.id, "languages.source", m.languages.source]);
+}
+
+const results = await Promise.all(
+  targets.map(async ([id, field, url]) => {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const res = await fetch(url, { redirect: "follow", signal: AbortSignal.timeout(15000) });
+        if (res.ok) return null;
+        if (attempt === 2) return `  ${id} ${field}: ${res.status} ${url}`;
+      } catch (error) {
+        if (attempt === 2) return `  ${id} ${field}: ${error.message} ${url}`;
+      }
+      await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
+    }
+  })
+);
+
+const dead = results.filter(Boolean);
+if (dead.length) {
+  console.error(dead.join("\n"));
+  console.error(`error: ${dead.length} of ${targets.length} manifest URLs do not resolve`);
+  process.exit(1);
+}
+console.log(`${targets.length} URLs resolve`);
+NODE

--- a/mise-tasks/check/manifest
+++ b/mise-tasks/check/manifest
@@ -44,6 +44,10 @@ for (const m of models) {
   if (m.id !== m.id.toLowerCase() || !m.id) fail(at, "id must be lowercase and non-empty");
   if (m.name?.[0] !== m.name?.[0]?.toUpperCase()) fail(at, "name must be capitalized");
   if (!m.summary?.endsWith(".")) fail(at, "summary must be one sentence ending in a period");
+  // The tagline is the voice, the summary is the fact. Rendered in different
+  // places, so they must not collapse into each other.
+  if (!m.tagline?.endsWith(".")) fail(at, "tagline must end in a period");
+  if (m.tagline === m.summary) fail(at, "tagline must not restate the summary");
   if (!LIFECYCLE.includes(m.lifecycle)) fail(at, `lifecycle ${m.lifecycle}`);
   if (!VISIBILITY.includes(m.visibility)) fail(at, `visibility ${m.visibility}`);
   if (!m.runtime.every((r) => RUNTIME.includes(r))) fail(at, `runtime ${m.runtime}`);


### PR DESCRIPTION
First of four PRs syncing GitHub and Hugging Face from `manifest.json`. This one only corrects and extends the registry — nothing is rendered or published yet.

Adds a `tagline` to all 16 models, taken from the website's existing copy where one exists and written to match for align, clips and title. The tagline is the voice the Hub cards will lead with; `summary` stays the fact and is what both model tables will use. `check:manifest` requires one and rejects a tagline that just restates the summary.

Fills in links I had wrong or missing: `toxic` has a live demo Space, and eye, face, moderator, toxic and who all have live website pages. Align, clips and title stay null — they genuinely have no page. New `check:links` task verifies every URL the manifest publishes actually resolves and runs in CI; it skips gated repos, where a 401 is correct rather than broken. 48 URLs currently resolve.