### PR TITLE
Archive the Hub cards and render their replacements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       - run: mise run check:manifest
       - run: mise run check:links
       - run: mise run check:docs
+      - run: mise run hub:sync
       # The .d.ts files are the API every TypeScript consumer sees, and they are
       # hand-written. This job has no built core, so it checks that they compile;
       # the js job runs the same task after build:wasm, where it also proves the

--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ and ship it everywhere. New models are added regularly, and the weights live on
 coordinates ships from this repo; the rest are published weights whose SDKs are
 still in progress.
 
-The table is generated from [`manifest.json`](manifest.json) by `mise run
-docs:render` — edit the manifest, not the rows. It is the registry every surface
-reads: what each model is called, which SDKs are live, where its weights are,
-and which languages it covers.
-
 ## Swift
 
 ### Install

--- a/Tools/manifest-docs.mjs
+++ b/Tools/manifest-docs.mjs
@@ -53,6 +53,75 @@ export function renderTable(models) {
   ].join("\n");
 }
 
+/// Where a model's canonical docs live. Models with no repo of their own point
+/// at the org, which is the honest answer rather than a link to nothing.
+function github(model, org) {
+  return model.home ? `${org.github}/${model.home}` : org.github;
+}
+
+/// The Hub card body: what the model is, and where the real docs are. Anything
+/// longer belongs on GitHub, which this links to.
+export function renderCardBody(model, org) {
+  const links = [`- **SDKs and documentation:** ${github(model, org)}`];
+  if (model.demo?.page) links.push(`- **Website:** ${model.demo.page}`);
+  return [`# ${model.name}`, "", model.tagline, "", model.summary, "", ...links, ""].join("\n");
+}
+
+/// Front matter is HF's search index, not prose, so it survives the rewrite.
+/// Only the fields the manifest is authoritative for are replaced; `tags`,
+/// `pipeline_tag` and `library_name` are curated on the Hub and kept verbatim.
+export function mergeFrontMatter(existing, model) {
+  const owned = { license: "other" };
+  owned.license_name = model.weights.license;
+  owned.license_link = "https://license.desertant.com/1.0";
+  const codes = model.languages?.codes;
+  if (codes) owned.language = codes;
+  else if (model.languages) owned.language = ["multilingual"];
+
+  const blocks = parseBlocks(existing);
+  const rendered = [];
+  const seen = new Set();
+  for (const [key, lines] of blocks) {
+    if (key in owned) {
+      rendered.push(emit(key, owned[key]));
+      seen.add(key);
+    } else {
+      rendered.push(lines.join("\n"));
+    }
+  }
+  for (const [key, value] of Object.entries(owned)) {
+    if (!seen.has(key)) rendered.push(emit(key, value));
+  }
+  return rendered.join("\n");
+}
+
+/// Front matter as [key, rawLines] pairs, so unknown keys round-trip untouched
+/// rather than being reserialized by a parser this repo does not have.
+function parseBlocks(text) {
+  const blocks = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    if (/^[A-Za-z_][\w-]*:/.test(line)) blocks.push([line.slice(0, line.indexOf(":")), [line]]);
+    else if (blocks.length) blocks[blocks.length - 1][1].push(line);
+  }
+  return blocks;
+}
+
+function emit(key, value) {
+  return Array.isArray(value) ? [`${key}:`, ...value.map((v) => `- ${v}`)].join("\n") : `${key}: ${value}`;
+}
+
+/// A card's front matter and body, split on the `---` fences.
+export function splitCard(text) {
+  const match = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  return match ? { frontMatter: match[1], body: match[2] } : { frontMatter: "", body: text };
+}
+
+export function renderCard(existing, model, org) {
+  const front = mergeFrontMatter(splitCard(existing).frontMatter, model);
+  return `---\n${front}\n---\n\n${renderCardBody(model, org)}`;
+}
+
 /// Replace the marked block in `text`, leaving every hand-written line alone.
 export function replaceBlock(text, body) {
   const start = text.indexOf(MARKERS.start);

--- a/Tools/manifest-docs.mjs
+++ b/Tools/manifest-docs.mjs
@@ -67,30 +67,35 @@ export function renderCardBody(model, org) {
   return [`# ${model.name}`, "", model.tagline, "", model.summary, "", ...links, ""].join("\n");
 }
 
-/// Front matter is HF's search index, not prose, so it survives the rewrite.
-/// Only the fields the manifest is authoritative for are replaced; `tags`,
-/// `pipeline_tag` and `library_name` are curated on the Hub and kept verbatim.
+/// Front matter is HF's search index, not prose, so it survives the rewrite —
+/// but every field in it is the manifest's, so a card cannot drift from the
+/// registry. Unknown keys still round-trip untouched.
 export function mergeFrontMatter(existing, model) {
   const owned = { license: "other" };
   owned.license_name = model.weights.license;
   owned.license_link = "https://license.desertant.com/1.0";
+  // `undefined` drops the key: a model the manifest says has no languages must
+  // not keep one from the card it is replacing (clear's claimed `en`, for a
+  // denoiser).
   const codes = model.languages?.codes;
-  if (codes) owned.language = codes;
-  else if (model.languages) owned.language = ["multilingual"];
+  owned.language = codes ?? (model.languages ? ["multilingual"] : undefined);
+  owned.tags = model.hub.tags;
+  if (model.hub.pipelineTag) owned.pipeline_tag = model.hub.pipelineTag;
+  if (model.hub.libraryName) owned.library_name = model.hub.libraryName;
 
   const blocks = parseBlocks(existing);
   const rendered = [];
   const seen = new Set();
   for (const [key, lines] of blocks) {
     if (key in owned) {
-      rendered.push(emit(key, owned[key]));
+      if (owned[key] !== undefined) rendered.push(emit(key, owned[key]));
       seen.add(key);
     } else {
       rendered.push(lines.join("\n"));
     }
   }
   for (const [key, value] of Object.entries(owned)) {
-    if (!seen.has(key)) rendered.push(emit(key, value));
+    if (!seen.has(key) && value !== undefined) rendered.push(emit(key, value));
   }
   return rendered.join("\n");
 }

--- a/docs/hub-cards/_org.md
+++ b/docs/hub-cards/_org.md
@@ -1,0 +1,29 @@
+# Little brains in every product.
+
+A European AI lab building opinionated on-device models and SDKs.
+
+## Models
+
+| Model | What it does | Card | Demo | SDKs | Status |
+| --- | --- | --- | --- | --- | --- |
+| **Clear** | Audio enhancement, a 10-minute clip in ~5 seconds | [Model](https://huggingface.co/desert-ant-labs/clear) | [Demo](https://huggingface.co/spaces/desert-ant-labs/clear-demo) | [iOS](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Android](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Web](https://github.com/Desert-Ant-Labs/desert-ant-core) | Available |
+| **Emo** | Multi-language emoji suggestions, as fast as you can type | [Model](https://huggingface.co/desert-ant-labs/emo) | [Demo](https://huggingface.co/spaces/desert-ant-labs/emo-demo) | [iOS](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Android](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Web](https://github.com/Desert-Ant-Labs/desert-ant-core) | Available |
+| **Gist** | Content topic tagging, 36 topics across 101 languages | [Model](https://huggingface.co/desert-ant-labs/gist) | [Demo](https://huggingface.co/spaces/desert-ant-labs/gist-demo) | [iOS](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Android](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Web](https://github.com/Desert-Ant-Labs/desert-ant-core) | Available |
+| **Redact** | Filter PII from any input, on device, across 27 languages | [Model](https://huggingface.co/desert-ant-labs/redact) | [Demo](https://huggingface.co/spaces/desert-ant-labs/redact-demo) | [iOS](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Android](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Web](https://github.com/Desert-Ant-Labs/desert-ant-core) | Available |
+| **Shapes** | Anyone can draw, with fast cross-platform shape matching | [Model](https://huggingface.co/desert-ant-labs/shapes) | [Demo](https://huggingface.co/spaces/desert-ant-labs/shapes-demo) | [iOS](https://github.com/Desert-Ant-Labs/shapes) · [Android](https://github.com/Desert-Ant-Labs/shapes) · [Web](https://github.com/Desert-Ant-Labs/shapes) | Available |
+| **Tongue** | Names the language of a word or a phrase, across 84 languages | [Model](https://huggingface.co/desert-ant-labs/tongue) | [Demo](https://huggingface.co/spaces/desert-ant-labs/tongue-demo) | [iOS](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Android](https://github.com/Desert-Ant-Labs/desert-ant-core) · [Web](https://github.com/Desert-Ant-Labs/desert-ant-core) | Available |
+| **Uhm** | SOTA filler-word detection, zero inference cost | [Model](https://huggingface.co/desert-ant-labs/uhm) | [Demo](https://huggingface.co/spaces/desert-ant-labs/uhm-demo) | [iOS](https://github.com/Desert-Ant-Labs/desert-ant-core) | Available |
+| **Eye** | Pick the best images or frames. |  |  |  | Closed Beta |
+| **Face** | Lightning-fast face matching and search in your app |  |  |  | Closed Beta |
+| **Moderator** | On-device nudity detection before upload | [Model](https://huggingface.co/desert-ant-labs/moderator) |  |  | Closed Beta |
+| **Schemer** | Free text to typed JSON, no hallucinated fields | [Model](https://huggingface.co/desert-ant-labs/schemer) | [Demo](https://huggingface.co/spaces/desert-ant-labs/schemer-demo) |  | Closed Beta |
+| **Toxic** | Hate-speech and abuse triage in eight languages, fully on device | [Model](https://huggingface.co/desert-ant-labs/toxic) | [Demo](https://huggingface.co/spaces/desert-ant-labs/toxic-demo) |  | Closed Beta |
+| **Who** | Fast, on-device audio visual speaker diarization. |  |  |  | Closed Beta |
+
+Every model is free up to **100k Monthly Active Devices**. Unlimited inference per device.
+
+## SDKs
+
+Drop-in SDKs for **iOS, Android, and Web** ship with each available model, linked in the table above. More platforms and models are on the way.
+
+Email [contact@desertant.com](mailto:contact@desertant.com) for early access.

--- a/docs/hub-cards/align.md
+++ b/docs/hub-cards/align.md
@@ -1,0 +1,135 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.ai/1.0
+language:
+- multilingual
+tags:
+- speech
+- word-timestamps
+- forced-alignment
+- speech-recognition
+- on-device
+- core-ml
+- multilingual
+pipeline_tag: automatic-speech-recognition
+---
+
+# Align: on-device word-timestamp refinement for Apple SpeechAnalyzer
+
+Corrects the word-level timings that Apple's `SpeechTranscriber` and `SpeechAnalyzer`
+return, without replacing them. Align observes the same audio the analyzer already
+receives, runs a small Core ML cascade on the CPU and Neural Engine, and returns the
+familiar result surface with tightened `audioTimeRange` values. The models are tiny
+(**about 0.7 MB** compiled Core ML) and refine a typical result in a few milliseconds
+on device.
+
+> Apple: `"world"` 2.61-3.04s  ➜  Align: `"world"` 2.57-2.98s
+
+## Try it
+
+Ships as an Apple SwiftPM package: **[Desert-Ant-Labs/align](https://github.com/Desert-Ant-Labs/align)**.
+
+- **iOS / iPadOS / Mac Catalyst / macOS / tvOS / visionOS:** the Swift SDK (Swift Package
+  Manager). It bundles the compiled Core ML models below, so it works fully offline. The
+  package adds to apps with low deployment targets; the SpeechAnalyzer refinement APIs are
+  gated with `@available` and run on the 26 releases those frameworks require.
+- Add one input modifier (`inputs.recordingAudio(for: refiner)`) and one result modifier
+  (`transcriber.results.refiningTimestamps(with: refiner)`) to the standard Apple pipeline.
+
+## Files
+
+| File | Format | Size | Contents |
+|---|---|---:|---|
+| `align_coarse.mlmodelc` | Compiled Core ML (FP16) | ~0.3 MB | Coarse stage: searches a 241-frame (2.4 s) context, fixed batch-16 |
+| `align_fine.mlmodelc` | Compiled Core ML (FP16) | ~0.3 MB | Fine stage: searches an 81-frame (0.8 s) crop centered on the coarse prediction |
+| `mel_filters.bin` | Float32 filter bank | ~40 KB | Log-mel filter bank the runtime frontend needs |
+| `calibrator.bin` | Gradient-boosted trees | ~70 KB | Correction calibrator over coarse/fine uncertainty features |
+| `refiner_config.json` | JSON | tiny | Frontend, lexical, and language config the runtime needs |
+| `coarse.pt` | PyTorch checkpoint | ~0.5 MB | Coarse-stage weights (for retraining / other runtimes) |
+| `fine.pt` | PyTorch checkpoint | ~0.5 MB | Fine-stage weights (for retraining / other runtimes) |
+
+The compiled `.mlmodelc` stages, `mel_filters.bin`, `calibrator.bin`, and `refiner_config.json`
+are exactly what the Swift SDK bundles. The `.pt` checkpoints are the training-run weights.
+
+## Architecture
+
+A two-stage coarse-to-fine cascade over a log-mel spectrogram, refining one boundary at a time:
+
+- **Frontend**: an Accelerate/vDSP log-mel spectrogram of the same audio Apple transcribes.
+- **Coarse stage**: a compact convolutional model searches a 2.4 s context around Apple's
+  proposed boundary and predicts a distribution over frames.
+- **Fine stage**: a second model re-searches a 0.8 s crop recentered on the coarse prediction
+  for a tighter estimate.
+- **Lexical conditioning**: UTF-8 byte features of the neighboring words plus a language id let
+  a single model cover all nine languages.
+- **Calibrator**: a small gradient-boosted-tree policy maps coarse/fine uncertainty features to
+  a final correction, fit only on the validation split to reduce large regressions.
+- **Structural fallback**: boundaries whose correction would be invalid, hit the search-window
+  edge, or lack streaming context keep Apple's original timestamp.
+
+Each stage runs fixed batch-16 on CPU + Neural Engine. Total parameters are about 117k per stage.
+
+## Inputs and outputs
+
+- **Input:** mono audio plus Apple's recognized words with their proposed start/end times.
+- **Output:** the same words with corrected start/end times, or Apple's original time when a
+  correction is not structurally safe.
+
+## Accuracy
+
+Evaluated on the exact Swift runtime and these bundled Core ML models over 223 clean and 210
+noisy group-held-out recordings across all nine languages, against forced-alignment references.
+
+| Condition | Apple raw error | Align error | Reduction | Median | Within 50 ms |
+|---|---:|---:|---:|---:|---:|
+| Clean | 113.5 ms | 44.9 ms | 60% | 28.2 ms | 75.1% |
+| Noisy | 124.4 ms | 50.1 ms | 60% | 32.0 ms | 69.4% |
+
+Error is mean absolute distance from the reference boundary. Align roughly halves Apple's typical
+error and removes most of its large mistakes.
+
+## Languages
+
+English, Spanish, French, Italian, Portuguese, German, Japanese, Korean, and Chinese. A locale
+outside this set is passed through unchanged.
+
+## Limitations
+
+- References are machine forced-alignment estimates, not human annotations, so the figures show a
+  large, consistent reduction of Apple's timing error rather than sample-accurate ground truth.
+- A learned correction is not guaranteed to improve every boundary; the structural fallback keeps
+  Apple's timestamp when a correction looks unsafe but cannot catch every plausible-looking error.
+- English, Italian, Japanese, and Korean are the weakest languages under the current reference
+  convention.
+
+## Built on
+
+- [FLEURS](https://huggingface.co/datasets/google/fleurs) (CC BY 4.0): multilingual training audio.
+- [Qwen3-ForcedAligner-0.6B](https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B) (Apache-2.0):
+  primary word-boundary references for all nine languages.
+- OWSM-CTC v4 1B (CC BY 4.0): gross alignment-outlier check where validation agreement is stable.
+- Genuine Apple `SpeechAnalyzer` proposals collected on macOS 26.
+
+See [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). None of these systems are redistributed here.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.ai/1.0). Free for most apps;
+a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.ai>.
+
+## Citation
+
+```bibtex
+@software{align_2026,
+  title  = {Align: on-device word-timestamp refinement for Apple SpeechAnalyzer},
+  author = {Desert Ant Labs},
+  year   = {2026},
+  url    = {https://huggingface.co/desert-ant-labs/align},
+}
+```
+
+---
+
+© 2026 Desert Ant Labs · <https://desertant.ai>

--- a/docs/hub-cards/clear.md
+++ b/docs/hub-cards/clear.md
@@ -1,0 +1,168 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- en
+tags:
+- audio
+- speech
+- speech-enhancement
+- speech-denoising
+- noise-suppression
+- dereverberation
+- podcast
+- on-device
+- coreml
+- onnx
+- ios
+- android
+- deepfilternet
+pipeline_tag: audio-to-audio
+---
+
+# Clear
+
+On-device speech enhancement for podcasters, video creators and voice apps.
+
+**Messy recording in, clean audio out.** Reduce noise, clean up audio,
+normalize volume. Takes noisy 48 kHz mono or stereo audio (meeting
+recorders, bluetooth microphones, mobile device built-in mics, a laptop
+in a coffee shop) and returns rich, present, podcast-ready sound.
+
+Runs entirely on the Apple Neural Engine via Core ML and on Android via
+ONNX Runtime. The Core ML assets use the iOS 16 model format; the Swift SDK
+currently supports iOS 17+ and macOS 14+.
+
+## Sound
+
+Trained to deliver a **rich, present, close-miked podcast sound**.
+
+- **Denoised.**
+  HVAC, keyboard clicks, mouse rustle, mic bumps, room hum, laptop
+  fans, coffee shop background — all pulled down without chewing
+  consonants.
+- **Dereverbed.**
+  Untreated bedrooms, offices and hotel rooms come out sounding closer
+  to a treated studio. The model does not add reverberation of its own.
+- **Warm and present.**
+  Low-mids brought forward so voice sits comfortably in a mix rather
+  than sounding thin or distant.
+- **Sibilance-safe.**
+  No harsh peaks introduced when cleaning up S / T / F consonants.
+- **No pumping or musical-noise artefacts.**
+  Trained with a large detail-preservation loss so breaths, plosives
+  and vocal texture stay intact.
+
+## Variants
+
+Two variants ship. Their Core ML artifacts share the exact planar
+`spec / feat_erb / feat_spec → spec_enhanced` I/O contract and use a fixed
+batch of four independent two-second chunks. The ONNX artifacts retain their
+original DFN3 layout.
+
+### clear-studio
+
+The default. Quiet, studio-like character; silences sit close to true
+zero.
+
+Best for solo podcasts, tutorials, voiceover, video demos, screen
+recordings, and anything that wants a clean broadcast feel.
+
+| File | Purpose | Size |
+|---|---|---:|
+| `clear-studio.mlmodelc` | ANE-optimized Core ML (fp16 compute + 6-bit weight palette, iOS 16 target) | 9.0 MB |
+| `clear-studio.mlmodelc.zip` | Same compiled model, zipped | 8.6 MB |
+| `clear-studio.onnx` | Android / cross-platform ONNX (fp16 weights, fp32 I/O) | 24 MB |
+| `clear-studio.pt` | PyTorch checkpoint, for research and re-export | 46 MB |
+
+### clear-natural
+
+Preserves room tone, breath, and lip texture.
+
+For treated podcast studios, intentional voiceover, interviews where
+the room is part of the take, and remote guest recordings where
+absolute silence would sound wrong.
+
+| File | Purpose | Size |
+|---|---|---:|
+| `clear-natural.mlmodelc` | ANE-optimized Core ML (fp16 compute + 6-bit weight palette, iOS 16 target) | 9.0 MB |
+| `clear-natural.mlmodelc.zip` | Same compiled model, zipped | 8.6 MB |
+| `clear-natural.onnx` | Android / cross-platform ONNX | 24 MB |
+| `clear-natural.pt` | PyTorch checkpoint | 46 MB |
+
+## Performance
+
+The Core ML variants are optimized for the Apple Neural Engine.
+`MLComputePlan` confirms that all 492 model operations run on ANE.
+
+`clear-studio`, whole SDK pipeline on a 60-second clip, best of three:
+
+| Device | Realtime factor |
+|---|---:|
+| iPhone 16 Pro | **302x** |
+| MacBook Pro (M5) | **345x** |
+
+On iPhone 16 Pro, first-ever model loading takes approximately 3.4 seconds
+while Core ML compiles the ANE program. Cached launches load in approximately
+62 ms; applications should warm the model in the background.
+
+## Deployment target
+
+- **Core ML model** — iOS/iPadOS 16.0+ model format; ANE placement depends on hardware and OS.
+- **Swift SDK** — iOS 18+, macOS 15+, tvOS 18+, visionOS 2+.
+- **Android** — API 24+ (arm64-v8a, x86_64), via LiteRT.
+- **Other platforms** — the `.tflite` runs wherever LiteRT does: Linux, Windows, and the browser through LiteRT.js. The ONNX files are kept for runtimes the SDK does not cover.
+
+## Integration
+
+All three SDKs live in
+[`desert-ant-core`](https://github.com/Desert-Ant-Labs/desert-ant-core) and ship
+one version together.
+
+- **iOS / macOS.** Swift Package Manager: depend on `desert-ant-core` and take
+  its `Clear` product. The model is downloaded on first use and cached.
+- **Android / JVM.** `ai.desertant:clear` on Maven Central.
+- **JavaScript / TypeScript.**
+  [`@desert-ant-labs/clear`](https://www.npmjs.com/package/@desert-ant-labs/clear) —
+  WebAssembly + LiteRT.js in the browser, a prebuilt native core in Node.
+
+**Direct low-level use.** Load the `.mlmodelc` with Core ML and feed planar
+fp16 tensors: `spec (4,2,481,200)`, `feat_erb (4,1,32,200)`, and
+`feat_spec (4,2,96,200)`. Read `spec_enhanced (4,2,481,200)`, then ISTFT
+back to the time domain. Batch elements are independent. The ONNX files keep
+the original DFN3 layout for cross-platform runtimes. Integrations must handle
+STFT, feature extraction, layout conversion, ISTFT, and mastering around the
+Core ML call.
+
+See also: [desertant.com/models/clear](https://desertant.com/models/clear/).
+
+## What it's good for
+
+- **Meeting recorders.** Zoom, Teams, Meet, Detail exports — single or multi-speaker.
+- **Bluetooth microphones.** AirPods, Sony, headset mics.
+- **Mobile devices.** iPhone and Android built-in microphone recordings, voice notes, field recordings.
+- **Laptop built-in microphones.** MacBook and PC built-in mics.
+- **Untreated rooms.** Bedrooms, hotel rooms, kitchens, coffee shops.
+
+Whenever the pitch is *messy recording in, clean audio out*.
+
+## What it is not
+
+- Not a general-purpose audio denoiser.
+  Speech is the target; music, effects, and non-vocal signals get pulled down as noise.
+- Not a source separator.
+  Overlapping speakers stay overlapping.
+- Not a voice changer, cloner, or transcription model.
+
+## Keywords
+
+speech enhancement · noise suppression · dereverberation · speech
+denoising · reduce noise · clean up audio · normalize volume · turn a
+recording into studio sound · messy recording in clean audio out ·
+podcast audio · voice cleanup · meeting recorder cleanup · bluetooth
+microphone cleanup · mobile device audio · built-in microphone ·
+on-device audio · edge ML · Core ML · ONNX · iOS speech enhancement ·
+Android speech enhancement · real-time speech enhancement · DFN3 ·
+DeepFilterNet · studio sound · podcast sound · TCN · distilled model ·
+Apple Neural Engine · ANE

--- a/docs/hub-cards/clips.md
+++ b/docs/hub-cards/clips.md
@@ -1,0 +1,139 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- multilingual
+tags:
+- text
+- clip-selection
+- text-ranking
+- on-device
+- core-ml
+- litert
+- tflite
+- multilingual
+pipeline_tag: text-ranking
+---
+
+# clips
+
+Takes the sentences of a transcript and ranks contiguous spans, so a longer video can be cut
+into shorter clips.
+
+Selection is two graphs. A per-sentence **selector** returns a saliency score and start/end
+probabilities, which is what proposes candidate spans. A per-span **scorer** then ranks them.
+They are separate graphs because they take different inputs: the selector also reads five
+discourse scalars the scorer has no use for.
+
+On Apple platforms both graphs live in **one** Core ML package over a shared trunk. LiteRT has
+no equivalent packaging, so the other platforms ship two files and store the trunk twice.
+
+## Files
+
+| File | Format | Contents |
+|---|---|---|
+| `clips.mlmodelc/` | Compiled Core ML, int8 | Multifunction package. Function `select`: `ids`, `mask`, `disc` → `saliency`, `start_p`, `end_p`. Function `score`: `ids`, `mask` → `score` |
+| `clips-selector.tflite` | LiteRT, int8 weight-only | The selector, for Android, Linux and Windows |
+| `clips-scorer.tflite` | LiteRT, int8 weight-only | The scorer, for Android, Linux and Windows |
+| `clip_tokenizer.bin` | Unigram tokenizer | XLM-R SentencePiece pieces and scores, in the compact binary the runtime reads |
+| `clips_meta.json` | JSON | Graph widths, discourse-feature order and tokenizer ids a runtime needs |
+| `checkpoint/` | safetensors + PyTorch | The training checkpoint the exports were built from |
+
+### Reaching a function in the Core ML package
+
+A file path names the package, not the graph. Loading needs
+`MLModelConfiguration.functionName` set to `select` or `score`. Without it Core ML loads the
+package's default function and reports nothing, so both halves of the pipeline end up being
+the selector.
+
+### Windows
+
+The selector runs at 128 tokens, the scorer at 256, both at a fixed batch of 16 sentences.
+
+A single sentence is truncated to **64** tokens before it reaches the selector. That is the
+length the saliency heads were trained at and it is not the same thing as the graph width; a
+longer single sentence runs the heads off-distribution.
+
+### `checkpoint/`
+
+The exact checkpoint the exports come from, in the layout the training and export scripts
+read, rather than a flat repacked `.pt` that nothing can load. It holds the encoder as
+safetensors, the two head files, and `run_manifest.json` describing the run that produced it.
+
+There is no TensorFlow checkpoint. The LiteRT files are converted from PyTorch through
+StableHLO, so no TF SavedModel exists at any point.
+
+## Status
+
+Internal testing. This card carries no quality or latency figures: the evaluation behind this
+checkpoint has not completed independent review, and an unreviewed number on a public card
+gets quoted as if it had been.
+
+> ### ⚠️ The `.tflite` files do not work with the Desert Ant SDK yet. Do not build on them.
+>
+> Found by review after publication, by loading the flatbuffers rather than reasoning about
+> them. The LiteRT exports are real and faithful conversions of the checkpoint, but the SDK's
+> LiteRT backend cannot drive them:
+>
+> - the graphs name their inputs `args_0`, `args_1`, `args_2` and their outputs `output_0…2`;
+>   the SDK asks for `ids`, `mask`, `disc` and `saliency`, `start_p`, `end_p`. There is no
+>   mapping layer, so the first call fails.
+> - the graphs take **int64** ids and mask; the SDK builds int32.
+> - the scorer is 256 wide and the SDK's LiteRT backend cannot report a width, so it falls
+>   back to 128.
+>
+> They are left published because they are honest artifacts and someone driving LiteRT
+> directly can use them — the shapes and output order are in `clips_meta.json` and are
+> verified. They are **not** a working Android/Linux/Windows path today.
+>
+> Also unresolved: at these widths this export was measured at ~2.1 GB peak RSS against a
+> 1.6 GB Android budget, and the training repo's own recommendation for LiteRT is fp16 rather
+> than this int8 build.
+
+**The two platforms are not equally evidenced.** The Core ML package has clips that were
+generated from it and judged. **No clip has ever been read from the LiteRT files, on any
+platform.** Their only gate is a synthetic random-token batch, and that gate's own manifest
+records `is_a_quality_result: false`. The two exports also use different int8 schemes, recorded
+per platform in `clips_meta.json`.
+
+## Requirements
+
+The Core ML package is **specification version 9**: it requires **iOS 18 / macOS 15 / tvOS 18 /
+visionOS 2 / watchOS 11**, read off the compiled artifact. Reaching either graph needs
+`MLModelConfiguration.functionName` set to `select` or `score`.
+
+## Limits
+
+Behaviour worth knowing before you build on it, stated without figures for the reason above:
+
+- **It under-emits on short video.** Given a short transcript it returns markedly fewer clips
+  than a strong teacher finds worth cutting. If your product needs a guaranteed number of
+  clips from a two-minute video, measure before relying on it.
+- **It emits some dross**, most on podcast-length input. There is no confidence score to
+  filter on yet: `Clip.score` ranks within one video and is not calibrated across videos.
+- **The clip limit is a cap, not a quota.** Asking for 10 does not mean receiving 10.
+- **Selection is sensitive to small score changes.** Candidate spans around one moment score
+  very close together, so a different runtime, compute unit or quantization can return a
+  different-but-comparable set rather than the same set. Do not treat exact span equality
+  between two builds as a correctness check.
+- **Non-Latin scripts are under-tested.** The evaluation corpus is overwhelmingly Latin-script.
+- **Duration is a soft prior, not a rule.** Clips may come back shorter or longer than a
+  typical Short.
+
+## Built on
+
+- [`FacebookAI/xlm-roberta-base`](https://huggingface.co/FacebookAI/xlm-roberta-base) (MIT):
+  the shared encoder trunk and its SentencePiece vocabulary.
+
+See [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for most
+apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.
+
+---
+
+© 2026 Desert Ant Labs · <https://desertant.com>

--- a/docs/hub-cards/emo.md
+++ b/docs/hub-cards/emo.md
@@ -1,0 +1,115 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- multilingual
+tags:
+- text
+- emoji
+- text-classification
+- on-device
+- core-ml
+- litert
+- tflite
+- multilingual
+pipeline_tag: text-classification
+---
+
+# Emo: on-device emoji suggestions from text
+
+Takes a short text string and returns the best-matching emoji. Tuned for to-dos,
+calendar entries, notes, and message drafts across **23 languages** (including
+CJK, Arabic, Thai, Hindi, and more). The whole thing, model **and** tokenizer,
+is small (**~5 MB** on Apple via Core ML, **~11 MB** via LiteRT elsewhere) and runs in well under 2 ms on device.
+
+> `"Dentist appointment"` → 🦷  ·  `"réserver un vol pour Tokyo"` → ✈️  ·  `"犬の散歩"` → 🐕  ·  `"จองโรงแรม"` → 🏨
+
+## Try it
+
+All platforms ship from one repo: **[Desert-Ant-Labs/emo](https://github.com/Desert-Ant-Labs/emo)** (Swift, Kotlin, and JavaScript in a single codebase).
+
+- **Live demo:** [desert-ant-labs/emo-demo](https://huggingface.co/spaces/desert-ant-labs/emo-demo): type a phrase, get emojis, fully in your browser.
+- **iOS / macOS / tvOS / visionOS:** the Swift SDK (Swift Package Manager), with a built-in demo app. It bundles the compiled Core ML model below.
+- **Android / Kotlin:** Maven Central `ai.desertant:emo` with LiteRT (`.tflite`). The small model is bundled by default; exclude `ai.desertant:emo-tflite-resources` to force on-demand download or explicit-directory loading.
+- **Node / browser (JavaScript / TypeScript):** `npm i @desert-ant-labs/emo @litertjs/core` for browser builds, or just `npm i @desert-ant-labs/emo` for server-side Node. The npm package downloads the model from this repo on first use and caches it; browser inference uses [LiteRT.js](https://www.npmjs.com/package/@litertjs/core), and Node uses prebuilt native libraries (Core ML on macOS, LiteRT on Linux). Pass `directory` (Node) or `modelBaseUrl` (browser) to self-host / run offline.
+
+## Files
+
+| File | Format | Size | Contents |
+|---|---|---:|---|
+| `emo.tflite` | LiteRT / TFLite (int8) | ~10.2 MB | Fixed-window n-gram + masked semantic inputs, softmax `probabilities` output; runs on Android, Linux, Node, and the web (bundled by default in the Kotlin SDK; downloaded on demand by the JavaScript SDK) |
+| `emo.mlmodelc` | Compiled Core ML | ~4.6 MB | Mixed 4-/8-bit-palettized transformer, ready to load on Apple platforms (used by the Swift SDK) |
+| `emo_tokenizer.bin` | Pruned unigram tokenizer | ~0.75 MB | 48k SentencePiece pieces + scores; token ids = semantic-table rows |
+| `emo_meta.json` | JSON | tiny | emoji labels + n-gram hashing / fixed-window config the runtime needs |
+| `emo.pt` | PyTorch checkpoint | ~48 MB | Full-precision weights + semantic table + tokenizer (for retraining / other runtimes) |
+
+Older revisions (tags `v0.6.0` and earlier) carry `Emo.mlmodelc` and `emo.safetensors` for SDK versions that predate the unified cross-platform migration.
+
+## Architecture
+
+A compact two-stream classifier - no large encoder, just a tiny transformer over the semantic tokens:
+
+- **Lexical stream**: script-aware character/word n-grams (Latin, Han·Kana, Hangul
+  jamo, Devanagari clusters, SE-Asian, …) hashed into a fixed multi-hash signed
+  embedding table. Its size is independent of the number of languages.
+- **Semantic stream**: a frozen multilingual static embedding (Model2Vec
+  [`potion-multilingual-128M`](https://huggingface.co/minishlab/potion-multilingual-128M),
+  distilled from BAAI `bge-m3`), PCA-reduced to 128 dims and **vocab-pruned to the
+  48k tokens** that matter for the 22 target languages. Gives cross-lingual
+  generalization and handles out-of-vocabulary words. The matching ~0.75 MB unigram
+  tokenizer ships alongside (`emo_tokenizer.bin`).
+- **Semantic pooling**: a small 2-layer transformer encoder runs over the semantic
+  token sequence, then an attention pool - order-aware, so it composes phrases and
+  idioms instead of averaging tokens.
+- **Head**: a small MLP fusing the two streams into a softmax over a **curated vocabulary of ~800 everyday emojis** (the emojis that actually come up most across the
+  training phrases). Trained with n-gram dropout so the head relies on the semantic
+  stream, which is what makes it generalize across languages.
+
+## Inputs and outputs
+
+- **Input:** a plain text string. Best on short, intent-oriented text.
+- **Output:** a probability distribution over the ~800-emoji vocabulary; take the
+  top-1 (or top-k). Optimized for **top-1 relevance**.
+
+## Languages
+
+English, Spanish, Portuguese, French, German, Italian, Dutch, Russian, Polish,
+Turkish, Arabic, Chinese (Simplified & Traditional), Japanese, Korean, Hindi,
+Indonesian, Thai, Vietnamese, Ukrainian, Swedish, Danish, Czech.
+
+## Limitations
+
+- Tuned for short, intent-oriented text; long-form text produces noisier suggestions.
+- Emoji semantics are imprecise; near-ties at the top of the ranking are expected.
+- Per-language quality varies; lower-resource languages in the set are somewhat weaker.
+
+## Built on
+
+- [`minishlab/potion-multilingual-128M`](https://huggingface.co/minishlab/potion-multilingual-128M) (MIT): semantic embedding stream (PCA-reduced, vocab-pruned derivative) + tokenizer lineage.
+- [`BAAI/bge-m3`](https://huggingface.co/BAAI/bge-m3) (MIT): teacher the static embedding was distilled from.
+- [Model2Vec](https://github.com/MinishLab/model2vec) (MIT): static-embedding distillation method.
+- Unicode CLDR emoji annotations: multilingual keyword grounding in the training data.
+
+See [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for
+most apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.
+
+## Citation
+
+```bibtex
+@software{emo_2026,
+  title  = {Emo: on-device emoji suggestions from text},
+  author = {Desert Ant Labs},
+  year   = {2026},
+  url    = {https://huggingface.co/desert-ant-labs/emo},
+}
+```
+
+---
+
+© 2026 Desert Ant Labs · <https://desertant.com>

--- a/docs/hub-cards/gist.md
+++ b/docs/hub-cards/gist.md
@@ -1,0 +1,176 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- en
+- multilingual
+tags:
+- text
+- topic-classification
+- content-classification
+- multi-label
+- on-device
+- core-ml
+- tflite
+- litert
+- multilingual
+- model2vec
+pipeline_tag: text-classification
+library_name: litert
+---
+
+# gist: on-device content topic tagging
+
+Takes a piece of text — a title, a post, or a longer description — and returns the topics it is
+about, from a fixed **36-topic taxonomy**, across **101 languages**. A compact two-stream classifier
+(static embedding + hashed n-grams), with **no transformer at inference**. The deployable model is
+**~74 MB** (int8 vocab-pruned multilingual embedding + a small fp16 head) and runs fully on device
+with zero per-call cost. Multi-label by design: most items carry two or three topics, and per-item
+scores can be aggregated across a collection (for example into channel- or feed-level topics).
+
+> `"How to film a two-person podcast with two iPhones"` → **technology**, **creator-economy** ·
+> `"Cómo invertir en fondos indexados"` → **finance** ·
+> `"Tips for adopting a rescue dog"` → **pets-animals** ·
+> `"投资指数基金入门"` → **finance**
+
+## Try it
+
+- **Live demo:** [desert-ant-labs/gist-demo](https://huggingface.co/spaces/desert-ant-labs/gist-demo) — paste a post in any language and see its topics.
+- **SDKs (Swift / Android / JavaScript):** [github.com/Desert-Ant-Labs/gist](https://github.com/Desert-Ant-Labs/gist).
+
+## Use
+
+Drop-in SDKs run the model on device; each pins this repo's revision.
+
+```js
+import { Gist } from "@desert-ant-labs/gist";           // browser (wasm + LiteRT.js)
+// import { Gist } from "@desert-ant-labs/gist/native"; // Node (native)
+const gist = await Gist.load();
+await gist.classify("How to start a podcast with just your iPhone");
+// [{ slug: "technology", name: "Technology & Software", score: 0.91 },
+//  { slug: "creator-economy", name: "Creator Economy & Marketing", score: 0.44 }]
+```
+
+```swift
+import Gist
+let gist = Gist()
+let topics = try await gist.classify("How to start a podcast with just your iPhone")
+```
+
+## Files
+
+| File | Format | Size | Contents |
+|---|---|---:|---|
+| `gist_embedding.i8` + `.json` | int8 static embedding | ~64 MB | 101-language potion embedding (261,349 tokens × 256 dims), the semantic feature extractor |
+| `gist.mlmodelc` | Core ML | ~6 MB | The classifier head: fused features → 36 topic probabilities |
+| `gist.tflite` | LiteRT | ~13 MB | The same head, float32. Larger than the Core ML export because a float16 graph is not runnable: standard LiteRT/TFLite kernels cannot prepare one whose tensors are all float16, which broke the browser, Android and Linux runtimes until v2.2.0 |
+| `gist_tokenizer.bin` | Unigram | ~4 MB | The multilingual tokenizer |
+| `gist_config.json` | JSON | tiny | Slugs, feature dims, threshold |
+| `taxonomy.json` | JSON | ~8 KB | The 36 topics (slug, name, description, IAB + Apple category) |
+
+## Architecture
+
+A compact two-stream classifier — no large encoder:
+
+- **Semantic stream**: a frozen multilingual static embedding (Model2Vec
+  [`potion-multilingual-128M`](https://huggingface.co/minishlab/potion-multilingual-128M), distilled
+  from BAAI `bge-m3`), pruned per-script and int8-quantized. Tokenize (Unigram), gather the token
+  rows, mean-pool, L2-normalize. Cross-lingual by construction across **101 languages**.
+- **Lexical stream**: word and character n-grams hashed into a fixed vector, capturing proper nouns
+  and exact tokens the semantic embedding smears (names, brands, gear).
+- **Head**: a small MLP fusing the two streams (`[1, 8448]`) into a sigmoid over the **36-topic
+  taxonomy**, trained with class balancing so it does not default to over-represented topics.
+
+Distilled: open instruct LLMs (Apache/MIT) label the training text; a small student learns to
+reproduce it. Multi-label targets teach the co-occurrences (a tutorial is `technology` *and*
+`creator-economy`). Everything except the head is pure host-side code, so the same pipeline runs
+identically on Apple (Core ML), Android/Linux (LiteRT), and the web (WebAssembly + LiteRT.js).
+
+## Inputs and outputs
+
+- **Input:** a plain text string (title, or title + description). Best on short text like posts,
+  titles, and descriptions.
+- **Output:** a probability over the 36 topics (`features [1, 8448]` → `topic_probs [1, 36]`); take
+  the top-k above the threshold in `gist_config.json`. Optimized for **multi-label** use — an item's
+  2–3 topics, optionally aggregated across a collection.
+
+## Topics and standard taxonomy
+
+The 36 topics map to two industry-standard taxonomies so gist output can be rolled up or joined
+into existing systems: **IAB Content Taxonomy 2.2** (with each node's stable integer ID) and
+**Apple Podcasts categories**. The full, machine-readable crosswalk ships in this repo as
+[`taxonomy_crosswalk.json`](./taxonomy_crosswalk.json) (e.g. `law` → IAB `383` *News & Politics ›
+Law*, `crafts-hobbies` → IAB `248` *Arts and Crafts*, `finance` → IAB `391` *Personal Finance*).
+
+Five topics have no dedicated IAB 2.2 node and are flagged as gist extensions
+(`society-culture`, `creator-economy`, `outdoors-nature` map to a nearest parent; `history` and
+`self-improvement` have no IAB node); `film-tv` is a roll-up of IAB *Movies* + *Television*.
+
+## Languages
+
+Cross-lingual by construction: the multilingual static embedding shares one representation space
+across **101 languages**, so topic tagging transfers across all of them. A diverse 15-language spot
+check (across Latin, Cyrillic, Arabic, CJK, Devanagari, Hebrew, Thai, and Greek scripts) gives
+**88% top-3**, with CJK, Arabic, and Cyrillic scripts matching or beating the Latin ones — topic
+classification is largely language-agnostic in the shared embedding.
+
+## Model variants
+
+Two builds of the same 36-topic model live in this repo:
+
+| Variant | Location | Size | Coverage |
+|---|---|---:|---|
+| **Multilingual** (default) | repo root | ~74 MB | 101 languages |
+| **English-only** | [`en/`](./en) | **~15 MB** | English / Latin script only |
+
+The English build is a vocabulary prune of the same model — a smaller int8 embedding (32,251 tokens) and tokenizer, with the **same classifier head**, so it is **topic-identical to the multilingual model on English input** (no retraining). It does not cover non-Latin scripts (CJK, Arabic, Cyrillic, …); use it only when the input is reliably English/Latin. The Swift SDK selects it with `Gist(variant: .english)`. The JS and Kotlin SDKs currently load the multilingual build only: variant selection has to cross the shared native ABI, which has no slot for it yet.
+
+## Evaluation
+
+Recall on a held-out set of **572 human-labeled real posts (36 topics)**, zero-shot for the
+LLMs and zero-shot classifiers. Embedding classifiers get a light logistic head trained on the same
+corpus; **recall@3** is the product metric (downstream aggregation consumes the top few topics).
+
+| Model | Type | Size | recall@1 | recall@3 |
+|---|---|---:|---:|---:|
+| Qwen2.5-7B (cloud) | LLM zero-shot | server | **79%** | — |
+| multilingual-e5-small + head | transformer embed | 110 MB | 74% | 92% |
+| bge-small-en + head | transformer embed | 130 MB | 71% | 92% |
+| **gist** | **static embed + n-grams + MLP** | **~74 MB** | **71%** | **91%** |
+| all-MiniLM-L6-v2 + head | transformer embed | 90 MB | 68% | 90% |
+| potion + head | static embed | 30 MB | 65% | 89% |
+| mDeBERTa-v3-mnli-xnli | zero-shot NLI | 560 MB | 50% | 73% |
+| GLiClass-base | zero-shot | 400 MB | 44% | 65% |
+
+gist is **tied on recall@3** with the best small models, at a fraction of the size and one on-device
+pass — and it beats every zero-shot classifier decisively (they never learned the taxonomy or the
+distribution). Only a 7B cloud LLM clearly leads on recall@1. An MTEB cross-check confirms the
+transformer edge is genuine static-embedding tradeoff, not a quirk of this gold.
+
+## Built on
+
+- [`minishlab/potion-multilingual-128M`](https://huggingface.co/minishlab/potion-multilingual-128M) (MIT): semantic embedding stream (per-script pruned, int8) + tokenizer lineage.
+- [`BAAI/bge-m3`](https://huggingface.co/BAAI/bge-m3) (MIT): teacher the static embedding was distilled from.
+- [Model2Vec](https://github.com/MinishLab/model2vec) (MIT): static-embedding distillation method.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for
+most apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.
+
+## Citation
+
+```bibtex
+@software{gist_2026,
+  title  = {gist: on-device content topic tagging},
+  author = {Desert Ant Labs},
+  year   = {2026},
+  url    = {https://huggingface.co/desert-ant-labs/gist},
+}
+```
+
+---
+
+© 2026 Desert Ant Labs · <https://desertant.com>

--- a/docs/hub-cards/moderator.md
+++ b/docs/hub-cards/moderator.md
@@ -1,0 +1,142 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- en
+tags:
+- image
+- image-classification
+- content-moderation
+- nsfw
+- on-device
+- core-ml
+- onnx
+pipeline_tag: image-classification
+---
+
+# Moderator, on-device NSFW detection
+
+Moderator returns a single NSFW score from 0 to 1: the probability an image contains nudity or sexual activity. Threshold it (default 0.5) and you have your answer. Designed to pass real swimwear and lingerie photos while flagging real nude and sexual content. Apple-platform first; ships as Core ML at fp16 for size and as ONNX for cross-platform use.
+
+Per-region detail (nipples, genitals, buttocks, nudity, sexual activity) is available for policies that need it, for example allow-topless. See [Outputs](#inputs-and-outputs).
+
+## Try it
+
+- **iOS / macOS:** [`moderator-swift`](https://github.com/Desert-Ant-Labs/moderator-swift), the Swift SDK with a built-in demo app.
+
+## Files
+
+| File | Format | Size | Use |
+|---|---|---:|---|
+| `moderator.mlpackage.zip` | Core ML mlpackage (fp16) | ~18 MB | iOS / macOS on-device, default |
+| `moderator_6bit.mlpackage.zip` | Core ML mlpackage (6-bit palettized) | ~7 MB | iOS / macOS, size-constrained builds |
+| `moderator.onnx` | ONNX (fp32) | ~35 MB | Browser, server, Python via `onnxruntime` |
+
+The fp16 build is the default and matches the fp32 ONNX within fp16 rounding. The 6-bit build is the smallest that holds accuracy; 4-bit and below collapse and are not shipped.
+
+## Use
+
+### Swift (iOS / macOS)
+
+```swift
+import Moderator
+
+let moderator = try await Moderator()
+let result = try await moderator.analyze(image)
+
+print(result.score)      // 0...1, the NSFW score
+print(result.isNSFW)     // Bool, score >= threshold (default 0.5)
+
+// Optional per-region detail:
+print(result.regions.nude, result.regions.sexAct,
+      result.regions.nipples, result.regions.genitals, result.regions.buttocks)
+```
+
+See [`moderator-swift`](https://github.com/Desert-Ant-Labs/moderator-swift) for options, thresholds, and the demo app.
+
+### ONNX (Python / Node / Web)
+
+```python
+import onnxruntime as ort
+import numpy as np
+
+sess = ort.InferenceSession("moderator.onnx")
+# image: float32 [B, 3, 384, 384], RGB, ImageNet-normalized
+heads = sess.run(None, {"image": image})   # 5 region probabilities
+nsfw_score = np.max(heads, axis=0)          # the single NSFW score
+is_nsfw = nsfw_score >= 0.5
+```
+
+## Inputs and outputs
+
+The [Swift SDK](https://github.com/Desert-Ant-Labs/moderator-swift) handles all of this for you. For direct ONNX or Core ML use:
+
+### Input
+
+One tensor named `image`, shape `[1, 3, 384, 384]`, RGB, NCHW. Core ML takes `float16`, ONNX takes `float32`. Preprocess each image:
+
+1. Resize the short side to 384, center-crop to 384x384.
+2. Scale pixels to `[0, 1]`.
+3. Normalize: `mean = [0.485, 0.456, 0.406]`, `std = [0.229, 0.224, 0.225]`.
+
+One forward pass per image (no test-time augmentation baked in).
+
+### Output
+
+The **NSFW score**, from 0 to 1, thresholded at 0.5 by default. It is the max of five region heads, which are also returned individually for finer policies (for example, allow-topless ignores `nipples_visible`):
+
+- `nude`
+- `sex_act`
+- `nipples_visible`
+- `genitals_visible`
+- `buttocks_visible`
+
+### Passes
+
+Run one crop for speed, or more crops (taking the max score) for higher recall:
+
+| Crops per image | Recall | Specificity |
+|---|---:|---:|
+| 1 (center) | 74% | 97% |
+| 4 (multi-scale tiles) | 84% | 95% |
+| 8 (multi-scale tiles + flips) | 88% | 94% |
+
+- **Single images:** run 8 crops for best recall.
+- **Video:** 1 crop per frame is cheapest and most precise, and sampling across frames recovers recall. Use the 4-tile pass if you need higher per-frame recall.
+
+## Model
+
+- **Backbone:** MobileNetV4-Conv-Medium (8.4M params), Apache 2.0.
+- **Head:** 2-layer MLP (1280 to 512 to 5), L2-normalized features.
+
+## Training data: 100% clean
+
+This is the rare NSFW model with fully controlled data provenance. Nothing is scraped from the open internet. Every training image is either permissively licensed (public domain or Creative Commons) or generated in-house. Positives are drawn from public-domain fine art and museum open-access collections (classical nudes in painting, sculpture, and photography), historic and documentary photography, and openly-licensed imagery, plus photorealistic images generated with generative image models. The backbone is Apache 2.0.
+
+Clean, controlled provenance end to end is unusual for an NSFW classifier, where scraped datasets of unknown origin are the norm. It means no copyright or licensing exposure, and a model you can put in a commercial product with confidence.
+
+## Evaluation
+
+Held-out evaluation set (464 images, 75% SFW / 25% NSFW), scored on the single NSFW score at threshold 0.5 with the 8-crop pipeline.
+
+| Metric | Moderator | NudeNet |
+|---|---|---|
+| Recall (catches NSFW) | **87.8%** | 82.6% |
+| Specificity (SFW passed) | **93.7%** | 87.1% |
+| False-block rate (SFW flagged) | **6.3%** | 12.9% |
+
+Moderator beats NudeNet on both recall and precision, and flags about half as many SFW images.
+
+## Limitations
+
+- Adult-content classifier only. Subjects rendered as minors are out of scope by design; the training corpus excludes them and the model is not validated for that population.
+- Accuracy is lower on difficult images (crowded scenes, extreme close-ups, low light, or low resolution) than on clear, well-lit ones.
+- Anime/hentai and heavily-censored (mosaic) content are out of scope; the model is trained on photoreal.
+- This is a content-moderation aid, not a legal determination. Use with human review for any decision the model is the only gate on.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for
+most apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.

--- a/docs/hub-cards/redact.md
+++ b/docs/hub-cards/redact.md
@@ -1,0 +1,194 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- bg
+- hr
+- cs
+- da
+- nl
+- en
+- et
+- fi
+- fr
+- de
+- el
+- hu
+- ga
+- it
+- lv
+- lt
+- mt
+- pl
+- pt
+- ro
+- sk
+- sl
+- es
+- sv
+- nb
+- nn
+- is
+tags:
+- pii
+- redaction
+- token-classification
+- on-device
+- litert
+- tflite
+- core-ml
+- multilingual
+pipeline_tag: token-classification
+---
+
+# redact: on-device multilingual PII redaction
+
+Detects and redacts personal data (names, addresses, emails, phone numbers,
+cards, IBANs, national IDs and more) in text across **27 languages**
+(see [Languages](#languages)). A BIOES token classifier plus a portable, dependency-free
+deterministic layer for structured IDs. The deployable model is **~11.6 MB**
+(4-bit Core ML on Apple) or **~24.5 MB** (int8 LiteRT `.tflite` on Android, Linux
+and the web).
+
+> `"Call Anna Kovács at anna@example.hu, IBAN GB29NWBK60161331926819"` →
+> `"Call [GIVEN_NAME] [SURNAME] at [EMAIL], IBAN [BANK_ACCOUNT]"`
+
+## Try it
+
+All platforms ship from one repo: **[Desert-Ant-Labs/redact](https://github.com/Desert-Ant-Labs/redact)** (Swift, Kotlin, and JavaScript in a single codebase).
+
+- **Live demo:** [desert-ant-labs/redact-demo](https://huggingface.co/spaces/desert-ant-labs/redact-demo): paste text and watch PII get highlighted or masked, fully in your browser.
+- **iOS / macOS / tvOS / visionOS:** the Swift SDK (Swift Package Manager) with a built-in demo app. It bundles the compiled Core ML model below.
+- **Android / JVM (Kotlin):** Maven Central `ai.desertant:redact` — LiteRT (`.tflite`), with the model downloaded on demand or bundled via `ai.desertant:redact-tflite-resources`.
+- **Node / browser (JavaScript / TypeScript):** `npm i @desert-ant-labs/redact @litertjs/core` for browser builds, or just `npm i @desert-ant-labs/redact` for server-side Node. The npm package downloads the model from this repo on first use and caches it; browser inference uses [LiteRT.js](https://www.npmjs.com/package/@litertjs/core), and Node uses prebuilt native libraries. Pass `directory` (Node) or `modelBaseUrl` (browser) to self-host / run offline.
+
+```swift
+import Redact
+
+let redact = Redact()
+let r = try await redact.redaction(of: "Email Anna Kovács at anna@example.hu.")
+r.redactedText   // "Email [GIVEN_NAME_1] [SURNAME_1] at [EMAIL_1]."
+```
+
+## Taxonomy (20 public labels, plus `ORG`)
+
+`GIVEN_NAME`, `SURNAME`, `STREET_NAME`, `BUILDING_NUMBER`, `SECONDARY_ADDRESS`,
+`CITY`, `STATE`, `ZIP_CODE`, `EMAIL`, `PHONE`, `CREDIT_CARD`, `BANK_ACCOUNT`,
+`ROUTING_NUMBER`, `IP_ADDRESS`, `URL`, `GOVERNMENT_ID`, `PASSPORT`,
+`DRIVERS_LICENSE`, `TAX_ID`, `SSN`.
+
+`ORG` (organisation / company name) is detected but **not redacted by default**:
+a company is not a natural person. It exists so that `Silverfin`, `Odoo` or
+`Visma Nova` are recognised as organisations instead of being mislabelled as a
+`SURNAME`. Opt in by passing it explicitly in the SDK's `labels` option.
+
+The deterministic layer additionally emits `IMEI` (device identifier), a
+deterministic-only label outside the neural head.
+
+## How it compares
+
+Every system below was scored by the same harness on the same rows, each at its
+own operating point, so the comparison measures the models rather than the
+plumbing.
+
+| System | Recall | Precision | Size | Params |
+|---|---:|---:|---:|---:|
+| **redact** | **88.8** | **99.6** | **11.6 MB** | **23M** |
+| GLiNER-PII | 91.1 | 90.4 | 2.3 GB | 570M |
+| Rampart | 61.4 | 97.2 | 14.7 MB | 18.5M |
+| OpenAI privacy filter | 60.2 | 93.5 | 3 GB | 1.5B |
+
+**Recall** is the share of personal data fully masked (leak-safe), macro-averaged
+over WikiANN, MultiNERD and a format-valid structured-PII set across 24 EU
+languages. **Precision** is the share of masked spans that were really personal
+data, on the structured set. Size is the Apple build; the Android and web build
+is 24.5 MB.
+
+Not masking ordinary words matters as much as catching real ones, because a
+false positive corrupts the text a downstream model receives. On an 11,528-row
+negative set across 27 languages, built to provoke exactly that (sentence-initial
+capitals, ALL-CAPS input, month and weekday names, UI vocabulary, bare numbers,
+company names), 94.1% of rows come back untouched.
+
+### AWS Comprehend, English only
+
+Comprehend is the other service teams weigh, and it is not in the table above
+because its PII API **only accepts English** — every other language code is
+refused outright, so there is no way to run it on the other 23. Scored on the
+same English rows:
+
+| System | Names (WikiANN) | Names (MultiNERD) | Structured | English composite |
+|---|---:|---:|---:|---:|
+| redact | 69.5 | 94.9 | **95.0** | 86.5 |
+| AWS Comprehend | **84.3** | **98.5** | 91.9 | **91.6** |
+
+Leak-safe recall; precision is the same for both (99.8 against 100.0). On English
+names Comprehend is ahead of us. It also runs in the cloud, bills per call, and
+covers one of the 27 languages listed below.
+
+## Languages
+
+**27 languages**: every official EU language, plus 3 more.
+Latin, Greek and Cyrillic scripts.
+
+### The 24 EU languages
+
+| Code | Language |
+|---|---|
+| `bg` | Bulgarian |
+| `hr` | Croatian |
+| `cs` | Czech |
+| `da` | Danish |
+| `nl` | Dutch |
+| `en` | English |
+| `et` | Estonian |
+| `fi` | Finnish |
+| `fr` | French |
+| `de` | German |
+| `el` | Greek |
+| `hu` | Hungarian |
+| `ga` | Irish |
+| `it` | Italian |
+| `lv` | Latvian |
+| `lt` | Lithuanian |
+| `mt` | Maltese |
+| `pl` | Polish |
+| `pt` | Portuguese |
+| `ro` | Romanian |
+| `sk` | Slovak |
+| `sl` | Slovenian |
+| `es` | Spanish |
+| `sv` | Swedish |
+
+### Beyond the EU
+
+| Code | Language |
+|---|---|
+| `nb` | Norwegian Bokmål |
+| `nn` | Norwegian Nynorsk |
+| `is` | Icelandic |
+
+Coverage is not uniform: the largest EU languages are the strongest, and Maltese
+and Irish are the weakest of the 24. The per-language detection numbers are in
+the benchmark data.
+
+## Architecture
+
+- **Encoder:** Multilingual-MiniLM (XLM-R lineage) truncated to 6 layers with an
+  EU-script-trimmed vocab (~23 M params), fine-tuned for BIOES tagging.
+- **Deterministic layer:** a pure-stdlib post-processor owns high-confidence
+  structured labels (email, URL, IP/MAC, card, IBAN/BIC, VIN, SSN, routing,
+  tax id, government id, passport, driving licence, IMEI) with real validation
+  (Luhn, ISO-13616 IBAN, ISO-7064, per-country checksums) and reconciles them
+  with the model's contextual predictions. EU structured coverage includes
+  **checksum-validated national IDs for all 24 EU countries, all 27 EU VAT
+  numbers, IMEI, and per-country driving-licence numbers**. The same layer is
+  ported byte-for-byte to the JS and Swift runtimes (span-for-span parity).
+- Recommended runtime: `min_score = 0.6`, `max_length = 256`, `stride = 64`.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for
+most apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.

--- a/docs/hub-cards/schemer.md
+++ b/docs/hub-cards/schemer.md
@@ -1,0 +1,264 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- multilingual
+- en
+- de
+- es
+- fr
+- it
+- nl
+- da
+- 'no'
+- sv
+- pl
+- pt
+- ja
+- zh
+tags:
+- text
+- structured-output
+- schema
+- json
+- extraction
+- multilingual
+- on-device
+- core-ml
+- onnx
+pipeline_tag: other
+---
+
+# Schemer, on-device text to structured JSON
+
+Schemer is a **schema-native extraction model**: it takes free text and a
+developer-supplied schema, and returns a JSON object that matches the
+schema. The schema is the model's input, not a prompt suggestion, and every
+field is decoded by a head built for its type. It does not generate text.
+
+- **211M parameters**: 218 MB int8 (verified lossless) or 111 MB int4
+- **13 languages**, 0.075 per-language accuracy spread
+- **Nested schemas**: arrays of objects extract via deterministic
+  segment-and-recurse in the harness (0.99 on the internal nested eval)
+- **Documents up to ~1,100 tokens** (roughly 3 pages); short inputs run a
+  fast 256-token path
+- **Offline**, ~200 MB RAM; 8.7 ms per encoder pass on an Apple Neural
+  Engine
+
+Three guarantees no generative extractor offers:
+
+1. **Typed by construction.** Labels are always one of your declared
+   choices, numbers arrive clamped to your range, datetimes are ISO 8601,
+   and relative expressions ("tomorrow at 3pm", "i morgen kl 15",
+   misspellings included) resolve against device time.
+2. **Absence detection.** Fields the text does not state come back null.
+   Schemer scores 0.91 on this; every LLM and span extractor we benched,
+   at any size, scores between 0.18 and 0.43.
+3. **Verbatim with offsets.** Extracted strings are substrings of the
+   input; the SDK surfaces character offsets, so hallucination auditing is
+   a substring check.
+
+> **Private pre-release.** Weights are staged here ahead of the SDK
+> release.
+
+## Try it
+
+- **iOS / macOS:** Swift SDK coming soon. The int4
+  Core ML encoders in `coreml/` are ANE-validated (8.1 ms/forward at the
+  256-token shape) and eval-confirmed on-device.
+- **Android / web:** ONNX graphs are staged in `onnx/` (int4 web encoder +
+  fp32 support graphs, quality measured through the actual graphs); the JS
+  harness port ships with the SDK.
+- The deterministic harness (relative dates, duration units, format gates,
+  string trims, anchor injection) ships as data in `harness/*.json`; every
+  SDK port must pass the bundled conformance fixtures bit-for-bit.
+
+## Files
+
+| File | Format | Size | Use |
+|---|---|---:|---|
+| `model-int8.pt` | int8 per-row | 218 MB | start here; full quality (0.800 overall) |
+| `model-int4-awq.pt` | int4 AWQ | 111 MB | when download or RAM is tight (0.793 overall) |
+| `model-fp32.pt` | fp32 | 850 MB | converting to other formats; not for deployment |
+| `onnx/encoder_web4e4.onnx` | int4 ONNX | 111 MB | run in the browser or on Android |
+| `onnx/*.onnx` | fp32 ONNX | 80 MB | decoding graphs; always ship with the encoder |
+| `coreml/*.mlpackage.zip` | int4 Core ML | 84 MB each | run on iOS / macOS; 256 + 1216 token shapes, ANE-resident, eval-confirmed on-device |
+| `tokenizer/`, `keep_ids.json` | | 11 MB | required by every runtime |
+| `harness/*.json` | | <1 MB | post-processing and nested-recursion rules every SDK port must implement |
+| `manifest.json` | | | verify downloads; measured quality per artifact |
+
+## Use
+
+The schema is plain JSON (paste an OpenAI/Gemini `responseSchema` and it
+works). One call per document:
+
+```json
+{
+  "title":        {"type": "string",  "describe": "the task title", "max_chars": 60},
+  "guest":        {"type": "string",  "describe": "person the meeting is with", "nullable": true},
+  "start":        {"type": "datetime","describe": "start time", "nullable": true},
+  "duration_min": {"type": "number",  "describe": "duration in minutes", "min": 0, "max": 480, "nullable": true},
+  "is_recurring": {"type": "boolean", "describe": "is this a recurring task"}
+}
+```
+
+Input `"Meeting with Sarah tomorow at 3pm for an hour to review the Q3
+deck. Recurring weekly."` returns (with device time 2026-07-05):
+
+```json
+{"title": "review the Q3 deck", "guest": "Sarah",
+ "start": "2026-07-06T15:00", "duration_min": 60, "is_recurring": true}
+```
+
+Note the typo tolerance, the relative-date resolution, the unit conversion
+("an hour" to 60), and the factoring: the title is the purpose of the
+meeting, the person lands in `guest`, and the temporal clutter lands in
+the temporal fields.
+
+## Model
+
+- **Encoder:** pruned mmBERT-base (22 layers, 103k-token vocabulary kept of
+  256k), jointly encoding `[schema summary ||| document]`. Two compiled
+  input shapes: 256 tokens (records) and 1216 tokens (documents). The
+  1216-token shape is the input limit: schema summary + document together;
+  longer inputs are truncated, so budget roughly 1,100 tokens of document.
+- **Reader:** one shared cross-attention reader over encoder states.
+- **Heads:** thin per-type decoders: label entailment, 3-way boolean
+  (absent/false/true), BIO span tagging for strings and arrays with trained
+  presence gates, datetime and number component decoders.
+- **Harness:** deterministic post-processing (locale number parsing, ISO
+  composition, 13-language relative-date lexicons, format gates). Shipped
+  as data plus a reference implementation; ports are conformance-tested.
+
+## Evaluation
+
+9,021 held-out records across seven usage slices, 13 languages, schemas
+the model never saw, one order-insensitive, absence-aware scorer for
+every model. The overall score weights the slices by product usage:
+short records 0.30, long documents 0.15, long documents with same-type
+distractors 0.15, reviews and registers 0.15, calendar 0.10, factored
+domains 0.10, nested schemas 0.05. Every model ran in its documented
+configuration (tool calling for FunctionGemma, template prompts for
+NuExtract-2.0, JSON chat for the instruct models, in-process span
+extraction for GLiNER2); sizes are measured bytes of the artifact
+benched.
+
+| Model | Overall | Absence (boolean) | Params | On disk |
+|---|---:|---:|---|---|
+| Gemma 4 26B A4B (int4 AWQ) | 0.834 | 0.428 | 26.6B | 17.2 GB |
+| Claude Haiku 4.5 (API) | 0.816 | 0.431 | n/a | API only |
+| Qwen 3.5 9B | 0.812 | 0.434 | 9.1B | 9.1 GB |
+| **Schemer** | **0.800** | **0.911** | 211M | 218 MB int8 |
+| **Schemer (int4)** | **0.793** | 0.908 | 211M | 111 MB int4 |
+| Ministral 3 8B | 0.790 | 0.430 | 8.0B | 17.8 GB |
+| Gemma 4 E2B (official int4 QAT) | 0.780 | 0.427 | 5.1B | 8.3 GB |
+| Qwen 3.5 0.8B | 0.651 | 0.351 | 0.87B | 1.75 GB |
+| NuExtract-2.0-2B | 0.643 | 0.393 | 2.2B | 4.4 GB |
+| GLiNER2-multi | 0.585 | 0.374 | 307M | 309 MB int8* |
+| GLiNER2-base | 0.524 | 0.368 | 205M | 834 MB |
+| NuExtract-tiny-v1.5 | 0.334 | 0.222 | 0.5B | 954 MB |
+| FunctionGemma 270M (tool calling) | 0.288 | 0.181 | 0.27B | 0.54 GB |
+
+*GLiNER2-multi int8 size verified by us with the same
+quantize-and-rebench methodology as our own int8 claim (accuracy held
+within 0.004 of fp32).
+
+### Per slice
+
+| Model | Short | Long doc | Long + distractors | Register | Calendar | Factored | Nested |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Gemma 4 26B A4B | **0.844** | **0.844** | 0.693 | 0.815 | 0.829 | 0.954 | **1.000** |
+| Claude Haiku 4.5 | 0.838 | 0.759 | **0.762** | **0.831** | 0.802 | 0.817 | **1.000** |
+| Qwen 3.5 9B | 0.828 | 0.807 | 0.717 | 0.791 | 0.774 | 0.891 | **1.000** |
+| **Schemer** | 0.759 | 0.708 | 0.685 | 0.829 | **0.946** | 0.946 | 0.988 |
+| **Schemer (int4)** | 0.754 | 0.689 | 0.671 | 0.820 | 0.943 | **0.967** | 0.985 |
+| Ministral 3 8B | 0.818 | 0.811 | 0.711 | 0.720 | 0.796 | 0.790 | 0.998 |
+| Gemma 4 E2B | 0.809 | 0.785 | 0.705 | 0.773 | 0.719 | 0.759 | **1.000** |
+| Qwen 3.5 0.8B | 0.721 | 0.635 | 0.560 | 0.581 | 0.529 | 0.689 | 0.936 |
+| NuExtract-2.0-2B | 0.763 | 0.704 | 0.542 | 0.648 | 0.496 | 0.805 | 0.000† |
+| GLiNER2-multi | 0.683 | 0.650 | 0.388 | 0.662 | 0.468 | 0.783 | 0.000† |
+| GLiNER2-base | 0.619 | 0.587 | 0.371 | 0.612 | 0.362 | 0.668 | 0.000† |
+| NuExtract-tiny-v1.5 | 0.406 | 0.277 | 0.248 | 0.280 | 0.275 | 0.417 | 0.439 |
+| FunctionGemma 270M | 0.339 | 0.254 | 0.232 | 0.274 | 0.299 | 0.421 | 0.000† |
+
+†The NuExtract-2.0, GLiNER2, and FunctionGemma interfaces cannot express
+arrays of objects; their nested cells score the resulting empty output.
+This is an interface limit, not an extraction failure.
+
+### Per field type
+
+Bold marks the best score in each row. Schemer's architecture shows plainly: it owns the typed/absence rows and trails larger extraction LLMs on free-text rows.
+
+| Type | Schemer | Schemer (int4) | NuExtract-2.0-2B (2.2B) | Qwen 3.5 0.8B |
+|---|---:|---:|---:|---:|
+| boolean | **0.911** | 0.908 | 0.393 | 0.351 |
+| datetime | **0.769** | 0.752 | 0.641 | 0.652 |
+| array | **0.766** | 0.750 | 0.731 | 0.686 |
+| number | **0.750** | 0.743 | 0.670 | 0.679 |
+| string | 0.648 | 0.637 | **0.774** | 0.716 |
+| label | 0.629 | 0.609 | **0.636** | 0.616 |
+
+### Per language
+
+Measured on the three slices that cover all 13 languages with identical
+composition (short records, long documents, long documents with
+distractors; ~600 records per language).
+
+| Language | Schemer | Qwen 3.5 0.8B | GLiNER2-multi |
+|---|---:|---:|---:|
+| French | **0.745** | 0.649 | 0.606 |
+| Spanish | **0.734** | 0.662 | 0.610 |
+| Italian | **0.731** | 0.653 | 0.603 |
+| Portuguese | **0.729** | 0.640 | 0.601 |
+| German | **0.728** | 0.635 | 0.591 |
+| Dutch | **0.724** | 0.621 | 0.600 |
+| Danish | **0.723** | 0.618 | 0.594 |
+| English | **0.717** | 0.706 | 0.632 |
+| Norwegian | **0.717** | 0.620 | 0.600 |
+| Swedish | **0.715** | 0.633 | 0.624 |
+| Japanese | **0.707** | 0.614 | 0.384 |
+| Chinese | **0.683** | 0.640 | 0.408 |
+| Polish | **0.670** | 0.609 | 0.597 |
+
+Schemer scores 0.800 overall; every model above it runs 9.1B to 26.6B
+parameters or an API. NuExtract-2.0-2B, the closest task-specific
+extractor, scores 0.643 at ten times the parameters. Schemer wins all
+13 languages against both the strongest sub-1B LLM and GLiNER2-multi,
+posts the top calendar score of any model at any size (0.946 next to
+the 26B's 0.829), and is the only model with reliable absence detection
+(0.911 next to a 0.18 to 0.43 field). Long documents: 0.708 at ~1,100
+tokens; 0.685 when the document contains same-type distractor records.
+
+## Limitations
+
+- **Nested schemas** extract via the harness (segment and recurse), not
+  the model itself: quality on messy real-world prose is not yet benched
+  externally; the 0.99 figure is our internal template-based eval.
+- **Extractive strings only:** Schemer will not compose or rewrite text;
+  abstractive titles from messy prose trail extraction LLMs (string
+  0.641 vs 0.774 for NuExtract-2.0-2B and ~0.86 for the 8B+ class). It
+  does factor titles extractively (purpose clause, people and times split
+  into their fields), but the title is always a substring of the input.
+- **Judgment labels** requiring world knowledge (severity triage) trail
+  the 8B+ class (0.629 vs ~0.82).
+- **Not a NER model:** it fills your fields; it does not enumerate every
+  entity mention (CrossNER span-F1 0.24 vs GLiNER2's 0.59).
+- English is the weakest of the 13 languages relative to competitors.
+
+## Citation
+
+```bibtex
+@software{schemer_2026,
+  title  = {Schemer: on-device text to structured JSON},
+  author = {Desert Ant Labs},
+  year   = {2026},
+  url    = {https://huggingface.co/desert-ant-labs/schemer}
+}
+```
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for
+most apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.

--- a/docs/hub-cards/shapes.md
+++ b/docs/hub-cards/shapes.md
@@ -1,0 +1,97 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+tags:
+- strokes
+- shapes
+- sketches
+- pen-input
+- on-device
+- core-ml
+- litert
+- tflite
+- pencilkit
+pipeline_tag: image-classification
+---
+
+# Shapes: on-device shape recognition from a single stroke
+
+Takes a single hand-drawn stroke (an ordered list of points) and recognizes it as
+a clean geometric shape, returning fitted vector geometry ready to snap to. Built
+for PencilKit-style "smart shapes": draw, pause, and the rough stroke becomes a
+crisp shape. The model is tiny (**about 0.2 MB** Core ML, **~1.3 MB** LiteRT) and
+runs in a few milliseconds on device.
+
+> ✏️ ➜ ▭  ·  ✏️ ➜ △  ·  ✏️ ➜ ◯  ·  ✏️ ➜ ★
+
+## Try it
+
+All platforms ship from one repo: **[Desert-Ant-Labs/shapes](https://github.com/Desert-Ant-Labs/shapes)** (Swift, Kotlin, and JavaScript in a single codebase).
+
+- **Live demo:** [desert-ant-labs/shapes-demo](https://huggingface.co/spaces/desert-ant-labs/shapes-demo): draw one stroke, get a fitted shape, fully in your browser.
+- **iOS / macOS / tvOS / visionOS:** the Swift SDK (Swift Package Manager) with a one-line `PKCanvasView.enableShapeSnapping()` and a demo app. It bundles the compiled Core ML model below.
+- **Android / JVM (Kotlin):** Maven Central `ai.desertant:shapes` with LiteRT (`.tflite`). The small model is bundled by default; exclude `ai.desertant:shapes-tflite-resources` to force on-demand download or explicit-directory loading.
+- **Node / browser (JavaScript / TypeScript):** `npm i @desert-ant-labs/shapes @litertjs/core` for browser builds, or just `npm i @desert-ant-labs/shapes` for server-side Node. The npm package downloads the model from this repo on first use and caches it (nothing model-sized ships in the tarball); browser inference uses [LiteRT.js](https://www.npmjs.com/package/@litertjs/core), and Node uses prebuilt native libraries. Pass `directory` (Node) or `modelBaseUrl` (browser) to self-host / run offline.
+
+## Files
+
+| File | Format | Size | Contents |
+|---|---|---:|---|
+| `shapes.tflite` | LiteRT / TFLite (fp32) | ~1.3 MB | Fixed `[1,256,3]` features + `[1,256]` mask window; runs on Android, Linux, Node, and the web (bundled by default in the Kotlin SDK; downloaded on demand by the JavaScript SDK) |
+| `shapes.mlmodelc` | Compiled Core ML | ~0.2 MB | 4-bit-palettized classifier, ready to load on Apple platforms (used by the Swift SDK) |
+| `shapes_meta.json` | JSON | tiny | classes, preprocessing constants, model dims, and snap gates |
+| `shapes.safetensors` | safetensors | ~0.2 MB | packed portable weights (reference) |
+| `model.pt` | PyTorch checkpoint | ~1.5 MB | trained weights (for export / fine-tuning) |
+| `config.json` | JSON | tiny | class list, preprocessing constants, and per-class snap gates |
+
+Older revisions (tag `v0.1.0`) carry `shapes.onnx` for SDK versions that predate the LiteRT migration.
+
+## How it works
+
+Two stages, *the network proposes, geometry verifies*:
+
+1. **Classify**: the stroke is resampled and fed to a compact sequence classifier
+   (Conv1d stem → small Transformer encoder → masked mean-pool → MLP), which
+   predicts the shape type (or `none` to reject scribbles).
+2. **Fit + snap**: a classical geometric fitter produces clean vector parameters
+   (min-area box, moment/PCA ellipse, max-area triangle, …), then regularizes them
+   (snap to axes, circles, squares, and 15° rotation increments). A fit-residual
+   gate vetoes poor fits so non-shapes stay rejected.
+
+## Inputs and outputs
+
+- **Input:** an ordered list of stroke points in canvas coordinates. Single stroke.
+- **Output:** a shape class plus fitted geometry, or nothing if the stroke is rejected.
+
+## Classes
+
+`line`, `rectangle`, `triangle`, `ellipse`, `star`, plus `none` (the reject class:
+scribbles, partial shapes, and other non-shape strokes). Squares and circles are
+covered by `rectangle` and `ellipse` (snapped when near-regular).
+
+## Limitations
+
+- Single stroke only; multi-stroke shapes aren't recognized.
+- Tuned for deliberate shapes; very rough or ambiguous strokes are rejected by design.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for
+most apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.
+
+## Citation
+
+```bibtex
+@software{shapes_2026,
+  title  = {Shapes: on-device shape recognition from a single stroke},
+  author = {Desert Ant Labs},
+  year   = {2026},
+  url    = {https://huggingface.co/desert-ant-labs/shapes},
+}
+```
+
+---
+
+© 2026 Desert Ant Labs · <https://desertant.com>

--- a/docs/hub-cards/title.md
+++ b/docs/hub-cards/title.md
@@ -1,0 +1,84 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- multilingual
+tags:
+- text
+- text-generation
+- summarization
+- on-device
+- mlx
+- multilingual
+pipeline_tag: text-generation
+---
+
+# title
+
+Writes a title and a one or two sentence description for a passage of text, on device.
+
+Fine-tuned on transcript clips, but the task it learned is general: it takes prose and returns
+a card for it. The register is deliberately plain, with no emoji, no hashtags and no clickbait,
+and a description is meant to identify *this* passage rather than its topic.
+
+## Files
+
+An MLX model directory. Load the folder, not a single file.
+
+| File | Contents |
+|---|---|
+| `model.safetensors` | 6-bit quantized weights |
+| `model.safetensors.index.json` | shard index; present even for one shard, because the loader reads it |
+| `config.json` | architecture and quantization config |
+| `generation_config.json` | decode defaults |
+| `tokenizer.json`, `tokenizer_config.json` | byte-level BPE with merges |
+| `chat_template.jinja` | the chat template the fine-tune was trained against |
+
+The chat template is not incidental. A different template is a different task to this model.
+
+## The prompt
+
+The model was fine-tuned against one specific instruction, and a paraphrase is a different
+task to it. It lives in `Titles.prompt` in the SDK; use that wording. The reply is two labelled
+lines:
+
+```
+TITLE: <3-8 words, no final punctuation>
+DESC: <1-2 sentences>
+```
+
+Parse tolerantly. A card model that drifts off format should degrade to a usable title rather
+than throw.
+
+## Apple only
+
+MLX runs on Apple silicon and nowhere else, so there is no Android, Linux or Windows artifact
+here and no manifest promising one. A Core ML export exists in the training repository and is
+kept as evidence rather than as a candidate: on short autoregressive decode the Neural Engine
+is bandwidth-bound, and the Core ML arm lost on first token, throughput, load time and resident
+memory.
+
+## Status
+
+Internal testing, and less settled than that phrase usually implies. This card carries no
+quality figures: no independent review has been completed, and a known open issue is that the
+model sometimes opens a description with a stock phrase its own instruction forbids. Treat the
+output as needing a read before it reaches a user.
+
+## Built on
+
+- [`ibm-granite/granite-4.0-350m`](https://huggingface.co/ibm-granite/granite-4.0-350m) —
+  the base model this is fine-tuned from.
+
+See [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for most
+apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.
+
+---
+
+© 2026 Desert Ant Labs · <https://desertant.com>

--- a/docs/hub-cards/tongue.md
+++ b/docs/hub-cards/tongue.md
@@ -1,0 +1,229 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- multilingual
+tags:
+- language-identification
+- language-detection
+- langid
+- text-classification
+- on-device
+- edge-ai
+- mobile
+- browser
+- offline
+- onnx
+- multilingual
+pipeline_tag: text-classification
+---
+
+# tongue: on-device language identification for short text
+
+Takes a short piece of text and names the language it is written in. Tuned for
+the regime where language detection is hardest and most useful on a device —
+search boxes, chat messages, keyboard input — across **84 languages**. The
+shipped weights are **2 MB** int8 (2,104,940 bytes), there is no tokenizer and no vocabulary
+file, and a detection costs tens of microseconds.
+
+> `"kann ich das haben"` → German · `"안녕하세요"` → Korean · `"привет как дела"` → Russian · `"quanto costa il biglietto"` → Italian
+
+On genuinely ambiguous input it says so rather than guessing: `"la casa"` comes
+back as Italian *or* Spanish, because the phrase is equally both.
+
+**Live demo:** [desert-ant-labs/tongue-demo](https://huggingface.co/spaces/desert-ant-labs/tongue-demo)
+— runs entirely in your browser; nothing you type leaves the page.
+
+## Files
+
+| File | Format | Size | Contents |
+|---|---|---:|---|
+| `tongue_int8.bin` | Raw int8 + fp32 | 2.01 MiB | The shipped artifact: int8 embedding table, fp32 linear head and bias. Byte-identical to what the live demo runs. |
+| `tongue_int4.bin` | Raw int4 + fp32 | 1.01 MiB | Half-size alternative for tight bundles. Same architecture, 4-bit embedding. Costs roughly 0.4pp on short text — see Sizes. |
+| `tongue.onnx` | ONNX (fp32, opset 17) | 8.4 MB | Portable graph for onnxruntime / onnxruntime-web. Verified against the PyTorch reference. |
+| `tongue.pt` | PyTorch checkpoint (fp32) | 8.4 MB | Full-precision weights for retraining or other runtimes. |
+| `tongue_meta.json` | JSON | tiny | Label order, bucket count, embedding dimension, n-gram orders, int8 scale, and the per-script routing tables a runtime needs. |
+| `labels.json` | JSON | tiny | The 59 model labels plus the script-decided languages, with English and native names. |
+| `config.json` | JSON | tiny | Training configuration and per-language validation accuracy. |
+
+There is no tokenizer file. tongue hashes raw character n-grams, so nothing has
+to be shipped or version-matched alongside the weights.
+
+## Architecture
+
+Two stages. No encoder, no learned tokenizer, no per-language models.
+
+- **Script router (zero parameters).** A [UAX #24](https://www.unicode.org/reports/tr24/)
+  script table decides any text whose script belongs to one language outright —
+  Hangul → Korean, Greek → Greek, Thai → Thai — and narrows multi-language
+  scripts (Cyrillic, Arabic, Devanagari, Bengali) to their candidate sets before
+  the model runs. Presence beats dominance, so a Latin brand name embedded in
+  Greek text does not derail the route.
+- **Lexical model.** FNV-1a-hashed character n-grams (orders 1–5, marked with
+  word boundaries) over Unicode scalars, summed through an int8 `EmbeddingBag`
+  into a linear head, decoded with a per-script masked softmax. The hash table
+  *is* the feature space, so model size does not grow with the language count.
+- **Prior correction.** The training corpus caps large languages and under-fills
+  thin ones, so the head absorbs a label prior. A fixed `-tau*log(prior)` shift
+  (tau = 0.75) is folded into the exported bias, which costs nothing at runtime
+  and keeps confusion pairs from collapsing onto the better-resourced side.
+- **Calibrated abstention.** Reliability is keyed off input length and the margin
+  between the top two candidates, not raw softmax confidence — which is
+  overconfident on very short text. Below the threshold the model reports a
+  tentative answer or a tie instead of committing.
+
+## Inputs and outputs
+
+**Input:** a short UTF-8 string. The runtime normalizes it (NFC, lowercase, URLs
+/ mentions / digits stripped, 512-character cap), hashes n-grams, and consults
+the router before the graph.
+**Output:** ranked ISO 639-1/639-3 codes with probabilities, plus a reliability
+signal (`confident` / `likely` / `tentative`). Script-decided inputs return a
+single confident answer.
+
+The ONNX graph carries **only the head**: `values` (int64 hashed bucket ids) and
+`offsets` (int64 per-sample starts) in, `logits` out. The normalizer, hasher and
+router are reimplemented natively per platform and verified against golden
+vectors — they must run before the model is consulted, and on inputs the model
+never sees. `tongue_meta.json` documents both tables.
+
+## Coverage
+
+59 languages are learned by the lexical model and a further 25 are decided by
+script alone, across 31 scripts — Latin, Cyrillic, Arabic, Greek and the CJK and
+Indic families among them — for **84 languages** in total. One of the 84,
+Mongolian, is detected only in the traditional Mongolian script; see failure
+mode 3.
+
+## Sizes
+
+Two quantisations of the same weights ship side by side. Pick on bundle budget,
+not on principle.
+
+| | `tongue_int8.bin` | `tongue_int4.bin` |
+|---|---|---|
+| Size | 2.01 MiB | **1.01 MiB** |
+| FLORES 2-word | 0.869 | 0.866 |
+| FLORES 5-word | 0.974 | 0.973 |
+| Held-out single words | 0.759 | 0.752 |
+| Held-out sentences | 0.971 | 0.970 |
+
+int4 uses one scale per embedding dimension with the scale clipped at the 99th
+percentile — plain max-scaling spends most of the 16 levels on a handful of
+outliers and costs 3.8pp instead of 0.4pp. The loss lands almost entirely on
+one- and two-word input, where there are fewer n-grams for quantisation error
+to cancel across; full sentences are unaffected within measurement noise. Since
+short text is what this model is for, int8 stays the default and int4 is the
+option when a megabyte matters more than the last half point.
+
+## Failure modes (read before deploying)
+
+Publishing these is part of the product.
+
+**1. One or two words is often genuinely undecidable, and no model size fixes
+it.** A single common word frequently belongs to several languages at once
+(`"sale"` is English, French and Italian; `"la casa"` is equally Italian and
+Spanish). tongue reports a tie or a tentative answer in these cases. It does not
+catch every one: a phrase mixing languages, like `"un garage sale"`, can still
+draw a confident-looking single answer.
+Mitigation: treat low-reliability output as "unknown", not as an answer, and ask
+for more text where the product allows it.
+
+**2. Malay and Indonesian are not reliably separable.** They share vocabulary
+and orthography to the point where short samples carry no distinguishing
+signal. This is a structural limit, not a tuning gap — it is not cheaply
+closable at this size, and every detector we measured struggles with it.
+Mitigation: if you need the distinction, treat `ms`/`id` as one bucket or
+disambiguate from user locale.
+
+**3. Mongolian is detected only in the traditional Mongolian script.**
+Mongolian written in Cyrillic — the dominant modern orthography — is not
+distinguished from the other Cyrillic languages and will usually come back as
+Russian. The language count includes Mongolian because the traditional script
+works; Cyrillic Mongolian does not. Mitigation: do not rely on tongue for
+Cyrillic Mongolian.
+
+**4. Brand names, numbers and code are not language.** `"Samsung Galaxy"`,
+`"v1.2.3"` and `"2024 annual report"` have no correct answer; the model will
+still return its best guess for anything with letters in it. Mitigation: filter
+non-prose input before detection.
+
+**5. Single-word scores are vocabulary recognition, not generalization.** The
+frequent words of a language appear in everyone's training data, so any
+detector's single-word accuracy partly measures memorized vocabulary. Read the
+word-pair and sentence numbers as the generalization signal.
+
+## Measured quality (the shipped artifact, not the checkpoint)
+
+Every number below is measured on the shipped int8 weights, on three
+public benchmarks, with other detectors run on the identical rows and language
+subsets. Higher is better.
+
+### FLORES-200 — a benchmark none of these detectors trained on
+
+Sentences from FLORES-200 truncated to their first 2, 3 and 5 words. Accuracy
+over the 20 languages the three detectors share.
+
+| Detector | Size | 2 words | 3 words | 5 words |
+|---|---|---|---|---|
+| **tongue** | **2 MB** | **0.869** | **0.933** | **0.974** |
+| lingua | 293 MB | 0.800 | 0.887 | 0.956 |
+| eld | ~1 MB | 0.780 | 0.856 | 0.912 |
+
+### The lingua test set — the benchmark that library publishes
+
+1,000 single words, word pairs and sentences per language, drawn from the
+same collection lingua trains on. Accuracy over the languages we share.
+
+| Detector | Size | Single words | Word pairs | Sentences |
+|---|---|---|---|---|
+| **tongue** | **2 MB** | **0.746** | **0.909** | **0.988** |
+| lingua | 293 MB | 0.752 | 0.915 | 0.985 |
+
+### eld — an independent benchmark, held out from training
+
+Accuracy over the languages tongue supports (53,035 single-word rows,
+53,613 word pairs, 53,141 sentences, 9,066 tweets).
+Apple is the built-in system detector; HeLI-OTS is a 51 MB JVM model. lingua 2.2.0 installs as a
+single 293 MB compiled extension with its language models embedded.
+
+| Detector | Size | Tweets | Single words | Word pairs | Sentences |
+|---|---|---|---|---|---|
+| **tongue** | **2 MB** | **0.992** | **0.759** | **0.887** | **0.971** |
+| lingua | 293 MB | 0.984 | 0.756 | 0.894 | 0.950 |
+| HeLI-OTS | 51 MB | 0.986 | 0.683 | 0.843 | 0.967 |
+| Apple | system | 0.997 | 0.641 | 0.719 | 0.748 |
+
+## How these numbers were made
+
+- **Benchmarks are eval-only.** FLORES-200, WiLI-2018 and the eld benchmark are
+  never trained on. Leipzig/Wortschatz corpora are excluded from training in
+  every form, because a competing detector's published test set is drawn from
+  them.
+- **Evaluation splits are leakage-controlled.** The training corpus is split
+  along the Tatoeba translation-link graph, so a sentence and its translations
+  cannot straddle train and validation.
+- **Numbers are re-measured on the exported bytes**, not extrapolated from the
+  training checkpoint, and the pure-JavaScript runtime is verified against the
+  Python reference on golden vectors (currently 119/119 identical, worst
+  probability delta 1.1e-16).
+- **Latency** is measured per single detection in JavaScript on an Apple-silicon
+  laptop: 0.013 ms for one word, 0.028 ms for a short sentence, 0.10 ms at 193
+  characters (p99 0.24 ms). On-device budgets on phone-class hardware will be
+  higher; the design target is under 1 ms.
+
+## Training data
+
+Built exclusively from commercially clean components: Tatoeba (CC BY 2.0 FR),
+Common Voice sentence collections (CC0), Wikidata Lexemes (CC0), Hunspell
+dictionaries (permissive per-dictionary) and five Universal Dependencies
+treebanks (CC BY 4.0). Share-alike sources are excluded by policy and by build
+check — no Wikipedia or Europarl text enters training. Attributions and dataset
+citations are in `THIRD_PARTY_NOTICES.md`.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0).
+Free for most apps; a commercial license is required at scale. Full terms at the
+link. Licensing: <licensing@desertant.com>.

--- a/docs/hub-cards/toxic.md
+++ b/docs/hub-cards/toxic.md
@@ -1,0 +1,442 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- en
+- de
+- fr
+- nl
+- pt
+- es
+- it
+- pl
+- da
+- sv
+- fi
+- hu
+- cs
+- sk
+- sl
+- hr
+- bg
+- el
+- ro
+- lt
+- lv
+- et
+- ga
+tags:
+- hate-speech
+- hate-speech-detection
+- toxicity-classification
+- content-moderation
+- offensive-language
+- text-classification
+- on-device
+- edge-ai
+- mobile
+- ios
+- android
+- browser
+- offline
+- litert
+- tflite
+- core-ml
+- coreml
+- onnx
+- multilingual
+pipeline_tag: text-classification
+---
+
+# toxic: on-device multilingual hate-speech and abuse triage
+
+`toxic` v0.1.0: a multilingual toxicity classifier for on-device hate
+speech detection and content moderation triage. Three content heads
+(`HATEFUL`, `ABUSIVE`, `THREAT`) plus protected-group target heads, across
+23 languages; each head is named for what its training labels measure and
+benchmarked individually below. Inference is 100% on-device: no text
+leaves the device to be scored.
+
+**0.847 macro-F1 on real Multilingual HateCheck across the seven EU
+languages** (de, fr, nl, pt, es, it, pl), measured on the shipped weights;
+three independent training runs of this recipe average **0.834**.
+
+**Out-of-domain corroboration, real in-the-wild corpora (binary
+toxic-vs-clean):** textdetox **0.724** macro-F1 (5 languages) and
+offenseval2020 **0.658** (3 languages), shipped weights, method stated
+with the tables below. These two sets share no construction lineage with
+our development benchmarks, which is exactly why they are here.
+
+**Provenance is load-bearing in this card and never blurred.** Eight of the
+23 languages (English plus the 7-EU set) are scored on real Multilingual
+HateCheck, the published, peer-reviewed benchmark. The other 15 are scored
+on translate-and-audit synthetic evaluation sets built for this project;
+those numbers are development-benchmark estimates, not MHC-comparable, and
+are never averaged into the 7-EU headline. Per-language tables for both
+tiers below are re-measured on the exact shipped bytes.
+
+**Looking for English only?** See
+[`toxic-en`](https://huggingface.co/desert-ant-labs/toxic-en), the English
+specialist. Same idea as Whisper's `.en` models: this multilingual model
+covers English too, but a model trained only on English does the job better
+for English-first apps. The English specialist scores
+0.855 on English real HateCheck against this model's 0.852; its card carries
+the per-artifact numbers.
+
+**Triage, not verdict.** Outputs are escalation signals for human review or
+a heavier local tier, not autonomous removal decisions. The failure modes
+below are published on purpose: read them before wiring the model into any
+enforcement path.
+
+## Try it
+
+[`desert-ant-labs/toxic-demo`](https://huggingface.co/spaces/desert-ant-labs/toxic-demo),
+a Hugging Face Space. Type or paste text and watch the scores live in the
+browser; nothing you type leaves the page.
+
+## Taxonomy: three heads, each named for its supervision
+
+Three content heads and ten target heads share one encoder, exposed as two
+multi-label output layers (content and target). Text can fire several heads
+at once; thresholds apply per head.
+
+- **`HATEFUL`**: public incitement to violence or hatred against a protected
+  group. Scoped to the EU notion of illegal hate speech (Framework Decision
+  2008/913/JHA).
+- **`ABUSIVE`**: abusive and insulting language, severity-ordered. Trained
+  on human severity annotations (civil_comments `insult` / `identity_attack`
+  crowd votes and per-corpus equivalents). It is a superset of `HATEFUL`: a
+  group-identity attack is also abusive language. It is **not** a
+  directedness signal: it does not tell you the abuse is aimed at the
+  reader, at a named person, or at anybody in particular, and integrations
+  must not infer that from the name or from a high score.
+- **`THREAT`**: threat of violence toward a person or group.
+- **Target heads (10):** the 2008/913/JHA protected grounds `RACE`,
+  `COLOUR`, `RELIGION`, `DESCENT`, `NATIONAL_ETHNIC_ORIGIN`, plus the
+  extended grounds `SEXUAL_ORIENTATION`, `GENDER`, `DISABILITY`, `AGE`,
+  `OTHER`. Only meaningful when `HATEFUL` fires; used for per-ground
+  fairness reporting.
+
+The `disabled_heads` mechanism in the meta (currently empty) is the valve
+for shipping any future failed gate safely: a head named there is pinned to
+an unreachable threshold on every platform.
+
+## Files
+
+| File | Format | Size | Contents |
+|---|---|---:|---|
+| `toxic.tflite` | LiteRT / TFLite (int4 blockwise-32) | 90.6 MB | Android and Linux, native LiteRT kernels |
+| `toxic.onnx` | ONNX (int4 + int4 embedding) | 100.2 MB | Browser artifact for ONNX Runtime Web |
+| `toxic.mlmodelc` | Core ML (4-bit palettized) | 80.2 MB | iOS / macOS, CPU+Neural Engine |
+| `toxic.pt` | PyTorch state dict (fp32) | 638.5 MB | Torch reference weights (~159.6M params, trimmed vocab) |
+| `config.json` | JSON | tiny | Encoder + head config (base, labels, `max_len`, vocab size) |
+| `tokenizer.json`, `tokenizer_config.json` | JSON | 3.7 MB | Trimmed (95,552-piece) SentencePiece-Unigram tokenizer (XLM-R lineage) |
+| `toxic_tokenizer.bin` | binary | 1.3 MB | The same tokenizer, precompiled binary form |
+| `labels.json` | JSON | tiny | `id2label` / `label2id` for both heads |
+| `toxic_meta.json` | JSON | tiny | Schema, labels, per-head + per-language thresholds, `disabled_heads` |
+
+Artifact sizes and per-artifact quality were re-measured on the exact
+shipped bytes at export; nothing in this table is extrapolated from a
+training checkpoint.
+
+## Measured quality
+
+### 7-EU real Multilingual HateCheck (the headline harness)
+
+| model | 7-EU macro-F1 |
+| --- | --: |
+| **Shipped weights (torch reference)** | **0.8470** |
+| Training-run mean, 3 seeds (0.8219 / 0.8323 / 0.8470) | 0.8337 |
+
+The shipped weights are the strongest of three full training runs; the mean
+is what a retrain of this recipe should reproduce.
+
+### Per language, real Multilingual HateCheck, on the shipped bytes
+
+| language | torch reference | ONNX int4 (browser) | TFLite int4 (Android) |
+| --- | --: | --: | --: |
+| Dutch (nl) | 0.834 | 0.825 | 0.816 |
+| German (de) | 0.865 | 0.861 | 0.850 |
+| French (fr) | 0.861 | 0.848 | 0.828 |
+| Italian (it) | 0.839 | 0.823 | 0.830 |
+| Spanish (es) | 0.844 | 0.846 | 0.825 |
+| Polish (pl) | 0.837 | 0.833 | 0.828 |
+| Portuguese (pt) | 0.850 | 0.834 | 0.836 |
+| English (en) | 0.852 | 0.839 | 0.857 |
+| **7-EU mean** | **0.8470** | **0.8386** | **0.8304** |
+
+Quantization costs, measured: ONNX int4 -0.8 points against the torch
+reference on the 7-EU mean, TFLite int4 -1.7, Core ML int4 -1.5 (7-EU
+0.8320, English 0.796, measured through the Core ML runtime on Apple
+silicon at the release's pinned CPU+Neural Engine configuration). English
+costs Core ML more than the other lanes; English-first iOS apps should
+prefer the English specialist. Threshold 0.40 throughout: that is the
+shipped default for `HATEFUL`, the only head this hate-only benchmark
+exercises (`ABUSIVE` and `THREAT` ship at 0.50).
+
+### Against runnable local baselines, same harness, same rows
+
+Every system below was scored by this project's own HateCheck harness on
+identical rows, so the comparison measures the models, not the plumbing.
+Our operating point is the shipped 0.40 default. Each competitor's
+operating point, stated in full:
+
+- **Llama-Guard-3-1B** emits a binary safe/unsafe verdict; there is
+  nothing to tune.
+- **Qwen3Guard-Gen-0.6B** emits a third "controversial" verdict on 19 to
+  34% of these rows per language. The table counts only a strict "unsafe"
+  as a hate verdict, the mapping that favors it: counting "controversial"
+  as hateful drops its 7-EU mean from 0.652 to 0.563 and English from
+  0.770 to 0.600, measured.
+- **Detoxify multilingual** is scored at its published 0.5 default. A
+  per-language best-threshold search lifts its 7-EU mean only to 0.498,
+  so the gap is not an operating-point artifact.
+- **Shieldstral-1.0-3B** (Mistral, August 2026) is policy-adaptive: it
+  takes a written policy at inference time and returns a calibrated
+  yes/no score in one forward pass. It was given this benchmark's own
+  target definition (hate toward protected groups, with counter-speech,
+  reclaimed slurs, and abuse at non-protected targets stated as non-hate)
+  and scored at its calibrated 0.5 default; a per-language threshold
+  sweep lifts its 7-EU mean only to 0.791. Of four policy wordings
+  tested, including Mistral's own strict-moderator card example, this one
+  scores highest for Shieldstral (the alternatives cost it 2.0 to 3.9
+  points on en/de) and is the only one whose best threshold is the
+  calibrated default, so the row shows the model at its measured best.
+  Its one published artifact is bf16 (7.7 GB, a 16 GB-GPU model):
+  runnable locally, not phone-class.
+
+| system | params | 7-EU macro-F1 | English |
+| --- | --- | --: | --: |
+| **toxic v0.1.0 (shipped weights, torch)** | 159.6M | **0.847** | 0.852 |
+| Shieldstral-1.0-3B | 3B | 0.786 | 0.820 |
+| Qwen3Guard-Gen-0.6B | 0.6B | 0.652 | 0.770 |
+| Llama-Guard-3-1B | 1B | 0.649 | 0.814 |
+| Llama-Guard-3-1B (int4) | 1B | 0.633 | 0.794 |
+| Qwen3Guard-Gen-0.6B (int4) | 0.6B | 0.622 | 0.750 |
+| Detoxify multilingual | 278M | 0.487 | 0.642 |
+
+The [`toxic-en`](https://huggingface.co/desert-ant-labs/toxic-en) English
+specialist scores 0.855 on the same English set at 31.9M parameters.
+
+For literature context (not measured with this harness): fine-tuned
+task-specific English models reach 0.85 to 0.90 macro-F1 on English
+HateCheck, and Röttger et al. (2021) report commercial cloud APIs around
+0.60. Our English scores (0.852 multilingual, 0.855 specialist) sit inside
+the published fine-tuned band, on device.
+
+Prompted general-purpose local LLMs were measured on the English set too.
+Gemma 4 12B reaches 0.958 and beats every dedicated classifier including
+ours, at roughly 75x this model's parameters. The only other prompted
+model to match us is Granite 4.0 tiny (7B) at 0.856, some 220x the
+parameters of `toxic-en`. Every prompted model under 4B scored below both
+of our models. Cloud APIs are deliberately not on this card: everything
+compared here runs locally, under your control, and the bolded row runs
+on a phone.
+
+### Out of domain, real corpora (binary toxic-vs-clean)
+
+Shipped torch reference. Our prediction is the union of the three content
+heads (max probability at threshold 0.40, exactly the release's flag-if-any
+rule); Detoxify multilingual scores the same rows at its conventional
+0.50. Neither model is threshold-tuned on the benchmark. Means are
+unweighted over the listed languages: the intersection of each benchmark's
+languages with our 23.
+
+| benchmark | languages | toxic macro-F1 | toxic ROC-AUC | Detoxify macro-F1 | Detoxify ROC-AUC |
+| --- | --- | --: | --: | --: | --: |
+| textdetox | en, de, fr, es, it | 0.724 | 0.843 | 0.771 | 0.865 |
+| offenseval2020 | en, da, el | 0.658 | 0.804 | 0.673 | 0.737 |
+
+Read per language before deploying: Detoxify's wins concentrate in
+English, its home construct and register (0.964 and 0.925 macro-F1 there);
+on German textdetox it collapses to 0.353 where this model holds 0.765.
+These corpora label broad offensiveness rather than this card's taxonomy,
+so this section measures construct transfer, not the heads on their own
+definitions.
+
+### Per head, held-out civil_comments, vs Detoxify-unbiased
+
+Same data, same split, paired confidence intervals; ROC-AUC because the two
+models calibrate differently. Detoxify-unbiased is the incumbent
+same-architecture-class classifier, scored on its home dataset. Measured on
+the shipped weights, 97,320 held-out rows.
+
+| head | toxic v0.1.0 (shipped weights) | Detoxify-unbiased | delta 95% CI |
+| --- | --: | --: | --- |
+| `HATEFUL` | 0.9801 | 0.9887 | [-0.011, -0.006] |
+| `ABUSIVE` (its supervision) | 0.9508 | 0.9778 | [-0.029, -0.025] |
+| `THREAT` | 0.9761 | 0.9892 | [-0.020, -0.005] |
+
+Read this honestly: these are close losses on Detoxify's home dataset. We
+carry 23 languages and 3 heads on one trunk; Detoxify-unbiased is an
+English-only model evaluated where it trained. The next table is what the
+multilingual trunk buys.
+
+### German, germeval2018 held-out 10% (ROC-AUC)
+
+We trained on the other 90% of germeval2018 and say so; Detoxify
+multilingual did not train on it. Shipped weights, 420 held-out rows,
+paired bootstrap CIs on the AUC difference.
+
+| head | toxic v0.1.0 (shipped weights) | Detoxify multilingual | delta 95% CI |
+| --- | --: | --: | --- |
+| `HATEFUL` | 0.8523 | 0.5912 | [+0.196, +0.331] |
+| `ABUSIVE` | 0.8777 | 0.4984 | [+0.292, +0.466] |
+
+### HateXplain: human labels, out of domain, length-unconfounded
+
+HateXplain was never trained on, its labels are human, and its hate and
+non-hate classes have matched length distributions, so a length shortcut
+scores nothing here.
+
+Shipped weights, 20,148 posts, three human annotators each.
+
+| contrast | subset | `HATEFUL` ROC-AUC |
+| --- | --- | --: |
+| hate vs normal | all posts | 0.8238 |
+| hate vs normal | unanimous annotators | 0.8823 |
+| hate vs offensive | all posts | 0.6820 |
+| hate vs offensive | unanimous annotators | 0.7247 |
+
+The hate-vs-offensive numbers are the honest ones to sit with: separating hate from
+merely offensive text is much harder than separating hate from normal text,
+for this model and for the field. Do not build a product feature that
+requires the hate/offensive boundary to be sharp.
+
+### The 15 synthetic-eval languages
+
+The 15 languages beyond the real-MHC set are scored on translate-and-audit
+synthetic sets built for this project (`data/eval/mhc_v2/`). Those numbers
+are provenance-tagged development estimates and are never co-averaged with
+real-MHC numbers, in this card or anywhere else. 444 rows across these sets
+(0.8%) could not be fully verified by the translation audit and are counted
+in these numbers (the eval harness has no per-row exclusion path); Danish,
+Latvian and Swedish carry the largest shares. Torch reference, threshold
+0.40:
+
+| language | macro-F1 (synthetic set, torch) |
+| --- | --: |
+| Danish (da) | 0.866 |
+| Swedish (sv) | 0.863 |
+| Finnish (fi) | 0.747 |
+| Hungarian (hu) | 0.746 |
+| Czech (cs) | 0.780 |
+| Slovak (sk) | 0.791 |
+| Slovenian (sl) | 0.760 |
+| Croatian (hr) | 0.795 |
+| Bulgarian (bg) | 0.829 |
+| Greek (el) | 0.788 |
+| Romanian (ro) | 0.833 |
+| Lithuanian (lt) | 0.729 |
+| Latvian (lv) | 0.744 |
+| Estonian (et) | 0.778 |
+| Irish (ga) | 0.670 |
+| mean (never co-averaged with real MHC) | 0.7812 |
+
+The same baselines were run on these synthetic sets, same rows for every
+system. Read this one asymmetrically: we trained toward these 15 languages
+and the baselines did not, so it demonstrates coverage they do not have
+rather than a like-for-like quality win.
+
+| system | params | synth-15 mean macro-F1 |
+| --- | --- | --: |
+| **toxic v0.1.0 (shipped weights, torch)** | 159.6M | **0.781** |
+| Shieldstral-1.0-3B | 3B | 0.684 |
+| Llama-Guard-3-1B | 1B | 0.446 |
+| Qwen3Guard-Gen-0.6B | 0.6B | 0.439 |
+| Detoxify multilingual | 278M | 0.291 |
+
+Shieldstral is the only baseline that holds a real score here, and it
+loses on the languages with the least text behind them: Irish 0.537 and
+Estonian 0.529 against this model's 0.670 and 0.778, consistent with the
+low-resource weakness Mistral reports in the [Shieldstral
+paper](https://arxiv.org/abs/2607.25857) (Table 8: their own
+prompt-classification scores fall away on Indonesian and Arabic).
+Every row here is scored on the repaired sets: the three older baselines
+were re-measured after 4 unusable Bulgarian rows were dropped, and not one
+of their numbers moved at this precision.
+
+## How these numbers were made
+
+The evaluation discipline is the product as much as the weights are:
+
+- **Every artifact-bound number is re-measured on the exact shipped bytes**,
+  not extrapolated from the training checkpoint.
+- **Provenance is tracked per language and never blurred.** Real
+  Multilingual HateCheck is the only source for the headline; the 15
+  synthetic languages are reported separately and labelled.
+- **Benchmarks are eval-only, with one honest qualification.** No HateCheck
+  row appears in training, in any language: that is enforced mechanically by
+  a hash-intersection check over every generated file. But HateCheck is a
+  *development* benchmark for this project at the construct level: the
+  template generator mirrors its functional cell names and the clean-side
+  generator targets its non-hate cells by name. So "no verbatim overlap" is
+  what we verify, and "held out" is not what we claim. The out-of-domain
+  numbers (textdetox, offenseval2020, HateXplain) are the ones to weigh if
+  you want figures untouched by that dependency.
+- **Every number names its denominator**, and comparisons run both models
+  through the identical harness.
+
+## Failure modes (read before deploying)
+
+Measured on the shipped bytes (ONNX artifact): non-hate false-positive
+rates at threshold 0.40 run 0.26 to 0.30 across the 7-EU languages and
+0.12 on English. The construct-level failure modes that survive any
+retrain of this architecture:
+
+**1. It sometimes flags people quoting or condemning hate.** Counter-speech
+and news reporting repeat the hateful words they argue against, and the
+model reacts to the words. Route flags to human review; never auto-remove
+on this signal alone.
+
+**2. Positive or neutral mentions of identity groups can trip it,
+especially outside English.** Treat short identity-statement texts as
+low-confidence.
+
+**3. `ABUSIVE` is a severity signal, not a targeting signal.** It orders
+text by how abusive the wording is. It will score some undirected profanity
+and some crude-but-aimless text; it does not know who, if anyone, is being
+addressed. If your policy distinguishes "attacks a person" from "swears a
+lot", this head alone cannot enforce that policy. The reason is measured,
+not stylistic: a directedness construct could not be validated at available
+label quality, so the head claims severity and nothing else.
+
+**4. Hate phrased as a question or an implication is harder than direct
+insults**, for this model and the field. Do not promise users that subtle
+hate is always caught.
+
+**5. The hate/offensive boundary is soft.** See the HateXplain table: 0.7247
+hate-vs-offensive against 0.8823 hate-vs-normal on the unanimous subset.
+Thresholds move along that boundary; they do not sharpen it.
+
+**6. Not yet measured: latency.** No latency number appears on this card
+because none has been measured on the shipped artifacts. Latency is
+published once measured, never assumed. The quantization deltas above
+already follow that rule.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0).
+Free below 100,000 monthly active devices per platform, per model; a
+commercial license is required beyond that. Full terms at the link.
+Licensing: <licensing@desertant.com>.
+
+Built exclusively from commercially clean components (CC0 / CC-BY / MIT /
+Apache-2.0 training data, MIT base encoder). Attributions, dataset citations
+and generator credits are in `THIRD_PARTY_NOTICES.md`.
+
+## Citation
+
+```bibtex
+@software{toxic_2026,
+  title  = {toxic: on-device multilingual hate-speech and abuse triage},
+  author = {Desert Ant Labs},
+  year   = {2026},
+  url    = {https://huggingface.co/desert-ant-labs/toxic},
+}
+```
+
+---
+
+© 2026 Desert Ant Labs · <https://desertant.com>

--- a/docs/hub-cards/uhm.md
+++ b/docs/hub-cards/uhm.md
@@ -1,0 +1,118 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: https://license.desertant.com/1.0
+language:
+- en
+- es
+- fr
+- de
+- nl
+tags:
+- audio
+- speech
+- filler-detection
+- disfluency
+- on-device
+- core-ml
+- onnx
+pipeline_tag: audio-classification
+---
+
+# Uhm: on-device filler-word detection
+
+A frame-precise classifier that finds "uh", "um", "hmm", and other fillers in audio with 20 ms timestamps. Uhm runs on device, does not require ASR, and is trained on English with acoustic transfer to Spanish, French, German, and Dutch.
+
+## Try it
+
+- **Browser demo:** [`huggingface.co/spaces/desert-ant-labs/uhm-demo`](https://huggingface.co/spaces/desert-ant-labs/uhm-demo). Drop in any audio or video file and get a click-to-seek filler timeline.
+- **Swift SDK:** [`github.com/Desert-Ant-Labs/uhm-swift`](https://github.com/Desert-Ant-Labs/uhm-swift). Downloads the Core ML model on first use and caches it locally.
+
+## Files
+
+| File | Format | Size | Use |
+|---|---|---:|---|
+| `uhm.mlmodelc/` | Core ML fp16 (compiled) | ~45 MB | iOS / macOS on-device |
+| `uhm-web-fp16.onnx` | ONNX fp16 | ~51 MB | Browser, server, Python (`onnxruntime`) |
+| `uhm.onnx` | ONNX fp32 | ~98 MB | Quantization-free reference |
+
+`uhm.mlmodelc/` is a compiled Core ML model directory. The Swift SDK downloads it with the Hugging Face Hub snapshot API, so only changed files are re-fetched on model updates.
+
+The shipped model is a DistilHuBERT fine-tune. It is the smaller and more precise Uhm runtime model; the older HuBERT-base tier is no longer published.
+
+## Use
+
+### Python (ONNX)
+
+```python
+from huggingface_hub import hf_hub_download
+import onnxruntime as ort
+
+path = hf_hub_download("desert-ant-labs/uhm", "uhm-web-fp16.onnx")
+session = ort.InferenceSession(path, providers=["CPUExecutionProvider"])
+```
+
+### Swift
+
+```swift
+import Uhm
+
+let uhm = try await Uhm()
+let result = try await uhm.analyze(audioURL: url)
+for filler in result.fillers {
+    print(filler.start, filler.end, filler.confidence, filler.type ?? .other)
+}
+```
+
+## Inputs and outputs
+
+- **Input:** 16 kHz mono audio, up to 30-second windows.
+- **Output:** per-frame softmax over 6 classes, one prediction every 20 ms.
+- **Class indices:** `0 = not_filler, 1 = uh, 2 = um, 3 = hmm, 4 = and, 5 = other`.
+
+Core ML input shape `(1, 480000)` float32; output `(1, 1499, 6)`. Requires iOS 17 / macOS 14 or newer.
+
+## Performance
+
+Warm on-device runs on the published fp16 Core ML model:
+
+| Device | Realtime factor |
+|---|---:|
+| iPhone 17 Pro | ~296× |
+| iPhone 15 Pro | ~169× |
+| iPad Pro M4 | ~279× |
+
+Realtime factor = audio duration ÷ analyze time; model load excluded.
+
+## Limitations
+
+- Trained on English; non-English performance is by acoustic transfer and has not been measured against per-language ground truth.
+- Best on podcast / meeting / talking-head audio. Heavy background music, laughter, or multi-speaker overlap degrades quality.
+- Type labels (`uh` / `um` / `hmm` / `and` / `other`) are secondary. Trust filler vs. not-filler more than the specific subtype.
+
+## Built on
+
+- Base architecture and pretrained weights: [`ntu-spml/distilhubert`](https://huggingface.co/ntu-spml/distilhubert), a distilled variant of [`facebook/hubert-base-ls960`](https://huggingface.co/facebook/hubert-base-ls960). Apache 2.0.
+- Public fine-tuning audio: [AMI Meeting Corpus](https://huggingface.co/datasets/edinburghcstr/ami) (`edinburghcstr/ami`, IHM split). CC BY 4.0, Edinburgh CSTR.
+- Internal video content created by the Desert Ant Labs team.
+
+## License
+
+[Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for
+most apps; a commercial license is required at scale. Full terms are at the link.
+Licensing: <licensing@desertant.com>.
+
+## Citation
+
+```bibtex
+@software{uhm_2026,
+  title  = {Uhm: on-device filler-word detection},
+  author = {Desert Ant Labs},
+  year   = {2026},
+  url    = {https://huggingface.co/desert-ant-labs/uhm},
+}
+```
+
+---
+
+© 2026 Desert Ant Labs · <https://desertant.com>

--- a/docs/hub-cards/who.md
+++ b/docs/hub-cards/who.md
@@ -1,0 +1,7 @@
+---
+license: other
+license_name: desert-ant-labs-source-available-1.0
+license_link: LICENSE.md
+---
+
+# who

--- a/manifest.json
+++ b/manifest.json
@@ -37,6 +37,11 @@
       },
       "runtime": ["coreml"],
       "variants": [],
+      "hub": {
+        "tags": ["speech", "word-timestamps", "forced-alignment", "speech-recognition", "on-device", "core-ml", "multilingual"],
+        "pipelineTag": "automatic-speech-recognition",
+        "libraryName": null
+      },
       "languages": null,
       "demo": null
     },
@@ -66,6 +71,11 @@
         { "id": "clear-studio", "default": true, "note": "Aggressive denoise and dereverb." },
         { "id": "clear-natural", "default": false, "note": "Lighter touch, keeps more of the room." }
       ],
+      "hub": {
+        "tags": ["audio", "speech", "speech-enhancement", "speech-denoising", "noise-suppression", "dereverberation", "podcast", "on-device", "core-ml", "onnx", "ios", "android", "deepfilternet"],
+        "pipelineTag": "audio-to-audio",
+        "libraryName": null
+      },
       "languages": null,
       "demo": {
         "space": "desert-ant-labs/clear-demo",
@@ -96,6 +106,11 @@
       },
       "runtime": ["coreml", "litert"],
       "variants": [],
+      "hub": {
+        "tags": ["text", "clip-selection", "text-ranking", "on-device", "core-ml", "litert", "tflite", "multilingual"],
+        "pipelineTag": "text-ranking",
+        "libraryName": null
+      },
       "languages": {
         "count": null,
         "codes": null,
@@ -127,6 +142,11 @@
       },
       "runtime": ["coreml", "litert"],
       "variants": [],
+      "hub": {
+        "tags": ["text", "emoji", "text-classification", "on-device", "core-ml", "litert", "tflite", "multilingual"],
+        "pipelineTag": "text-classification",
+        "libraryName": null
+      },
       "languages": {
         "count": 22,
         "codes": ["ar", "cs", "da", "de", "en", "es", "fr", "hi", "id", "it", "ja", "ko", "nl", "pl", "pt", "ru", "sv", "th", "tr", "uk", "vi", "zh"],
@@ -162,6 +182,11 @@
       },
       "runtime": ["coreml"],
       "variants": [],
+      "hub": {
+        "tags": ["image", "video", "frame-scoring", "aesthetics", "clip", "on-device", "core-ml"],
+        "pipelineTag": "image-feature-extraction",
+        "libraryName": null
+      },
       "languages": null,
       "demo": {
         "space": null,
@@ -192,6 +217,11 @@
       },
       "runtime": ["coreml"],
       "variants": [],
+      "hub": {
+        "tags": ["image", "face-recognition", "face-matching", "embeddings", "on-device", "core-ml"],
+        "pipelineTag": "image-feature-extraction",
+        "libraryName": null
+      },
       "languages": null,
       "demo": {
         "space": null,
@@ -225,6 +255,11 @@
         { "id": "multilingual", "default": true, "note": "36 topics, 101 languages, ~74 MB." },
         { "id": "english", "default": false, "note": "Same 36 topics, English/Latin only, ~15 MB." }
       ],
+      "hub": {
+        "tags": ["text", "topic-classification", "content-classification", "multi-label", "on-device", "core-ml", "tflite", "litert", "multilingual", "model2vec"],
+        "pipelineTag": "text-classification",
+        "libraryName": "litert"
+      },
       "languages": {
         "count": 101,
         "codes": null,
@@ -260,6 +295,11 @@
       },
       "runtime": ["coreml"],
       "variants": [],
+      "hub": {
+        "tags": ["image", "image-classification", "content-moderation", "nsfw", "on-device", "core-ml", "onnx"],
+        "pipelineTag": "image-classification",
+        "libraryName": null
+      },
       "languages": null,
       "demo": {
         "space": null,
@@ -290,6 +330,11 @@
       },
       "runtime": ["coreml", "litert"],
       "variants": [],
+      "hub": {
+        "tags": ["pii", "redaction", "token-classification", "on-device", "litert", "tflite", "core-ml", "multilingual"],
+        "pipelineTag": "token-classification",
+        "libraryName": null
+      },
       "languages": {
         "count": 27,
         "codes": ["bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "ga", "hr", "hu", "is", "it", "lt", "lv", "mt", "nb", "nl", "nn", "pl", "pt", "ro", "sk", "sl", "sv"],
@@ -325,6 +370,11 @@
       },
       "runtime": ["coreml"],
       "variants": [],
+      "hub": {
+        "tags": ["text", "structured-output", "schema", "json", "extraction", "multilingual", "on-device", "core-ml", "onnx"],
+        "pipelineTag": "other",
+        "libraryName": null
+      },
       "languages": {
         "count": 13,
         "codes": ["da", "de", "en", "es", "fr", "it", "ja", "nl", "no", "pl", "pt", "sv", "zh"],
@@ -360,6 +410,11 @@
       },
       "runtime": ["coreml", "litert"],
       "variants": [],
+      "hub": {
+        "tags": ["strokes", "shapes", "sketches", "pen-input", "on-device", "core-ml", "litert", "tflite", "pencilkit"],
+        "pipelineTag": "image-classification",
+        "libraryName": null
+      },
       "languages": null,
       "demo": {
         "space": "desert-ant-labs/shapes-demo",
@@ -390,6 +445,11 @@
       },
       "runtime": ["mlx"],
       "variants": [],
+      "hub": {
+        "tags": ["text", "text-generation", "summarization", "on-device", "mlx", "multilingual"],
+        "pipelineTag": "text-generation",
+        "libraryName": null
+      },
       "languages": {
         "count": null,
         "codes": null,
@@ -421,6 +481,11 @@
       },
       "runtime": ["pure"],
       "variants": [],
+      "hub": {
+        "tags": ["language-identification", "language-detection", "langid", "text-classification", "on-device", "edge-ai", "mobile", "browser", "offline", "onnx", "multilingual"],
+        "pipelineTag": "text-classification",
+        "libraryName": null
+      },
       "languages": {
         "count": 84,
         "codes": ["af", "am", "ar", "as", "az", "be", "bg", "bn", "bo", "ca", "chr", "cs", "cy", "da", "de", "dv", "el", "en", "eo", "es", "et", "eu", "fa", "fi", "fr", "ga", "gl", "gu", "he", "hi", "hr", "hu", "hy", "id", "is", "it", "ja", "ka", "kk", "km", "kn", "ko", "ku", "ky", "la", "lo", "lt", "lv", "mk", "ml", "mn", "mr", "ms", "my", "ne", "nl", "no", "or", "pa", "pl", "pt", "ro", "ru", "si", "sk", "sl", "sq", "sr", "st", "sv", "sw", "syr", "ta", "te", "th", "tl", "tr", "ug", "uk", "ur", "vi", "xh", "yo", "zh"],
@@ -456,6 +521,11 @@
       },
       "runtime": ["coreml", "litert"],
       "variants": [],
+      "hub": {
+        "tags": ["hate-speech", "hate-speech-detection", "toxicity-classification", "content-moderation", "offensive-language", "text-classification", "on-device", "edge-ai", "mobile", "ios", "android", "browser", "offline", "litert", "tflite", "core-ml", "onnx", "multilingual"],
+        "pipelineTag": "text-classification",
+        "libraryName": null
+      },
       "languages": {
         "count": 23,
         "codes": ["bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "ga", "hr", "hu", "it", "lt", "lv", "nl", "pl", "pt", "ro", "sk", "sl", "sv"],
@@ -493,6 +563,11 @@
       "variants": [
         { "id": "high", "default": true, "note": "DistilHuBERT. The base tier is unpublished." }
       ],
+      "hub": {
+        "tags": ["audio", "speech", "filler-detection", "disfluency", "on-device", "core-ml", "onnx"],
+        "pipelineTag": "audio-classification",
+        "libraryName": null
+      },
       "languages": {
         "count": 5,
         "codes": ["de", "en", "es", "fr", "nl"],
@@ -528,6 +603,11 @@
       },
       "runtime": ["coreml"],
       "variants": [],
+      "hub": {
+        "tags": ["audio", "speaker-diarization", "diarization", "speech", "on-device", "core-ml"],
+        "pipelineTag": "voice-activity-detection",
+        "libraryName": null
+      },
       "languages": null,
       "demo": {
         "space": null,

--- a/mise-tasks/check/manifest
+++ b/mise-tasks/check/manifest
@@ -70,6 +70,16 @@ for (const m of models) {
   if (m.home !== "desert-ant-core" && m.sdks.swift.status === "live" && !ownVersion)
     fail(at, "not homed here, so each live SDK needs its own version");
 
+  // Front matter is what the Hub indexes on, so it is the manifest's to state.
+  const tags = m.hub?.tags;
+  if (!Array.isArray(tags) || !tags.length) fail(at, "hub.tags must be a non-empty list");
+  else {
+    if (new Set(tags).size !== tags.length) fail(at, "duplicate hub.tags");
+    const bad = tags.filter((t) => !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(t));
+    if (bad.length) fail(at, `hub.tags must be lowercase kebab-case: ${bad}`);
+    if (tags.includes("coreml")) fail(at, 'hub.tags: use "core-ml", not "coreml"');
+  }
+
   const langs = m.languages;
   if (langs) {
     if (!BASIS.includes(langs.basis)) fail(at, `languages.basis ${langs.basis}`);

--- a/mise-tasks/hub/sync
+++ b/mise-tasks/hub/sync
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#MISE description="Render the Hub cards and org card from manifest.json (dry run)"
+#MISE dir="{{config_root}}"
+#MISE tools={node="22"}
+source "$MISE_PROJECT_ROOT/Tools/dal.sh"
+
+# Renders into .build/hub/ and diffs against docs/hub-cards/, the archived copy
+# of what the Hub serves today. Nothing is uploaded: publishing is a separate
+# task, so the diff can be read before any of it reaches the Hub.
+#
+# Gated repos are absent from docs/hub-cards/ and are skipped here too - the
+# archive is the list of repos this can see.
+
+node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { manifest, renderCard, renderTable, replaceBlock, MARKERS } from "./Tools/manifest-docs.mjs";
+
+const { models, org } = manifest();
+mkdirSync(".build/hub", { recursive: true });
+
+let rendered = 0;
+for (const model of models) {
+  // Internal models keep whatever card they have: eye and face are gated and
+  // unreachable, and who is public on the Hub but not something we advertise.
+  if (model.visibility === "internal") {
+    console.log(`  ${model.id}: internal, leaving its card alone`);
+    continue;
+  }
+  const archived = `docs/hub-cards/${model.id}.md`;
+  if (!existsSync(archived)) {
+    console.log(`  ${model.id}: no archived card, skipping`);
+    continue;
+  }
+  writeFileSync(`.build/hub/${model.id}.md`, renderCard(readFileSync(archived, "utf8"), model, org));
+  rendered++;
+}
+
+// The org card's prose stays hand-written; only the table is generated, so the
+// markers go in on the first sync and the rest of the file is left alone.
+let card = readFileSync("docs/hub-cards/_org.md", "utf8");
+if (!card.includes(MARKERS.start)) {
+  card = card.replace(/^\| Model \|[\s\S]*?(?=\n\n)/m, `${MARKERS.start}\n${MARKERS.end}`);
+}
+writeFileSync(".build/hub/_org.md", replaceBlock(card, renderTable(models)));
+
+console.log(`${rendered} model cards + org card rendered into .build/hub/`);
+NODE
+
+echo
+git --no-pager diff --no-index --stat docs/hub-cards .build/hub || true


### PR DESCRIPTION
Third of four PRs syncing GitHub and Hugging Face from `manifest.json`. Still nothing uploaded: this archives what the Hub serves today and renders the replacements so they can be read before PR 4 publishes them.

`docs/hub-cards/` is the current card for all 14 reachable model repos plus the org card, committed first so the rewrite is reversible from git rather than only from the Hub's history. `mise run hub:sync` renders replacements into `.build/hub/` and diffs against the archive; it runs in CI so a broken renderer fails a PR. Each card becomes the model name, its tagline, its summary, and links to GitHub and the website — around 2000 lines of prose come out across the set. The org card keeps all of its prose and gets only its table replaced, which adds the missing Align, Clips and Title, drops Shapes' links to the archived standalone repo, and removes the claim that Toxic covers eight languages.

Front matter is generated too: `hub.tags`, `hub.pipelineTag` and `hub.libraryName` now live in the manifest, so a card carries nothing the registry does not state. Proved by rendering every card from an empty string and getting identical bytes. The move fixed four real errors — toxic listed both `core-ml` and `coreml`, align's `license_link` still pointed at the retired `.ai` domain, clear advertised `language: en` for a denoiser, and emo's card claimed only `multilingual` where the manifest holds its 22 codes. `check:manifest` now rejects empty, duplicate, non-kebab-case and `coreml`-spelled tags.

Eye, face and who are `internal`, so their cards are left alone entirely; their tags are in the manifest for completeness. Also removes the README note about the table being generated, as requested.