### PR TITLE
Publish the model table to the GitHub org profile too

### DIFF
--- a/.github/workflows/hub-sync.yml
+++ b/.github/workflows/hub-sync.yml
@@ -1,11 +1,14 @@
-name: Hub sync
+name: Sync from manifest
 
-# Pushes the model cards and the org card to Hugging Face from manifest.json.
+# Pushes the model table and cards to every surface that publishes them:
+# Hugging Face model cards, the Hugging Face org card, and the GitHub org profile.
 # The only workflow in this repo that writes outside it, so it is deliberately
 # narrow: it runs on a manual dispatch, or on a push to main that actually
 # touched the registry or the renderer.
 #
-# Needs HF_TOKEN, a write token on the desert-ant-labs org.
+# Needs HF_TOKEN, a write token on the desert-ant-labs org, and
+# ORG_PROFILE_TOKEN, which needs contents:write on Desert-Ant-Labs/.github
+# (the workflow's own GITHUB_TOKEN cannot reach another repository).
 
 on:
   workflow_dispatch:
@@ -32,7 +35,7 @@ permissions:
 
 jobs:
   sync:
-    name: publish cards
+    name: publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -53,3 +56,15 @@ jobs:
               [ -n "$HF_TOKEN" ] || echo "::notice::HF_TOKEN is not set - previewing only."
           fi
           mise run hub:publish $flag
