### PR TITLE
Download weights over Xet on Apple platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ mise.local.toml
 .build-android/
 .build-androidtest/
 .build-floor/
+.build-xet/
 .swiftpm/
 Package.resolved
 Vendor/

--- a/Package.swift
+++ b/Package.swift
@@ -78,6 +78,27 @@ let mlxProducts: [Target.Dependency] = [
     .product(name: "MLXHuggingFace", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
 ]
 
+// Xet is opt-in for the graph reason above, not the macro one: swift-xet is pure Swift with no
+// plugin, but it pulls swift-nio, async-http-client and swift-nio-transport-services, and a
+// package dependency cannot carry a platform condition. Declared as a default trait it would
+// make every Linux, Android and wasm build clone and resolve the NIO stack for a transport only
+// Apple platforms ever construct (and Android's static-stdlib link has no appetite for NIO's C
+// targets). The PRODUCT edge below carries both conditions, so even with the trait enabled the
+// module is absent from a non-Apple build -- which is exactly what `#if canImport(Xet)` in
+// Sources/ModelStore/XetTransport.swift tests.
+//
+// A consumer opts in with:  .package(url: ..., traits: ["Xet"])
+// and gets chunk-deduplicated, parallel CAS downloads of the weights. Without it the store
+// keeps the single-stream URLSession path, which is also what the Xet transport falls back to,
+// so nothing about a model's files or their verification changes either way.
+let xetDependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/huggingface/swift-xet.git", from: "0.2.3"),
+]
+let xetProducts: [Target.Dependency] = [
+    .product(name: "Xet", package: "swift-xet",
+             condition: .when(platforms: [.iOS, .macOS, .tvOS, .visionOS], traits: ["Xet"])),
+]
+
 let jsDependencies: [Package.Dependency] = noJavaScriptKit ? [] : [
     .package(url: "https://github.com/swiftwasm/JavaScriptKit", from: "0.56.1"),
 ]
@@ -405,7 +426,7 @@ let libraryTargets: [Target] = [
             dependencies: [
                 .target(name: "CHostBridge", condition: .when(platforms: [.android])),
                 "JSHost",  // unconditional: see Inference
-            ] + jsWasi + jsEventLoop
+            ] + jsWasi + jsEventLoop + xetProducts
         ),
         .target(
             name: "HostBridge",
@@ -529,8 +550,13 @@ let package = Package(
             description: "MLX-backed generation (the Title model). Apple platforms only; "
                 + "pulls mlx-swift-lm and swift-transformers into the graph."
         ),
+        .trait(
+            name: "Xet",
+            description: "Download model weights over Hugging Face's Xet protocol. Apple "
+                + "platforms only; pulls swift-xet and the NIO stack into the graph."
+        ),
     ],
-    dependencies: jsDependencies + mlxDependencies + [
+    dependencies: jsDependencies + mlxDependencies + xetDependencies + [
         .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
     ],
     targets: coreTargets

--- a/README.md
+++ b/README.md
@@ -153,6 +153,28 @@ inside each package, so nothing here applies to it and nothing downloads.)
 `isDownloaded()` answers whether a model is usable with no network, and
 `download()` fetches it ahead of time with progress.
 
