### PR TITLE
Generate the README model table from manifest.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - run: mise run check:version
       - run: mise run check:manifest
       - run: mise run check:links
+      - run: mise run check:docs
       # The .d.ts files are the API every TypeScript consumer sees, and they are
       # hand-written. This job has no built core, so it checks that they compile;
       # the js job runs the same task after build:wasm, where it also proves the

--- a/README.md
+++ b/README.md
@@ -37,25 +37,37 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 
 ## Models
 
-| Model | What it does | Swift | Android | Web and Node | Weights |
-|---|---|---|---|---|---|
-| **Emo** | Multilingual emoji suggestion from short text, 23 languages | `Emo` | `ai.desertant:emo` | `@desert-ant-labs/emo` | [Hugging Face](https://huggingface.co/desert-ant-labs/emo) |
-| **Redact** | PII detection and reversible redaction, 27 languages | `Redact` | `ai.desertant:redact` | `@desert-ant-labs/redact` | [Hugging Face](https://huggingface.co/desert-ant-labs/redact) |
-| **Clear** | Speech enhancement: denoise, dereverb, podcast-ready 48 kHz | `Clear` | `ai.desertant:clear` | `@desert-ant-labs/clear` | [Hugging Face](https://huggingface.co/desert-ant-labs/clear) |
-| **Gist** | Content topic tagging over a 36-topic taxonomy, 101 languages | `Gist` | `ai.desertant:gist` | `@desert-ant-labs/gist` | [Hugging Face](https://huggingface.co/desert-ant-labs/gist) |
-| **Align** | Word-timestamp refinement for Apple's `SpeechAnalyzer` pipeline, 9 languages | `Align` | Apple-only | Apple-only | [Hugging Face](https://huggingface.co/desert-ant-labs/align) |
-| **Tongue** | Language identification for short text, 84 languages | `Tongue` | `ai.desertant:tongue` | `@desert-ant-labs/tongue` | Bundled (2 MB) |
-| **Shapes** | Single-stroke shape recognition: one hand-drawn stroke to clean vector geometry | `Shapes` | `ai.desertant:shapes` | `@desert-ant-labs/shapes` | [Hugging Face](https://huggingface.co/desert-ant-labs/shapes) |
-| **Uhm** | Filler-word detection: frame-precise "uh"/"um"/"hmm" spans | `Uhm` | Apple-only | Apple-only | [Hugging Face](https://huggingface.co/desert-ant-labs/uhm) |
+<!-- models:start -->
+| Model | What it does | SDKs | Weights | Status |
+| --- | --- | --- | --- | --- |
+| **Align** | Word-timestamp refinement for Apple's SpeechAnalyzer pipeline. | `Align` | [main](https://huggingface.co/desert-ant-labs/align) | Stable |
+| **Clear** | On-device speech enhancement: denoise, dereverb, and loudness-normalize. | `Clear` · `ai.desertant:clear` · `@desert-ant-labs/clear` | [v0.3.0](https://huggingface.co/desert-ant-labs/clear) | Stable |
+| **Clips** | On-device clip selection: a transcript's best non-overlapping moments, ranked. | `Clips` | [v0.1.0](https://huggingface.co/desert-ant-labs/clips) | Stable |
+| **Emo** | Multilingual on-device emoji suggestion. | `Emo` · `ai.desertant:emo` · `@desert-ant-labs/emo` | [v0.7.0](https://huggingface.co/desert-ant-labs/emo) | Stable |
+| **Eye** | On-device frame scoring: which shot to keep from a burst or a clip. | — | — | Closed beta |
+| **Face** | On-device face matching across a photo library or through a video. | — | — | Closed beta |
+| **Gist** | Multilingual on-device content topic tagging across a 36-topic taxonomy. | `Gist` · `ai.desertant:gist` · `@desert-ant-labs/gist` | [v2.2.0](https://huggingface.co/desert-ant-labs/gist) | Stable |
+| **Moderator** | On-device NSFW image detection, trained only on licensed and synthetic data. | — | [main](https://huggingface.co/desert-ant-labs/moderator) | Beta |
+| **Redact** | Multilingual on-device PII detection and redaction. | `Redact` · `ai.desertant:redact` · `@desert-ant-labs/redact` | [v0.4.0](https://huggingface.co/desert-ant-labs/redact) | Stable |
+| **Schemer** | On-device structured extraction into a caller-supplied JSON schema. | — | [main](https://huggingface.co/desert-ant-labs/schemer) | Beta |
+| **Shapes** | On-device single-stroke shape recognition. | `Shapes` · `ai.desertant:shapes` · `@desert-ant-labs/shapes` | [v0.3.0](https://huggingface.co/desert-ant-labs/shapes) | Stable |
+| **Title** | On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text. | `Title` | [v0.1.0](https://huggingface.co/desert-ant-labs/title) | Stable |
+| **Tongue** | On-device language identification for short text across 84 languages. | `Tongue` · `ai.desertant:tongue` · `@desert-ant-labs/tongue` | Bundled · [v1.0.0](https://huggingface.co/desert-ant-labs/tongue) | Stable |
+| **Toxic** | On-device hate-speech triage for European languages. | — | [main](https://huggingface.co/desert-ant-labs/toxic) | Experimental |
+| **Uhm** | On-device filler-word detection: frame-precise "uh"/"um"/"hmm" spans. | `Uhm` | [612592c](https://huggingface.co/desert-ant-labs/uhm) | Stable |
+| **Who** | On-device speaker labeling: per-person turns with timestamps. | — | — | Closed beta |
+<!-- models:end -->
 
 Each model behaves the same on every platform, so you can build a feature once
 and ship it everywhere. New models are added regularly, and the weights live on
-[Hugging Face](https://huggingface.co/desert-ant-labs).
+[Hugging Face](https://huggingface.co/desert-ant-labs). A model with SDK
+coordinates ships from this repo; the rest are published weights whose SDKs are
+still in progress.
 
-[`manifest.json`](manifest.json) is the machine-readable version of this table,
-covering every Desert Ant Labs model rather than only the ones built here: what
-each one is called, which SDKs are live, where its weights are, and which
-languages it covers. Tooling should read it instead of hard-coding a list.
+The table is generated from [`manifest.json`](manifest.json) by `mise run
+docs:render` — edit the manifest, not the rows. It is the registry every surface
+reads: what each model is called, which SDKs are live, where its weights are,
+and which languages it covers.
 
 ## Swift
 

--- a/Tools/manifest-docs.mjs
+++ b/Tools/manifest-docs.mjs
@@ -1,0 +1,62 @@
+// Renders manifest.json into the surfaces that publish it. One module so the
+// GitHub README table and the Hugging Face org card cannot disagree: they are
+// the same function over the same file.
+
+import { readFileSync } from "node:fs";
+
+export const MARKERS = { start: "<!-- models:start -->", end: "<!-- models:end -->" };
+
+export function manifest(root = ".") {
+  return JSON.parse(readFileSync(`${root}/manifest.json`, "utf8"));
+}
+
+/// Lifecycle and visibility are separate facts; readers want one word.
+function status(model) {
+  if (model.lifecycle === "beta" && model.visibility === "internal") return "Closed beta";
+  return model.lifecycle[0].toUpperCase() + model.lifecycle.slice(1);
+}
+
+/// Package coordinates for every SDK that ships, in Swift/Kotlin/JS order.
+function sdks(model) {
+  const live = ["swift", "kotlin", "js"]
+    .map((sdk) => model.sdks[sdk])
+    .filter((sdk) => sdk?.status === "live" && sdk.package)
+    .map((sdk) => `\`${sdk.package}\``);
+  return live.length ? live.join(" · ") : "—";
+}
+
+/// A commit pin is 40 characters of noise in a table cell; a tag is not.
+function short(revision) {
+  if (!revision) return "main";
+  const isCommit = revision.length === 40 && /^[0-9a-f]+$/.test(revision);
+  return isCommit ? revision.slice(0, 7) : revision;
+}
+
+/// A gated repo has nothing a reader can open, so it gets no link at all.
+function weights(model, { linkInternal = false } = {}) {
+  const { source, url, revision } = model.weights;
+  if (model.visibility === "internal" && !linkInternal) return "—";
+  if (source === "bundled") return revision ? `Bundled · [${revision}](${url})` : "Bundled";
+  if (source === "none" || !url) return "—";
+  return `[${short(revision)}](${url})`;
+}
+
+/// The table both surfaces publish. Rows follow the manifest's A-Z order.
+export function renderTable(models) {
+  const rows = models.map(
+    (m) => `| **${m.name}** | ${m.summary} | ${sdks(m)} | ${weights(m)} | ${status(m)} |`
+  );
+  return [
+    "| Model | What it does | SDKs | Weights | Status |",
+    "| --- | --- | --- | --- | --- |",
+    ...rows,
+  ].join("\n");
+}
+
+/// Replace the marked block in `text`, leaving every hand-written line alone.
+export function replaceBlock(text, body) {
+  const start = text.indexOf(MARKERS.start);
+  const end = text.indexOf(MARKERS.end);
+  if (start === -1 || end === -1) throw new Error(`missing ${MARKERS.start} / ${MARKERS.end} markers`);
+  return text.slice(0, start) + `${MARKERS.start}\n${body}\n` + text.slice(end);
+}

--- a/mise-tasks/check/docs
+++ b/mise-tasks/check/docs
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#MISE description="Verify the README model table matches manifest.json"
+#MISE dir="{{config_root}}"
+#MISE tools={node="22"}
+source "$MISE_PROJECT_ROOT/Tools/dal.sh"
+
+# A generated table that nothing checks is a table that goes stale between
+# releases. This fails the PR instead of committing a fix behind your back.
+
+node --input-type=module <<'NODE'
+import { readFileSync } from "node:fs";
+import { manifest, renderTable, replaceBlock } from "./Tools/manifest-docs.mjs";
+
+const current = readFileSync("README.md", "utf8");
+if (replaceBlock(current, renderTable(manifest().models)) !== current) {
+  console.error("error: README.md model table is stale. Run `mise run docs:render`.");
+  process.exit(1);
+}
+console.log("README.md model table is current");
+NODE

--- a/mise-tasks/docs/render
+++ b/mise-tasks/docs/render
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#MISE description="Render manifest.json into the README model table"
+#MISE dir="{{config_root}}"
+#MISE tools={node="22"}
+source "$MISE_PROJECT_ROOT/Tools/dal.sh"
+
+node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync } from "node:fs";
+import { manifest, renderTable, replaceBlock } from "./Tools/manifest-docs.mjs";
+
+const rendered = replaceBlock(readFileSync("README.md", "utf8"), renderTable(manifest().models));
+writeFileSync("README.md", rendered);
+console.log("README.md model table rendered");
+NODE


### PR DESCRIPTION
Second of four PRs syncing GitHub and Hugging Face from `manifest.json`. `Tools/manifest-docs.mjs` is one renderer both surfaces will call, so the README table and the Hub org card cannot drift — they are the same function over the same file. The org card and the model cards land in the next two PRs; nothing is published to the Hub yet.

`mise run docs:render` writes the table between `<!-- models:start -->` markers, leaving the surrounding prose hand-written. `mise run check:docs` re-renders and diffs, failing the PR on a stale table rather than committing a fix behind your back. Columns are Model · What it does · SDKs · Weights · Status, with `summary` as the description and `lifecycle` + `visibility` folded into one status word. Uhm's 40-character commit pin renders as `612592c`, and gated models get an em dash rather than a link, since there is nothing a reader can open.

Worth a look before it ships: the table is identical on both surfaces, so this README now lists all 16 models including the six not built here. I added a line distinguishing them — a model with SDK coordinates ships from this repo, the rest are published weights. Say the word if you would rather GitHub showed only what it builds; the renderer takes a filter either way.