+
+      - name: Publish the GitHub org profile
+        env:
+          ORG_PROFILE_TOKEN: ${{ secrets.ORG_PROFILE_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          flag=""
+          if [ "$DRY_RUN" = "true" ] || [ -z "$ORG_PROFILE_TOKEN" ]; then
+              flag="--dry-run"
+              [ -n "$ORG_PROFILE_TOKEN" ] || echo "::notice::ORG_PROFILE_TOKEN is not set - previewing only."
+          fi
+          mise run github:profile $flag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ SDK coordinates against `packages/`, and `sdkVersion` against `VERSION`. Adding 
 | README model table (between `<!-- models:start -->` markers) | `mise run docs:render` | `mise run check:docs` |
 | Hugging Face model cards | `mise run hub:publish` | published on merge to `main` |
 | Hugging Face org card table | `mise run hub:publish` | published on merge to `main` |
+| GitHub org profile table | `mise run github:profile` | published on merge to `main` |
 
 Editing any of these by hand is wasted work: the README table is reverted by the
 next render, and a Hub card edited on huggingface.co is overwritten by the next
@@ -74,10 +75,13 @@ manifest. They have nothing to do with `VERSION`.
 
 ## Hub publishing
 
-`.github/workflows/hub-sync.yml` publishes on any merge to `main` touching
+`.github/workflows/hub-sync.yml` publishes to Hugging Face and to the GitHub org
+profile (`Desert-Ant-Labs/.github`) on any merge to `main` touching
 `manifest.json`, `Tools/manifest-docs.mjs`, `mise-tasks/hub/**`, or the workflow
 itself. It needs the `HF_TOKEN` secret with write access to all repos under the
-`desert-ant-labs` org; without it the run previews instead of failing.
+`desert-ant-labs` org, and `ORG_PROFILE_TOKEN` with contents:write on
+`Desert-Ant-Labs/.github`. Without either, that half of the run previews instead
+of failing.
 
 A manual dispatch defaults to a dry run. Preview locally with
 `mise run hub:publish --dry-run`, which needs no token, or render the cards to

--- a/Tools/manifest-docs.mjs
+++ b/Tools/manifest-docs.mjs
@@ -127,6 +127,16 @@ export function renderCard(existing, model, org) {
   return `---\n${front}\n---\n\n${renderCardBody(model, org)}`;
 }
 
+/// Put markers around a table that predates them, so a hand-written page can be
+/// adopted without editing it by hand first. `header` is the start of its header
+/// row; the table runs to the next blank line.
+export function insertMarkers(text, header) {
+  if (text.includes(MARKERS.start)) return text;
+  const table = new RegExp(`^\\| ${header} \\|[\\s\\S]*?(?=\\n\\n)`, "m");
+  if (!table.test(text)) throw new Error(`no table starting "| ${header} |" to replace`);
+  return text.replace(table, `${MARKERS.start}\n${MARKERS.end}`);
+}
+
 /// Replace the marked block in `text`, leaving every hand-written line alone.
 export function replaceBlock(text, body) {
   const start = text.indexOf(MARKERS.start);

--- a/mise-tasks/github/profile
+++ b/mise-tasks/github/profile
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#MISE description="Publish the model table to the GitHub org profile card"
+#MISE dir="{{config_root}}"
+#MISE tools={node="22"}
+#USAGE flag "--dry-run" help="Print what would change and push nothing"
+source "$MISE_PROJECT_ROOT/Tools/dal.sh"
+
+# github.com/Desert-Ant-Labs renders Desert-Ant-Labs/.github profile/README.md.
+# Same generated table as the repo README and the Hub org card, same markers,
+# and the prose around it stays hand-written.
+#
+# Needs a token with contents:write on that repo. The workflow's own
+# GITHUB_TOKEN cannot reach another repository, so this is a separate secret.
+
+export DAL_DRY_RUN="${usage_dry_run:-false}"
+
+node --input-type=module <<'NODE'
+import { manifest, renderTable, replaceBlock, insertMarkers } from "./Tools/manifest-docs.mjs";
+
+const dryRun = process.env.DAL_DRY_RUN === "true";
+const token = process.env.ORG_PROFILE_TOKEN || process.env.GH_TOKEN;
+if (!dryRun && !token) {
+  console.error("error: ORG_PROFILE_TOKEN is not set. Run with --dry-run to preview instead.");
+  process.exit(1);
+}
+
+const REPO = "Desert-Ant-Labs/.github";
+const PATH = "profile/README.md";
+const api = `https://api.github.com/repos/${REPO}/contents/${PATH}`;
+const headers = {
+  Accept: "application/vnd.github+json",
+  ...(token ? { Authorization: `Bearer ${token}` } : {}),
+};
+
+const res = await fetch(api, { headers });
+if (!res.ok) {
+  console.error(`error: GET ${REPO}/${PATH}: ${res.status}`);
+  process.exit(1);
+}
+const file = await res.json();
+const current = Buffer.from(file.content, "base64").toString("utf8");
+
+const next = replaceBlock(insertMarkers(current, "Product"), renderTable(manifest().models));
+if (next === current) {
+  console.log("org profile is already current");
+  process.exit(0);
+}
+
+console.log(`org profile: ${current.length} -> ${next.length} bytes`);
+if (dryRun) process.exit(0);
+
+const write = await fetch(api, {
+  method: "PUT",
+  headers: { ...headers, "Content-Type": "application/json" },
+  body: JSON.stringify({
+    message: "Sync model table from manifest.json",
+    content: Buffer.from(next).toString("base64"),
+    sha: file.sha,
+  }),
+});
+if (!write.ok) {
+  const detail = await write.text();
+  if (write.status === 403 || write.status === 404) {
+    console.error(`error: the token cannot write to ${REPO}. It needs contents:write there.`);
+  } else {
+    console.error(`error: PUT ${REPO}: ${write.status} ${detail}`);
+  }
+  process.exit(1);
+}
+console.log("org profile published");
+NODE


### PR DESCRIPTION
github.com/Desert-Ant-Labs renders `Desert-Ant-Labs/.github` `profile/README.md`, and it had drifted exactly the way the Hub org card had: no Align, Clips, Title or Toxic, Shapes still pointing at the archived standalone repo, and Redact claiming 24 languages against the manifest's 27.

Same generated table, same markers, same renderer. The prose around it stays hand-written: the headline, the 100k-devices line, and the Links section are all preserved. Needs an `ORG_PROFILE_TOKEN` secret with contents:write on `Desert-Ant-Labs/.github`, because a workflow's own GITHUB_TOKEN cannot write to another repository; without it that step previews and the run stays green. The workflow is renamed "Sync from manifest" since it is no longer only about the Hub.

Two things to decide before merging. The generated table shows package coordinates where the old one showed which GitHub repo each SDK lives in, which was arguably more useful on a GitHub org page - the tradeoff for one identical table everywhere. And the new table lists Eye, Face, Who and Toxic, which the profile did not name before; the Hub org card already does, so this makes them consistent, but it is a visibility change on a public page.