### PR TITLE
Table columns: platforms instead of packages, and a plain Docs link

### DIFF
--- a/.github/workflows/hub-sync.yml
+++ b/.github/workflows/hub-sync.yml
@@ -23,6 +23,7 @@ on:
       - manifest.json
       - Tools/manifest-docs.mjs
       - mise-tasks/hub/**
+      - mise-tasks/github/**
       - .github/workflows/hub-sync.yml
 
 # One writer at a time: two merges landing together must not race the Hub.
@@ -53,7 +54,7 @@ jobs:
           flag=""
           if [ "$DRY_RUN" = "true" ] || [ -z "$HF_TOKEN" ]; then
               flag="--dry-run"
-              [ -n "$HF_TOKEN" ] || echo "::notice::HF_TOKEN is not set - previewing only."
+              [ -n "$HF_TOKEN" ] || echo "::warning::HF_TOKEN is not set, so the Hub was NOT updated."
           fi
           mise run hub:publish $flag
 
@@ -65,6 +66,6 @@ jobs:
           flag=""
           if [ "$DRY_RUN" = "true" ] || [ -z "$ORG_PROFILE_TOKEN" ]; then
               flag="--dry-run"
-              [ -n "$ORG_PROFILE_TOKEN" ] || echo "::notice::ORG_PROFILE_TOKEN is not set - previewing only."
+              [ -n "$ORG_PROFILE_TOKEN" ] || echo "::warning::ORG_PROFILE_TOKEN is not set, so the GitHub org profile was NOT updated."
           fi
           mise run github:profile $flag

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ let clean = try await Redact().redaction(of: "Email Anna at anna@example.hu.")
 ## Models
 
 <!-- models:start -->
-| Model | What it does | SDKs | Docs and examples |
+| Model | What it does | Platform | Docs |
 | --- | --- | --- | --- |
-| **Align** | Word-timestamp refinement for Apple's SpeechAnalyzer pipeline. | `Align` | [Align docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/align.md) |
-| **Clear** | On-device speech enhancement: denoise, dereverb, and loudness-normalize. | `Clear` · `ai.desertant:clear` · `@desert-ant-labs/clear` | [Clear docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/clear.md) |
-| **Clips** | On-device clip selection: a transcript's best non-overlapping moments, ranked. | `Clips` | [Clips docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/clips.md) |
-| **Emo** | Multilingual on-device emoji suggestion. | `Emo` · `ai.desertant:emo` · `@desert-ant-labs/emo` | [Emo docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/emo.md) |
-| **Gist** | Multilingual on-device content topic tagging across a 36-topic taxonomy. | `Gist` · `ai.desertant:gist` · `@desert-ant-labs/gist` | [Gist docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/gist.md) |
-| **Redact** | Multilingual on-device PII detection and redaction. | `Redact` · `ai.desertant:redact` · `@desert-ant-labs/redact` | [Redact docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/redact.md) |
-| **Shapes** | On-device single-stroke shape recognition. | `Shapes` · `ai.desertant:shapes` · `@desert-ant-labs/shapes` | [Shapes docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/shapes.md) |
-| **Title** | On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text. | `Title` | [Title docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/title.md) |
-| **Tongue** | On-device language identification for short text across 84 languages. | `Tongue` · `ai.desertant:tongue` · `@desert-ant-labs/tongue` | [Tongue docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/tongue.md) |
-| **Uhm** | On-device filler-word detection: frame-precise "uh"/"um"/"hmm" spans. | `Uhm` | [Uhm docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/uhm.md) |
+| **Align** | Word-timestamp refinement for Apple's SpeechAnalyzer pipeline. | Apple | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/align.md) |
+| **Clear** | On-device speech enhancement: denoise, dereverb, and loudness-normalize. | Apple · Android · Linux · Windows · Web · Node | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/clear.md) |
+| **Clips** | On-device clip selection: a transcript's best non-overlapping moments, ranked. | Apple · Linux · Windows | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/clips.md) |
+| **Emo** | Multilingual on-device emoji suggestion. | Apple · Android · Linux · Windows · Web · Node | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/emo.md) |
+| **Gist** | Multilingual on-device content topic tagging across a 36-topic taxonomy. | Apple · Android · Linux · Windows · Web · Node | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/gist.md) |
+| **Redact** | Multilingual on-device PII detection and redaction. | Apple · Android · Linux · Windows · Web · Node | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/redact.md) |
+| **Shapes** | On-device single-stroke shape recognition. | Apple · Android · Linux · Windows · Web · Node | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/shapes.md) |
+| **Title** | On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text. | Apple | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/title.md) |
+| **Tongue** | On-device language identification for short text across 84 languages. | Apple · Android · Linux · Windows · Web · Node | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/tongue.md) |
+| **Uhm** | On-device filler-word detection: frame-precise "uh"/"um"/"hmm" spans. | Apple | [docs](https://github.com/Desert-Ant-Labs/desert-ant-core/blob/main/docs/models/uhm.md) |
 
 ### In closed beta
 

--- a/Tools/manifest-docs.mjs
+++ b/Tools/manifest-docs.mjs
@@ -26,14 +26,6 @@ function short(revision) {
   return isCommit ? revision.slice(0, 7) : revision;
 }
 
-/// Package coordinates for every SDK that ships, in Swift/Kotlin/JS order.
-function sdks(model) {
-  return SDKS.map((sdk) => model.sdks[sdk])
-    .filter((sdk) => sdk?.status === "live" && sdk.package)
-    .map((sdk) => `\`${sdk.package}\``)
-    .join(" · ");
-}
-
 /// The per-model page, which is the only documentation link a table carries.
 /// Absolute because two of the three surfaces that publish this table are not
 /// in this repo, so a relative path would resolve against the wrong root.
@@ -53,10 +45,10 @@ export function renderTable(models, org) {
   const preview = models.filter((m) => !ships(m));
 
   const main = [
-    "| Model | What it does | SDKs | Docs and examples |",
+    "| Model | What it does | Platform | Docs |",
     "| --- | --- | --- | --- |",
     ...shipping.map(
-      (m) => `| **${m.name}** | ${m.summary} | ${sdks(m)} | [${m.name} docs](${docsURL(m, org)}) |`
+      (m) => `| **${m.name}** | ${m.summary} | ${platforms(m, "short")} | [docs](${docsURL(m, org)}) |`
     ),
   ];
   if (!preview.length) return main.join("\n");
@@ -169,23 +161,34 @@ export function replaceBlock(text, body) {
 
 export const MODEL_MARKERS = { start: "<!-- model:start -->", end: "<!-- model:end -->" };
 
+/// The page header has room to name the Apple OSes; a table cell does not.
 const PLATFORM_NAMES = {
-  apple: "iOS, macOS, tvOS, visionOS",
-  android: "Android",
-  linux: "Linux",
-  windows: "Windows",
-  web: "Browser",
-  node: "Node",
+  apple: { short: "Apple", long: "iOS, macOS, tvOS, visionOS" },
+  android: { short: "Android", long: "Android" },
+  linux: { short: "Linux", long: "Linux" },
+  windows: { short: "Windows", long: "Windows" },
+  web: { short: "Web", long: "Browser" },
+  node: { short: "Node", long: "Node" },
 };
 
-/// Every platform any live SDK claims, deduplicated, in declaration order.
-function platforms(model) {
+/// Rendered in this order rather than the order the SDKs happen to declare
+/// them, so every row reads the same way down the column.
+const PLATFORM_ORDER = ["apple", "android", "linux", "windows", "web", "node"];
+
+/// Every platform any live SDK claims, deduplicated and canonically ordered.
+function platformIDs(model) {
   const seen = new Set();
   for (const sdk of SDKS) {
     const decl = model.sdks[sdk];
     if (decl?.status === "live") for (const p of decl.platforms ?? []) seen.add(p);
   }
-  return [...seen].map((p) => PLATFORM_NAMES[p] ?? p).join(", ");
+  return PLATFORM_ORDER.filter((p) => seen.has(p));
+}
+
+function platforms(model, form = "long") {
+  return platformIDs(model)
+    .map((p) => PLATFORM_NAMES[p]?.[form] ?? p)
+    .join(form === "short" ? " · " : ", ");
 }
 
 /// The install snippet per SDK. Versions come from the manifest so a release

--- a/docs/models/clear.md
+++ b/docs/models/clear.md
@@ -7,7 +7,7 @@ On-device speech enhancement: denoise, dereverb, and loudness-normalize.
 
 | | |
 | --- | --- |
-| **Platforms** | iOS, macOS, tvOS, visionOS, Linux, Windows, Android, Browser, Node |
+| **Platforms** | iOS, macOS, tvOS, visionOS, Android, Linux, Windows, Browser, Node |
 | **Weights** | [v0.3.0](https://huggingface.co/desert-ant-labs/clear) |
 | **Demo** | https://desertant.com/models/clear/ |
 

--- a/docs/models/emo.md
+++ b/docs/models/emo.md
@@ -7,7 +7,7 @@ Multilingual on-device emoji suggestion.
 
 | | |
 | --- | --- |
-| **Platforms** | iOS, macOS, tvOS, visionOS, Linux, Windows, Android, Browser, Node |
+| **Platforms** | iOS, macOS, tvOS, visionOS, Android, Linux, Windows, Browser, Node |
 | **Languages** | 22 |
 | **Weights** | [v0.7.0](https://huggingface.co/desert-ant-labs/emo) |
 | **Demo** | https://desertant.com/models/emo/ |

--- a/docs/models/gist.md
+++ b/docs/models/gist.md
@@ -7,7 +7,7 @@ Multilingual on-device content topic tagging across a 36-topic taxonomy.
 
 | | |
 | --- | --- |
-| **Platforms** | iOS, macOS, tvOS, visionOS, Linux, Windows, Android, Browser, Node |
+| **Platforms** | iOS, macOS, tvOS, visionOS, Android, Linux, Windows, Browser, Node |
 | **Languages** | 101 |
 | **Weights** | [v2.2.0](https://huggingface.co/desert-ant-labs/gist) |
 | **Demo** | https://desertant.com/models/gist/ |

--- a/docs/models/redact.md
+++ b/docs/models/redact.md
@@ -7,7 +7,7 @@ Multilingual on-device PII detection and redaction.
 
 | | |
 | --- | --- |
-| **Platforms** | iOS, macOS, tvOS, visionOS, Linux, Windows, Android, Browser, Node |
+| **Platforms** | iOS, macOS, tvOS, visionOS, Android, Linux, Windows, Browser, Node |
 | **Languages** | 27 |
 | **Weights** | [v0.4.0](https://huggingface.co/desert-ant-labs/redact) |
 | **Demo** | https://desertant.com/models/redact/ |

--- a/docs/models/shapes.md
+++ b/docs/models/shapes.md
@@ -7,7 +7,7 @@ On-device single-stroke shape recognition.
 
 | | |
 | --- | --- |
-| **Platforms** | iOS, macOS, tvOS, visionOS, Linux, Windows, Android, Browser, Node |
+| **Platforms** | iOS, macOS, tvOS, visionOS, Android, Linux, Windows, Browser, Node |
 | **Weights** | [v0.3.0](https://huggingface.co/desert-ant-labs/shapes) |
 | **Demo** | https://desertant.com/models/shapes/ |
 

--- a/docs/models/tongue.md
+++ b/docs/models/tongue.md
@@ -7,7 +7,7 @@ On-device language identification for short text across 84 languages.
 
 | | |
 | --- | --- |
-| **Platforms** | iOS, macOS, tvOS, visionOS, Linux, Windows, Android, Browser, Node |
+| **Platforms** | iOS, macOS, tvOS, visionOS, Android, Linux, Windows, Browser, Node |
 | **Languages** | 84 |
 | **Weights** | Bundled with the SDK ([v1.0.0](https://huggingface.co/desert-ant-labs/tongue)) |
 | **Demo** | https://desertant.com/models/tongue/ |


### PR DESCRIPTION
`SDKs` becomes `Platform`, listing the platforms a model's SDKs actually cover, and `Docs and examples` becomes `Docs` with a plain `[docs]` link in the cell. Package coordinates have not disappeared: they are on each model's page next to the install line that uses them, which is where you need them.

All three surfaces render from the same function, so the README, the Hugging Face org card and the GitHub org profile get byte-identical tables. I verified that by extracting the marked block from all three rendered outputs and diffing them. Hand-written prose above and below each table is untouched.

Two fixes to the sync workflow while I was in it. `mise-tasks/github/**` was missing from the trigger paths, so a change to the profile task alone would not have published. And a missing token now logs a warning rather than a notice, because the GitHub org profile has never actually synced: `ORG_PROFILE_TOKEN` still is not set, and the last run said so in a notice that was easy to miss on a green check.
