### PR TITLE
Publish the Hub cards from CI

### DIFF
--- a/.github/workflows/hub-sync.yml
+++ b/.github/workflows/hub-sync.yml
@@ -1,0 +1,55 @@
+name: Hub sync
+
+# Pushes the model cards and the org card to Hugging Face from manifest.json.
+# The only workflow in this repo that writes outside it, so it is deliberately
+# narrow: it runs on a manual dispatch, or on a push to main that actually
+# touched the registry or the renderer.
+#
+# Needs HF_TOKEN, a write token on the desert-ant-labs org.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print what would change and upload nothing"
+        type: boolean
+        default: true
+  push:
+    branches: [main]
+    paths:
+      - manifest.json
+      - Tools/manifest-docs.mjs
+      - mise-tasks/hub/**
+      - .github/workflows/hub-sync.yml
+
+# One writer at a time: two merges landing together must not race the Hub.
+concurrency:
+  group: hub-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: publish cards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: jdx/mise-action@v4
+      # The cards are only as good as the registry they come from.
+      - run: mise run check:manifest
+      - run: mise run check:links
+      # Without the secret this previews rather than failing, so merging to main
+      # before the token exists leaves main green instead of red.
+      - name: Publish
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          flag=""
+          if [ "$DRY_RUN" = "true" ] || [ -z "$HF_TOKEN" ]; then
+              flag="--dry-run"
+              [ -n "$HF_TOKEN" ] || echo "::notice::HF_TOKEN is not set - previewing only."
+          fi
+          mise run hub:publish $flag

--- a/mise-tasks/hub/publish
+++ b/mise-tasks/hub/publish
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#MISE description="Publish the rendered cards and org card to the Hugging Face Hub"
+#MISE dir="{{config_root}}"
+#MISE tools={node="22"}
+#USAGE flag "--dry-run" help="Print what would change and upload nothing"
+source "$MISE_PROJECT_ROOT/Tools/dal.sh"
+
+# Renders against what the Hub serves RIGHT NOW rather than against
+# docs/hub-cards/, so a card edited on the Hub since the archive was taken is
+# not silently reverted. Only the org card's prose survives that way, but that
+# is exactly the part that is hand-written.
+#
+# Needs HF_TOKEN with write scope on the org. A dry run needs no token: every
+# repo it reads is public.
+
+export DAL_DRY_RUN="${usage_dry_run:-false}"
+
+node --input-type=module <<'NODE'
+import { manifest, renderCard, renderTable, replaceBlock, MARKERS } from "./Tools/manifest-docs.mjs";
+
+const dryRun = process.env.DAL_DRY_RUN === "true";
+const token = process.env.HF_TOKEN;
+if (!dryRun && !token) {
+  console.error("error: HF_TOKEN is not set. Run with --dry-run to preview instead.");
+  process.exit(1);
+}
+
+const API = "https://huggingface.co/api";
+const auth = token ? { Authorization: `Bearer ${token}` } : {};
+
+async function readCard(kind, repo) {
+  const prefix = kind === "space" ? "spaces/" : "";
+  const res = await fetch(`https://huggingface.co/${prefix}${repo}/raw/main/README.md`, { headers: auth });
+  if (!res.ok) throw new Error(`GET ${repo}: ${res.status}`);
+  return res.text();
+}
+
+async function writeCard(kind, repo, content, summary) {
+  const body = [
+    JSON.stringify({ key: "header", value: { summary } }),
+    JSON.stringify({
+      key: "file",
+      value: { path: "README.md", content: Buffer.from(content).toString("base64"), encoding: "base64" },
+    }),
+  ].join("\n");
+  const res = await fetch(`${API}/${kind}s/${repo}/commit/main`, {
+    method: "POST",
+    headers: { ...auth, "Content-Type": "application/x-ndjson" },
+    body,
+  });
+  if (!res.ok) throw new Error(`COMMIT ${repo}: ${res.status} ${await res.text()}`);
+}
+
+const { models, org } = manifest();
+const summary = "Sync card from manifest.json";
+let changed = 0;
+let skipped = 0;
+
+for (const model of models) {
+  if (model.visibility === "internal") {
+    console.log(`  ${model.id}: internal, left alone`);
+    continue;
+  }
+  const repo = model.weights.repo;
+  const current = await readCard("model", repo);
+  const next = renderCard(current, model, org);
+  if (next === current) {
+    skipped++;
+    continue;
+  }
+  console.log(`  ${model.id}: ${current.length} -> ${next.length} bytes`);
+  if (!dryRun) await writeCard("model", repo, next, summary);
+  changed++;
+}
+
+// The org card is a Space repo whose prose is hand-written; only the table is
+// ours, and the markers go in on the first sync.
+const orgRepo = `${org.hub.split("/").pop()}/README`;
+const currentOrg = await readCard("space", orgRepo);
+const marked = currentOrg.includes(MARKERS.start)
+  ? currentOrg
+  : currentOrg.replace(/^\| Model \|[\s\S]*?(?=\n\n)/m, `${MARKERS.start}\n${MARKERS.end}`);
+const nextOrg = replaceBlock(marked, renderTable(models));
+if (nextOrg !== currentOrg) {
+  console.log(`  org card: ${currentOrg.length} -> ${nextOrg.length} bytes`);
+  if (!dryRun) await writeCard("space", orgRepo, nextOrg, summary);
+  changed++;
+} else {
+  skipped++;
+}
+
+console.log(`${changed} ${dryRun ? "would change" : "published"}, ${skipped} already current`);
+NODE


### PR DESCRIPTION
Last of four PRs syncing GitHub and Hugging Face from `manifest.json`. Stacked on #117 and will retarget to `main` once that merges. This is the only one that writes outside the repo, and it does nothing until an `HF_TOKEN` secret with org write scope exists — without it the workflow previews and stays green rather than failing.

`mise run hub:publish` renders against what the Hub serves right now rather than against `docs/hub-cards/`, so prose edited on the Hub since the archive was taken is not silently reverted — which matters for the org card, whose prose is hand-written and whose table is the only generated part. It uploads only what differs, leaves internal models alone, and takes `--dry-run`. The workflow runs on manual dispatch (defaulting to a dry run) or on a push to `main` that touched the manifest, the renderer or the task, re-runs `check:manifest` and `check:links` first, and holds a concurrency lock so two merges cannot race the Hub.

Current dry run against the live Hub: 14 cards change, the org card goes 3924 → 3241 bytes, and eye, face and who are left alone. The model cards shrink hard — toxic 19344 → 748 bytes, schemer 11593 → 556, tongue 11229 → 997.

Suggested first run: dispatch manually with `dry_run` checked, read the output, then dispatch again unchecked.