### PR TITLE
Stabilize server device identity

### DIFF
--- a/Sources/Usage/AppIdentity.swift
+++ b/Sources/Usage/AppIdentity.swift
@@ -62,15 +62,16 @@ public func hostProvidedApiKey() -> String? {
 #endif
 }
 
-/// A device id supplied by the JS host, for cases where the auto-generated,
-/// persisted UUID doesn't fit — chiefly a server-side Node process (no per-device
-/// storage; the "device" is the host's own notion). `globalThis.__dalDeviceId`
-/// may be a string or a function returning one. `nil` off WASI or when unset.
+/// A host-provided device id, for when the auto-generated UUID doesn't fit —
+/// chiefly a server-side process. On WASI reads `globalThis.__dalDeviceId`;
+/// elsewhere the `DAL_DEVICE_ID` environment variable. `nil` when unset.
 public func hostProvidedDeviceId() -> String? {
 #if os(WASI)
     return jsHostString("__dalDeviceId")
 #else
-    return nil
+    guard let raw = getenv("DAL_DEVICE_ID") else { return nil }
+    let value = String(cString: raw)
+    return value.isEmpty ? nil : value
 #endif
 }
 

--- a/Sources/Usage/Storage.swift
+++ b/Sources/Usage/Storage.swift
@@ -46,11 +46,41 @@ func resolveDeviceId(_ explicit: String?, _ storage: UsageStorage) -> String {
     explicit ?? hostProvidedDeviceId() ?? storage.persistentDeviceId()
 }
 
+/// Last-resort device id when storage holds none. On Linux prefer the host's
+/// stable /etc/machine-id, so a server fleet whose UserDefaults can't persist
+/// counts one device per host, not one per process; otherwise a random UUID.
+func fallbackDeviceId() -> String {
+#if os(Linux)
+    if let machineId = linuxMachineId() { return machineId }
+#endif
+    return generateUUID()
+}
+
+#if os(Linux)
+/// /etc/machine-id (a 128-bit host id) formatted as a UUID. `nil` if unreadable.
+private func linuxMachineId() -> String? {
+    for path in ["/etc/machine-id", "/var/lib/dbus/machine-id"] {
+        guard let raw = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
+        let hex = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard hex.count == 32, hex.allSatisfy(\.isHexDigit) else { continue }
+        var i = hex.startIndex
+        var parts: [String] = []
+        for n in [8, 4, 4, 4, 12] {
+            let j = hex.index(i, offsetBy: n)
+            parts.append(String(hex[i..<j]))
+            i = j
+        }
+        return parts.joined(separator: "-")
+    }
+    return nil
+}
+#endif
+
 extension UsageStorage {
     /// The stable per-install device id, generated and persisted on first use.
     public func persistentDeviceId() -> String {
         if let existing = get(deviceIdKey), !existing.isEmpty { return existing }
-        let id = generateUUID()
+        let id = fallbackDeviceId()
         set(deviceIdKey, id)
         return id
     }

--- a/Sources/Usage/Transport.swift
+++ b/Sources/Usage/Transport.swift
@@ -9,7 +9,7 @@ import JavaScriptKit
 /// The shared ingest endpoint. Every SDK reports to the same place, so it is not
 /// part of the public API. A host may override it (tests/diagnostics) via
 /// `hostProvidedIngestEndpoint()`.
-private let defaultIngestEndpoint = "https://platform.desertant.ai/api/v1/ingest"
+private let defaultIngestEndpoint = "https://events.desertant.com/api/v1/ingest"
 private var ingestEndpoint: String { hostProvidedIngestEndpoint() ?? defaultIngestEndpoint }
 
 /// A `send` transport that POSTs the serialized body to `endpoint`.


### PR DESCRIPTION
- Server processes on ephemeral filesystems (containers, serverless) minted a fresh device id per process start, inflating MAD with hundreds of phantom devices; they now fall back to the host's stable /etc/machine-id, so a fleet counts one device per host instead of one per process.
- Added a `DAL_DEVICE_ID` environment override on native builds (matching the existing `DAL_APP_ID` / `DAL_API_KEY`), so a server can pin its own device identity explicitly.
- Point the ingest endpoint straight at events.desertant.com instead of the legacy platform.desertant.ai, dropping the 308 redirect hop on every event.