### PR TITLE
Generate the docs on set-version, and check them in mise run test

### DIFF
--- a/mise-tasks/set-version
+++ b/mise-tasks/set-version
@@ -52,6 +52,11 @@ sed -i.bak -E \
     -e 's|(desert-ant-core\.git", from: ")[0-9]+\.[0-9]+\.[0-9]+|\1'"$version"'|' \
     README.md && rm -f README.md.bak
 
+# Everything generated from manifest.json, so a release cannot ship a stale
+# table because someone forgot the command.
+mise run docs:render > /dev/null
+
 mise run check:version > /dev/null
 mise run check:manifest > /dev/null
+mise run check:docs > /dev/null
 echo "everything set to $version"

--- a/mise.toml
+++ b/mise.toml
@@ -48,6 +48,9 @@ depends = ["build:swift", "build:wasm", "build:node-native", "build:android"]
 description = "Run every check and test suite that needs no device or simulator"
 depends = [
     "check:version",
+    "check:manifest",
+    "check:links",
+    "check:docs",
     "check:isolation",
     "check:types",
     "check:swift-floor",


### PR DESCRIPTION
Removes two things you would otherwise have to remember. `set-version` now runs `docs:render` before its checks, so a release cannot ship a README table that disagrees with the manifest. And `mise run test` gains `check:manifest`, `check:links` and `check:docs`, so a stale table or a dead link fails locally before the push rather than in CI.

Verified by breaking a table row, running `mise run set-version 3.0.0`, and watching it come back correct.

Worth knowing where the remaining seam is: this covers release time, but a manifest edit in an ordinary PR still needs `mise run docs:render` by hand. `check:docs` fails that PR with the exact command, which I would rather have than a bot pushing commits to your branches — a workflow with write access to the repo is a bigger blast radius than a failing check. The Hub cards have no such seam; they publish on any merge to main that touches the manifest or the renderer.