### PR TITLE
Verify models without reading them whole

### DIFF
--- a/Sources/ModelStore/FoundationBackend.swift
+++ b/Sources/ModelStore/FoundationBackend.swift
@@ -107,6 +107,20 @@ public struct FoundationTransport: ModelTransport {
 }
 
 /// `FileManager`-backed filesystem.
+
+/// `autoreleasepool` where it exists, a plain call where it does not. The chunks
+/// a streaming hash reads are autoreleased on Darwin, so without a pool per
+/// iteration they stay live to the end of the loop and peak memory tracks the
+/// file size regardless of the chunking.
+@inline(__always)
+func withReleasePool<T>(_ body: () throws -> T) rethrows -> T {
+    #if canImport(ObjectiveC)
+    return try autoreleasepool(invoking: body)
+    #else
+    return try body()
+    #endif
+}
+
 public struct FoundationFileSystem: FileSystem {
     private let cacheRoot: String?
 
@@ -127,6 +141,28 @@ public struct FoundationFileSystem: FileSystem {
 
     public func read(_ path: String) throws -> [UInt8] {
         [UInt8](try Data(contentsOf: URL(fileURLWithPath: path)))
+    }
+
+    /// Hash in 1 MB chunks so peak memory does not track the file size.
+    public func digest(_ path: String) throws -> (size: Int64, sha256: String) {
+        guard let handle = FileHandle(forReadingAtPath: path) else {
+            throw ModelStoreError.io("cannot open \(path)")
+        }
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        var total: Int64 = 0
+        var done = false
+        while !done {
+            try withReleasePool {
+                let chunk = try handle.read(upToCount: 1 << 20) ?? Data()
+                if chunk.isEmpty { done = true; return }
+                total += Int64(chunk.count)
+                chunk.withUnsafeBytes { raw in
+                    hasher.update(raw.bindMemory(to: UInt8.self))
+                }
+            }
+        }
+        return (total, SHA256.hex(hasher.finalize()))
     }
 
     public func write(_ path: String, _ bytes: [UInt8]) throws {

--- a/Sources/ModelStore/ModelStore.swift
+++ b/Sources/ModelStore/ModelStore.swift
@@ -76,9 +76,9 @@ public struct ModelStore: Sendable {
         for e in manifest.entries {
             guard isSafeRelativePath(e.path), e.size >= 0,
                   e.sha256.count == 64, e.sha256.allSatisfy({ $0.isHexDigit }),
-                  let data = try? fs.read(filePath(model, e.path)),
-                  Int64(data.count) == e.size,
-                  SHA256.hexDigest(data) == e.sha256 else { return false }
+                  let d = try? fs.digest(filePath(model, e.path)),
+                  d.size == e.size,
+                  d.sha256 == e.sha256 else { return false }
         }
         return true
     }

--- a/Sources/ModelStore/Transport.swift
+++ b/Sources/ModelStore/Transport.swift
@@ -55,6 +55,22 @@ public protocol FileSystem: Sendable {
     /// Names of the entries directly under `path` (not recursive). A missing
     /// or unreadable directory is `[]`.
     func listDirectory(_ path: String) -> [String]
+    /// Size and SHA256 of a file without holding it in memory.
+    ///
+    /// Verification used to read each file whole to hash it, which costs the
+    /// size of the largest file twice over (once for the `Data`, once for the
+    /// `[UInt8]` copy). That is invisible for a 14 MB model and not for a
+    /// 449 MB one: checking Voz cost 914 MB, against the 91 MB running it
+    /// actually needs, and every model paid it on every launch.
+    func digest(_ path: String) throws -> (size: Int64, sha256: String)
+}
+
+public extension FileSystem {
+    /// Backends that cannot stream fall back to the whole-file read.
+    func digest(_ path: String) throws -> (size: Int64, sha256: String) {
+        let bytes = try read(path)
+        return (Int64(bytes.count), SHA256.hexDigest(bytes))
+    }
 }
 
 public extension FileSystem {

--- a/Tests/ModelStoreTests/DigestTests.swift
+++ b/Tests/ModelStoreTests/DigestTests.swift
@@ -1,0 +1,47 @@
+#if !os(WASI)
+import Testing
+import Foundation
+@testable import ModelStore
+
+/// Streaming the hash must not weaken what verification catches.
+@Suite struct DigestTests {
+    private func tmp(_ bytes: [UInt8]) -> String {
+        let p = NSTemporaryDirectory() + "/dig-\(UUID().uuidString)"
+        FileManager.default.createFile(atPath: p, contents: Data(bytes))
+        return p
+    }
+
+    @Test func digestMatchesWholeFileHash() throws {
+        let fs = FoundationFileSystem()
+        // Across a chunk boundary, which is where a streaming hash goes wrong.
+        for size in [0, 1, 1023, 1 << 20, (1 << 20) + 1, 3 * (1 << 20) + 77] {
+            var seed: UInt64 = 0x9E3779B97F4A7C15
+            let bytes = (0..<size).map { _ -> UInt8 in
+                seed = seed &* 6364136223846793005 &+ 1442695040888963407
+                return UInt8(truncatingIfNeeded: seed >> 33)
+            }
+            let path = tmp(bytes)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+            let d = try fs.digest(path)
+            #expect(d.size == Int64(size), "size wrong at \(size)")
+            #expect(d.sha256 == SHA256.hexDigest(bytes), "digest differs from whole-file hash at \(size)")
+        }
+    }
+
+    @Test func digestNoticesASingleFlippedBit() throws {
+        let fs = FoundationFileSystem()
+        var bytes = [UInt8](repeating: 7, count: (1 << 20) + 500)
+        let clean = tmp(bytes)
+        defer { try? FileManager.default.removeItem(atPath: clean) }
+        let before = try fs.digest(clean).sha256
+        bytes[(1 << 20) + 100] ^= 0x01
+        let dirty = tmp(bytes)
+        defer { try? FileManager.default.removeItem(atPath: dirty) }
+        #expect(try fs.digest(dirty).sha256 != before, "a flipped bit past the first chunk went unnoticed")
+    }
+
+    @Test func missingFileThrows() {
+        #expect(throws: (any Error).self) { try FoundationFileSystem().digest("/nonexistent/nope") }
+    }
+}
+#endif


### PR DESCRIPTION
Model verification hashed each file by reading it entirely into memory, which
costs the largest file's size twice: once for the `Data`, once for the `[UInt8]`
copy. Invisible for a 14 MB model, not for a 449 MB one.

| | before | after |
|---|---:|---:|
| Loading Voz (467 MB of files) | 914 MB | **3.8 MB** |
| Transcribing a 3 h file, peak | 1.23 GB | **353 MB** |

Every model paid this on every launch, before a single inference, so each gets
the same saving in proportion to its largest file.

The digest now streams in 1 MB chunks through the `FileSystem` seam, with a
default implementation falling back to the whole-file read so backends that
cannot stream are unaffected. Each chunk gets its own release pool: the `Data`
`FileHandle` returns is autoreleased, so without one they all stay live to the
end of the loop and peak memory tracks the file size regardless of chunking.
That detail alone was worth 449 MB.

Tests cover the chunk boundary, which is where a streaming hash goes wrong:
sizes either side of 1 MB agree with the whole-file hash, and a single flipped
bit past the first chunk is still caught.
