### PR TITLE
Ear is stable, not beta

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -125,7 +125,7 @@
       "tagline": "Name the language from thirty seconds.",
       "summary": "On-device spoken language identification across 99 languages.",
       "category": "Language identification",
-      "lifecycle": "beta",
+      "lifecycle": "stable",
       "visibility": "public",
       "home": "desert-ant-core",
       "sdks": {


### PR DESCRIPTION
Every SDK is live, both runtimes are verified against the same recordings, and the Android binding asserts the same answers through JNI.

The registry value was left at `beta` from when the weights repo was private and nothing had run end to end. Neither is true now.
