### PR TITLE
Clear: default to cpuOnly

### DIFF
--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -229,10 +229,10 @@ public final class Clear: @unchecked Sendable {
     }
 
     /// `computeUnits` selects the Core ML compute units on Apple (ignored by the
-    /// LiteRT/JS backends). Default `.all`, letting Core ML place the work
-    /// itself; pass `.cpuOnly` if CPU-only benchmarks better for your model
-    /// and hardware (the palettized model has run ~2x faster on the CPU than
-    /// the Neural Engine or GPU on some M-series Macs).
+    /// LiteRT/JS backends). Default ``ComputeUnits/cpuOnly``: the palettized
+    /// graph runs faster on the CPU than on the ANE and pays no first-launch
+    /// specialization, while `.all` adds a GPU compile this model never
+    /// profitably uses. Pass `.all` for the previous behaviour.
     /// `concurrency` is the model-session pool size (see `defaultConcurrency`).
     ///
     /// Nothing is bundled with this package. To ship the model with your app,
@@ -245,7 +245,7 @@ public final class Clear: @unchecked Sendable {
     /// separately, so switching versions never clobbers another's files.
     public convenience init(directory: String? = nil, variant: ModelVariant = .default,
                             revision: String? = nil,
-                            computeUnits: ComputeUnits = .all,
+                            computeUnits: ComputeUnits = .cpuOnly,
                             concurrency: Int = Clear.defaultConcurrency) {
         self.init(directory: directory, cacheRoot: nil, variant: variant,
                   revision: .exact(revision ?? ClearModel.revision),
@@ -262,7 +262,7 @@ public final class Clear: @unchecked Sendable {
     /// ``Result/modelRevision``.
     public convenience init(directory: String? = nil, variant: ModelVariant = .default,
                             revision: RevisionRequirement,
-                            computeUnits: ComputeUnits = .all,
+                            computeUnits: ComputeUnits = .cpuOnly,
                             concurrency: Int = Clear.defaultConcurrency) {
         self.init(directory: directory, cacheRoot: nil, variant: variant, revision: revision,
                   computeUnits: computeUnits, concurrency: concurrency)
@@ -276,7 +276,7 @@ public final class Clear: @unchecked Sendable {
     public init(directory: String?, cacheRoot: String?,
                 variant: ModelVariant = .default,
                 revision requirement: RevisionRequirement = .exact(ClearModel.revision),
-                computeUnits: ComputeUnits = .all,
+                computeUnits: ComputeUnits = .cpuOnly,
                 concurrency: Int = Clear.defaultConcurrency) {
         // A variant is its own slice of the model repo, so the loader resolves
         // that distribution rather than the catalog entry's default one; the
@@ -323,7 +323,7 @@ public final class Clear: @unchecked Sendable {
     /// keyed by revision produces self-identifying runs. It is never checked
     /// against the file - there is nothing offline to check it against.
     public init(modelPath: String, revision: String? = nil,
-                computeUnits: ComputeUnits = .all,
+                computeUnits: ComputeUnits = .cpuOnly,
                 concurrency: Int = Clear.defaultConcurrency) throws {
         // Built eagerly (this initializer throws), then handed to the loader so
         // the rest of the class has one path to its assets.

--- a/Sources/Clear/ModelLoading.swift
+++ b/Sources/Clear/ModelLoading.swift
@@ -44,7 +44,7 @@ public struct ModelAssets: Sendable {
     /// file name, so a pre-downloaded artifact still identifies itself on
     /// `Result`.
     init(modelPath: String, revision: String? = nil,
-         computeUnits: ComputeUnits = .all, concurrency: Int = 1) throws {
+         computeUnits: ComputeUnits = .cpuOnly, concurrency: Int = 1) throws {
         self.init(
             sessions: try (0..<max(1, concurrency)).map { _ in
                 try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)


### PR DESCRIPTION
## Problem

The first enhance after an install can take **minutes** before any audio is processed. Under `.all`, Core ML also prepares a GPU path this model never profitably uses, and on Mac that first-launch compile is pathological.

## Benchmarks

Full `enhance()` path (resample + mastering included). Mac: 19-minute 48 kHz mono m4a. iPhone 17 Pro: 5-minute slice, cold per configuration via reinstall (the app container keys the specialization cache), then 3 warm passes.

| | `.all` | `.cpuAndNeuralEngine` | `.cpuOnly` |
|---|---|---|---|
| iPhone 17 Pro (cold + warm, flat) | 87x | 90x | **~250x** |

The palettized graph runs ~2.5x faster on CPU than on the ANE and pays no specialization, so cold equals warm — the doc comment's earlier observation ("CPU ~2x faster on some M-series") was right and now holds on iPhone too.

## Change

Default `computeUnits` to `.cpuOnly` on Clear's four public inits and the internal `modelPath` init. The parameter stays exposed; `.all` remains available for the previous behaviour. Doc comment updated with the measured numbers.

All 33 ClearTests pass.