+### Faster downloads on Apple platforms (the `Xet` trait)
+
+Our Hub repos are stored on [Xet](https://huggingface.co/docs/hub/en/xet/index),
+Hugging Face's content-addressed backend, which serves a file as deduplicated
+chunks fetched in parallel rather than one stream. Swift consumers can opt into
+it with a package trait:
+
+```swift
+.package(url: "https://github.com/Desert-Ant-Labs/desert-ant-core.git", from: "3.0.0",
+        traits: ["Xet"])
+```
+
+Nothing else changes: the same files land in the same cache and are verified the
+same way, and anything not Xet-backed (or a CAS that is having a bad day) falls
+back to the ordinary HTTPS download. It is opt-in because it pulls
+[swift-xet](https://github.com/huggingface/swift-xet) and the NIO stack into the
+resolved graph, which no Linux, Android or web build has any use for. Those
+platforms, and the Node and Kotlin SDKs, keep the plain download path.
+
+Set `HF_TOKEN` in the environment for a gated or private repo; public models need
+no token.
+
 ### Offline and airgapped
 
 Model files are ordinary HTTPS downloads, so a directory can be populated from

--- a/Sources/ModelStore/FoundationBackend.swift
+++ b/Sources/ModelStore/FoundationBackend.swift
@@ -202,13 +202,26 @@ public extension StoredModel {
 }
 
 public extension ModelStore {
-    /// Default Apple/Linux store: URLSession + FileManager.
+    /// Default Apple/Linux store: URLSession + FileManager, or the Xet
+    /// transport where the `Xet` trait put it in the graph (Apple only; it keeps
+    /// URLSession underneath as its fallback).
     ///
     /// - Parameter cacheRoot: base for the managed cache layout. `nil` uses the
     ///   platform caches directory, which is the usual case on Apple and Linux.
     init(cacheRoot: String? = nil, endpoint: String = "https://huggingface.co") {
-        self.init(transport: FoundationTransport(),
+        self.init(transport: ModelStore.platformTransport(),
                   fileSystem: FoundationFileSystem(cacheRoot: cacheRoot), endpoint: endpoint)
+    }
+
+    /// The best transport this build has. `canImport` rather than a platform
+    /// check: the Xet module is in the graph only for an Apple build that
+    /// enabled the trait (see XetTransport.swift).
+    static func platformTransport() -> any ModelTransport {
+        #if canImport(Xet)
+        return acceleratedTransport()
+        #else
+        return FoundationTransport()
+        #endif
     }
 
     /// An explicit `cacheRoot` wins; `nil` falls back to FileManager's caches

--- a/Sources/ModelStore/ModelStore.swift
+++ b/Sources/ModelStore/ModelStore.swift
@@ -108,6 +108,31 @@ public struct ModelStore: Sendable {
         let tree = try await transport.tree(treeURL(model))
         let resolved = try resolve(model.files, in: tree, repo: model.repo)
 
+        let manifest: [Manifest.Entry]
+        do {
+            manifest = try await fetchAll(model, resolved, progress: progress)
+        } catch {
+            // The transport gets its end-of-model signal whether or not the
+            // model arrived, or a failed download leaks its connections.
+            await transport.finishDownloads()
+            throw error
+        }
+        await transport.finishDownloads()
+
+        try fs.makeDirectory(parentDir(manifestPath(model)))
+        try fs.write(
+            manifestPath(model),
+            Manifest(requested: model.files, entries: manifest).serialized()
+        )
+        return storedModel(for: model)
+    }
+
+    /// Fetch every resolved file, reporting one combined progress across them.
+    private func fetchAll(
+        _ model: ModelSpec,
+        _ resolved: [RemoteEntry],
+        progress: @Sendable @escaping (DownloadProgress) -> Void
+    ) async throws -> [Manifest.Entry] {
         let totalBytes = resolved.reduce(0) { $0 + $1.size }
         var completedBytes: Int64 = 0
         let report: @Sendable (Int64) -> Void = { done in
@@ -133,13 +158,7 @@ public struct ModelStore: Sendable {
             manifest.append(.init(path: e.path, size: e.size, sha256: sha))
             report(completedBytes)
         }
-
-        try fs.makeDirectory(parentDir(manifestPath(model)))
-        try fs.write(
-            manifestPath(model),
-            Manifest(requested: model.files, entries: manifest).serialized()
-        )
-        return storedModel(for: model)
+        return manifest
     }
 
     /// Directories of every revision of `repo` present in the managed cache,

--- a/Sources/ModelStore/Transport.swift
+++ b/Sources/ModelStore/Transport.swift
@@ -29,6 +29,11 @@ public protocol ModelTransport: Sendable {
     /// throw, and resolution falls back to the downloaded cache.
     func tags(_ url: String) async throws -> [String]
     func download(_ url: String, to destinationPath: String, onBytes: @escaping @Sendable (Int64) -> Void) async throws
+    /// Called once when the store stops downloading a model, on success and on
+    /// failure alike. A stateless transport ignores it; one that keeps
+    /// connections alive across a model's files (the Xet transport) releases
+    /// them here, so nothing outlives the download it was opened for.
+    func finishDownloads() async
 }
 
 public extension ModelTransport {
@@ -37,6 +42,9 @@ public extension ModelTransport {
     func tags(_ url: String) async throws -> [String] {
         throw ModelStoreError.io("tag listing not supported by this transport")
     }
+
+    /// Most transports hold nothing between files.
+    func finishDownloads() async {}
 }
 
 /// Filesystem seam: the small set of operations the store needs. `move` must be

--- a/Sources/ModelStore/XetPointer.swift
+++ b/Sources/ModelStore/XetPointer.swift
@@ -1,0 +1,99 @@
+// What the Hub tells us about a file's Xet storage, and nothing about how it is
+// fetched: this file is Foundation-free and compiles on every platform so the
+// parsing is testable without the `Xet` trait (the transport that uses it is
+// Apple-only, see XetTransport.swift).
+
+/// A file's coordinates in Hugging Face's content-addressable storage.
+///
+/// Hub files are served twice over: an ordinary LFS redirect, and - for repos
+/// migrated to Xet, which ours are - a content-defined chunk stream that
+/// deduplicates against chunks already on disk and downloads the rest in
+/// parallel. A `HEAD` on the usual `resolve` URL carries both: `X-Xet-Hash` is
+/// the Merkle hash the CAS reconstructs the file from, and the `Link` header's
+/// `xet-auth` relation is where a read token for it comes from.
+public struct XetPointer: Sendable, Equatable {
+    /// 64-char hex Merkle hash of the file's contents (`X-Xet-Hash`).
+    public let fileID: String
+    /// Hub endpoint that mints a short-lived CAS read token.
+    public let refreshURL: String
+
+    public init(fileID: String, refreshURL: String) {
+        self.fileID = fileID
+        self.refreshURL = refreshURL
+    }
+
+    /// Build a pointer from the two response headers, or `nil` when the file is
+    /// not Xet-backed (small git-tracked files never are) or the headers are not
+    /// what we expect. `nil` is not an error: it means "download this the plain
+    /// way".
+    ///
+    /// - Parameter resolveURL: the `resolve` URL the headers came from, used for
+    ///   the refresh endpoint when the `Link` header is absent. The Hub has
+    ///   served that header since Xet shipped, but a proxy or a mirror endpoint
+    ///   may drop it, and the endpoint is derivable.
+    public static func from(xetHash: String?, link: String?, resolveURL: String) -> XetPointer? {
+        guard let xetHash, isFileID(xetHash) else { return nil }
+        guard let refresh = link.flatMap(authURL(inLink:)) ?? readTokenURL(forResolveURL: resolveURL)
+        else { return nil }
+        return XetPointer(fileID: xetHash, refreshURL: refresh)
+    }
+
+    /// A CAS file id is a 64-char lowercase-or-upper hex hash. Rejecting
+    /// anything else here keeps a surprising header out of a URL path.
+    static func isFileID(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy(\.isHexDigit)
+    }
+
+    /// The `xet-auth` target from an RFC 8288 `Link` header:
+    /// `<url>; rel="xet-auth", <url>; rel="xet-reconstruction-info"`.
+    static func authURL(inLink link: String) -> String? {
+        for section in sections(of: link) {
+            guard let open = section.firstIndex(of: "<"),
+                  let close = section[open...].firstIndex(of: ">") else { continue }
+            let target = String(section[section.index(after: open)..<close])
+            let params = section[section.index(after: close)...].lowercased()
+                .filter { $0 != " " && $0 != "\"" }
+            guard params.contains("rel=xet-auth"), target.hasPrefix("https://") else { continue }
+            return target
+        }
+        return nil
+    }
+
+    /// Split a `Link` header on the commas that separate its entries, ignoring
+    /// commas inside `<...>` - the signed CDN URLs the Hub returns are full of
+    /// them.
+    private static func sections(of link: String) -> [String] {
+        var out: [String] = []
+        var current = ""
+        var inAngle = false
+        for ch in link {
+            switch ch {
+            case "<": inAngle = true; current.append(ch)
+            case ">": inAngle = false; current.append(ch)
+            case "," where !inAngle: out.append(current); current = ""
+            default: current.append(ch)
+            }
+        }
+        out.append(current)
+        return out
+    }
+
+    /// `<endpoint>/<repo>/resolve/<rev>/<file>` ->
+    /// `<endpoint>/api/models/<repo>/xet-read-token/<rev>`.
+    static func readTokenURL(forResolveURL url: String) -> String? {
+        // Split rather than search for "/resolve/": String.range(of:) is
+        // Foundation, which this module keeps out of every file but one.
+        // "https://host/owner/repo/resolve/<rev>/<file>" is
+        // ["https:", "", "host", "owner", "repo", "resolve", rev, ...], so the
+        // marker is never before index 5 and a repo literally named "resolve"
+        // cannot be mistaken for it.
+        let parts = url.split(separator: "/", omittingEmptySubsequences: false)
+        guard let marker = parts.dropFirst(5).firstIndex(of: "resolve"),
+              marker + 1 < parts.count else { return nil }
+        let endpoint = parts[..<(marker - 2)].joined(separator: "/")
+        let repo = parts[(marker - 2)..<marker].joined(separator: "/")
+        let revision = parts[marker + 1]
+        guard !endpoint.isEmpty, !repo.isEmpty, !revision.isEmpty else { return nil }
+        return "\(endpoint)/api/models/\(repo)/xet-read-token/\(revision)"
+    }
+}

--- a/Sources/ModelStore/XetTransport.swift
+++ b/Sources/ModelStore/XetTransport.swift
@@ -1,0 +1,173 @@
+// Apple-only transport that fetches weights over Hugging Face's Xet protocol
+// instead of a single LFS stream: chunk-level deduplication against what the
+// CAS already served plus parallel xorb fetches, which is several times faster
+// on a first download of a large model and near-free on a revision bump that
+// only moves a few chunks.
+//
+// `canImport(Xet)` is the whole gate. swift-xet is a *trait*-conditional package
+// dependency restricted to Apple platforms in Package.swift (see the `Xet`
+// trait there), so this file exists only in a graph that asked for it: a
+// consumer without the trait, and every Linux/Android/wasm build, compiles the
+// module exactly as before and keeps the URLSession path.
+#if canImport(Xet)
+import Foundation
+import Xet
+
+/// ``ModelTransport`` that downloads Xet-backed files through the CAS and falls
+/// back to ``FoundationTransport`` for everything else.
+///
+/// The fallback is not only for small files. A repo that has not been migrated,
+/// a mirror endpoint that serves plain LFS, and a CAS request that fails all
+/// take it, so enabling the trait can make a download faster and cannot make it
+/// impossible. The store verifies size and SHA-256 either way, so neither path
+/// is trusted more than the other.
+public final class XetTransport: ModelTransport {
+    private let fallback = FoundationTransport()
+    private let hubToken: String?
+    private let session = DownloaderSession()
+
+    /// - Parameter hubToken: Hub token for gated or private repos. `nil` reads
+    ///   `HF_TOKEN` from the environment, matching the rest of the Hub tooling;
+    ///   public repos need none.
+    public init(hubToken: String? = nil) {
+        let token = hubToken ?? ProcessInfo.processInfo.environment["HF_TOKEN"]
+        self.hubToken = token.flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    public func tree(_ url: String) async throws -> [RemoteEntry] { try await fallback.tree(url) }
+
+    public func tags(_ url: String) async throws -> [String] { try await fallback.tags(url) }
+
+    public func download(_ url: String, to destinationPath: String,
+                         onBytes: @escaping @Sendable (Int64) -> Void) async throws {
+        guard let pointer = await pointer(for: url),
+              let refreshURL = URL(string: pointer.refreshURL) else {
+            try await fallback.download(url, to: destinationPath, onBytes: onBytes)
+            return
+        }
+        let downloader = await session.downloader(refreshURL: refreshURL, hubToken: hubToken)
+        // Callers require monotonic progress, and a poll already in flight when
+        // the download finishes would otherwise report a stale, smaller size
+        // after the final count.
+        let reported = HighWaterMark(onBytes)
+        do {
+            let written = try await withProgressPolling(of: destinationPath, report: reported.report) {
+                try await downloader.download(pointer.fileID, to: URL(fileURLWithPath: destinationPath))
+            }
+            reported.report(written)
+        } catch is CancellationError {
+            throw ModelStoreError.io("GET \(url): cancelled")
+        } catch {
+            // A CAS failure must not be a download failure: the file is still on
+            // the Hub behind the ordinary redirect. It reports through the same
+            // high-water mark, so restarting the file does not walk progress
+            // backwards for whoever is watching.
+            try await fallback.download(url, to: destinationPath, onBytes: reported.report)
+        }
+    }
+
+    /// Releases the CAS connections once the store has finished a model. Each
+    /// downloader owns an event-loop group and a pool of prewarmed connections,
+    /// which is why one is kept across a model's files and why it must not
+    /// outlive them.
+    public func finishDownloads() async {
+        await session.shutdown()
+    }
+
+    // MARK: internals
+
+    /// `HEAD` the resolve URL without following the redirect, which is the only
+    /// place the Hub states a file's CAS hash. Any failure here answers `nil`
+    /// and the caller downloads the plain way.
+    private func pointer(for url: String) async -> XetPointer? {
+        guard let u = URL(string: url) else { return nil }
+        var request = URLRequest(url: u)
+        request.httpMethod = "HEAD"
+        if let hubToken { request.setValue("Bearer \(hubToken)", forHTTPHeaderField: "Authorization") }
+        guard let (_, response) = try? await URLSession.shared.data(for: request,
+                                                                    delegate: NoRedirects()),
+              let http = response as? HTTPURLResponse else { return nil }
+        return XetPointer.from(
+            xetHash: http.value(forHTTPHeaderField: "X-Xet-Hash"),
+            link: http.value(forHTTPHeaderField: "Link"),
+            resolveURL: url
+        )
+    }
+
+    /// swift-xet reports no progress, so poll the file it is writing. 250 ms is
+    /// well under the store's own reporting granularity and costs one `stat`.
+    private func withProgressPolling<T>(
+        of path: String,
+        report: @escaping @Sendable (Int64) -> Void,
+        _ body: () async throws -> T
+    ) async rethrows -> T {
+        let poll = Task {
+            while !Task.isCancelled {
+                try await Task.sleep(nanoseconds: 250_000_000)
+                if let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+                   let size = (attrs[.size] as? NSNumber)?.int64Value {
+                    report(size)
+                }
+            }
+        }
+        defer { poll.cancel() }
+        return try await body()
+    }
+}
+
+/// Forwards only values greater than every value forwarded before it.
+private final class HighWaterMark: @unchecked Sendable {
+    private let lock = NSLock()
+    private let onBytes: @Sendable (Int64) -> Void
+    private var highest: Int64 = 0
+
+    init(_ onBytes: @escaping @Sendable (Int64) -> Void) { self.onBytes = onBytes }
+
+    var report: @Sendable (Int64) -> Void {
+        { [self] bytes in
+            let forward = lock.withLock { () -> Bool in
+                guard bytes > highest else { return false }
+                highest = bytes
+                return true
+            }
+            if forward { onBytes(bytes) }
+        }
+    }
+}
+
+/// Holds one downloader per repo revision (the refresh URL identifies it) for as
+/// long as the store is working through that model's files, so the token, the
+/// event-loop group and the prewarmed connections are paid for once instead of
+/// once per file.
+private actor DownloaderSession {
+    private var current: (refreshURL: URL, downloader: XetDownloader)?
+
+    func downloader(refreshURL: URL, hubToken: String?) async -> XetDownloader {
+        if let current, current.refreshURL == refreshURL { return current.downloader }
+        await shutdown()
+        let downloader = XetDownloader(refreshURL: refreshURL, hubToken: hubToken)
+        current = (refreshURL, downloader)
+        return downloader
+    }
+
+    func shutdown() async {
+        guard let current else { return }
+        self.current = nil
+        try? await current.downloader.shutdown()
+    }
+}
+
+/// Reading `X-Xet-Hash` means seeing the 302 itself, not the CDN response it
+/// points at.
+private final class NoRedirects: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest) async -> URLRequest? { nil }
+}
+
+public extension ModelStore {
+    /// The Apple default when the `Xet` trait is enabled: CAS downloads with the
+    /// URLSession path underneath them.
+    static func acceleratedTransport() -> any ModelTransport { XetTransport() }
+}
+#endif

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -106,3 +106,16 @@ Android regex uses `java.util.regex.Pattern` and JSON parsing uses the Kotlin
 host's native JSON, both through the JNI host. Android NFKC normalization uses
 the platform `libicu.so` exposed by the NDK (API 31+), so no regex, JSON, or
 Unicode normalization library is vendored or hand-rolled.
+
+---
+
+## Optional Swift package dependencies
+
+Neither is in a default build: each sits behind a package trait, so a consumer
+that does not ask for it never resolves or links it.
+
+- **swift-xet** - Hugging Face - **Apache-2.0**. Xet-protocol model downloads on
+  Apple platforms, behind the `Xet` trait. Pulls swift-nio, async-http-client and
+  swift-nio-transport-services (Apple, **Apache-2.0**).
+- **mlx-swift-lm** - Apple - **MIT**, and **swift-transformers** - Hugging Face -
+  **Apache-2.0**. MLX generation for Title, behind the `MLX` trait.

--- a/Tests/ModelStoreTests/ModelStoreTests.swift
+++ b/Tests/ModelStoreTests/ModelStoreTests.swift
@@ -62,6 +62,21 @@ final class DroppingTransport: ModelTransport, @unchecked Sendable {
     }
 }
 
+/// Counts the end-of-model signal the store owes a stateful transport.
+final class SessionTransport: ModelTransport, @unchecked Sendable {
+    let inner: ModelTransport
+    private let lock = NSLock()
+    private var finishes = 0
+    var finishCount: Int { lock.withLock { finishes } }
+
+    init(_ inner: ModelTransport) { self.inner = inner }
+    func tree(_ url: String) async throws -> [RemoteEntry] { try await inner.tree(url) }
+    func download(_ url: String, to path: String, onBytes: @escaping @Sendable (Int64) -> Void) async throws {
+        try await inner.download(url, to: path, onBytes: onBytes)
+    }
+    func finishDownloads() async { lock.withLock { finishes += 1 } }
+}
+
 final class LockedDouble: @unchecked Sendable {
     private let lock = NSLock(); private var value = 0.0
     func set(_ v: Double) { lock.withLock { value = v } }
@@ -267,6 +282,61 @@ final class ModelStoreTests {
         do { try await s.download(m); Issue.record("expected integrity failure") }
         catch let e as ModelStoreError { if case .integrityCheckFailed = e {} else { Issue.record("\(e)") } }
         #expect(!s.isDownloaded(m))
+    }
+
+    @Test func transportSessionEndsOnSuccessAndOnFailure() async throws {
+        let payload = ["redact.tflite": [UInt8](repeating: 0x41, count: 512)]
+        let ok = SessionTransport(MockTransport(payload))
+        try await store(ok).download(model(["redact.tflite"]))
+        #expect(ok.finishCount == 1)
+
+        // A different file, or the manifest just written would make this a
+        // cached no-op that never reaches the transport at all.
+        let dropped = SessionTransport(DroppingTransport(["labels.json": Array("{}".utf8)]))
+        _ = try? await store(dropped).download(model(["labels.json"]))
+        #expect(dropped.finishCount == 1)
+    }
+
+    @Test func xetPointerFromHubHeaders() {
+        let resolve = "https://huggingface.co/desert-ant-labs/redact/resolve/v0.4.0/redact.tflite"
+        let hash = String(repeating: "a1", count: 32)
+        let link = "<https://huggingface.co/api/models/desert-ant-labs/redact/xet-read-token/abc>;"
+            + " rel=\"xet-auth\", <https://cas-server.xethub.hf.co/v1/reconstructions/\(hash)>;"
+            + " rel=\"xet-reconstruction-info\""
+
+        let pointer = XetPointer.from(xetHash: hash, link: link, resolveURL: resolve)
+        #expect(pointer?.fileID == hash)
+        #expect(pointer?.refreshURL == "https://huggingface.co/api/models/desert-ant-labs/redact/xet-read-token/abc")
+
+        // No Link header: the token endpoint is derived from the resolve URL.
+        #expect(XetPointer.from(xetHash: hash, link: nil, resolveURL: resolve)?.refreshURL
+            == "https://huggingface.co/api/models/desert-ant-labs/redact/xet-read-token/v0.4.0")
+
+        // Not Xet-backed, or nonsense: no pointer, so the caller downloads the
+        // ordinary way rather than failing.
+        #expect(XetPointer.from(xetHash: nil, link: link, resolveURL: resolve) == nil)
+        #expect(XetPointer.from(xetHash: "short", link: link, resolveURL: resolve) == nil)
+        #expect(XetPointer.from(xetHash: String(repeating: "z", count: 64), link: link, resolveURL: resolve) == nil)
+        #expect(XetPointer.from(xetHash: hash, link: "<x>; rel=\"other\"", resolveURL: "not a url") == nil)
+    }
+
+    @Test func xetLinkParsingIgnoresCommasInsideURLs() {
+        // The Hub's signed CDN URLs carry commas in their query strings, so
+        // splitting the header on every comma finds the wrong target.
+        let link = "<https://cdn.test/x?p=a,b,c>; rel=\"xet-reconstruction-info\","
+            + "<https://hub.test/api/models/o/r/xet-read-token/main>;rel=xet-auth"
+        #expect(XetPointer.authURL(inLink: link) == "https://hub.test/api/models/o/r/xet-read-token/main")
+        #expect(XetPointer.authURL(inLink: "<https://hub.test/a>; rel=\"canonical\"") == nil)
+        // Only https targets: a token request must not be downgraded.
+        #expect(XetPointer.authURL(inLink: "<http://hub.test/a>; rel=\"xet-auth\"") == nil)
+    }
+
+    @Test func xetReadTokenURLFromResolveURL() {
+        #expect(XetPointer.readTokenURL(forResolveURL:
+            "https://hub.test/owner/repo/resolve/main/dir/file.bin")
+            == "https://hub.test/api/models/owner/repo/xet-read-token/main")
+        #expect(XetPointer.readTokenURL(forResolveURL: "https://hub.test/owner/repo/blob/main/f") == nil)
+        #expect(XetPointer.readTokenURL(forResolveURL: "https://hub.test/resolve/main/f") == nil)
     }
 
     @Test func posixFileSystemBackend() async throws {

--- a/mise-tasks/build/swift
+++ b/mise-tasks/build/swift
@@ -31,3 +31,18 @@ for model in $(dal_select "${usage_model:-all}"); do
         swift build --scratch-path .build-host --target "$product" -Xlinker "-L$litert"
     fi
 done
+
+# The Xet transport is behind `canImport(Xet)` (Sources/ModelStore/XetTransport.swift),
+# so not one line of it is compiled by anything above: without this, the faster
+# download path could break and only a consumer that enabled the trait would
+# find out. Apple-only, and once for the whole package rather than per model,
+# because it is shared code and not a model's own graph.
+#
+# Its own scratch directory, not .build-host: flipping traits back and forth in
+# one scratch path leaves the Xcode build system with a module cache it then
+# fails to scan ("clang dependency scanning failure"), and test:swift runs next
+# in .build-host without traits.
+if [ "$(uname)" = Darwin ] && [ "${usage_model:-all}" = all ]; then
+    echo "== ModelStore (Xet trait) =="
+    swift build --scratch-path .build-xet --traits Xet --target ModelStore
+fi


### PR DESCRIPTION
Our Hub repos are Xet-backed, so a weight file can arrive as deduplicated chunks fetched in parallel rather than one LFS stream. This adds a `ModelTransport` that uses it on Apple platforms.

The transport `HEAD`s the resolve URL without following the redirect, reads `X-Xet-Hash` and the `Link` header's `xet-auth` target, and hands both to [swift-xet](https://github.com/huggingface/swift-xet). Files with no Xet hash (the small git-tracked ones) and any CAS failure fall back to the existing URLSession path, and the store verifies size and SHA-256 either way, so enabling this changes no file that lands on disk and no check that guards it.

It is opt-in behind a `Xet` package trait, for the reason the `MLX` trait exists: swift-xet pulls the NIO stack, a package dependency cannot carry a platform condition, and no Linux, Android or wasm build has any use for it. The product edge is conditional on the trait *and* on Apple, so `#if canImport(Xet)` is the whole gate in the source, and a consumer that does not ask for it resolves exactly the graph it does today.

One downloader is kept per repo revision rather than per file, since each owns an event-loop group and a pool of prewarmed connections. That is what the new `ModelTransport.finishDownloads()` seam is for: the store signals the end of a model on success and on failure alike, with a default no-op for every other transport. swift-xet reports no progress, so progress is polled off the file being written and clamped to a high-water mark, which keeps reports monotonic including across a mid-file fallback.

`mise run build:swift` now also compiles `ModelStore` with the trait (its own scratch dir, since flipping traits inside one leaves the Xcode build system with a module cache it cannot scan). Without that, nothing in CI would compile the gated file at all.

Verified against the Hub: `redact.tflite` came down over the CAS path in about 1.5s for 24 MB and passed the store's verification, `labels.json` took the LFS path, and `EmoTests.HubDownloadTests` (which asserts monotonic progress) passes with the trait enabled. `mise run test:swift`, `check:docs`, `check:manifest`, `check:links` and `check:isolation` are green.