### PR TITLE
Read the embedding table in place instead of copying it

### DIFF
--- a/Sources/Voz/Assets.swift
+++ b/Sources/Voz/Assets.swift
@@ -10,7 +10,11 @@ struct Assets {
     /// copies a row without converting. The embedding stays outside the graph:
     /// a gather over an 8193 x 640 table has no Neural Engine kernel and is a
     /// table read the host does for free.
-    let embedding: [Element]
+    ///
+    /// Held as the mapped file rather than an array of its contents: the bytes
+    /// on disk are already exactly the layout the decode reads, so there is
+    /// nothing to convert. See ``withEmbedding(_:)``.
+    private let embeddingData: Data
     let mel: MLModel
     let encoder: MLModel
     let decodeStep: MLModel
@@ -37,9 +41,7 @@ struct Assets {
             throw VozError.invalidModel(
                 "embedding.f16 has \(raw.count) bytes, expected \(expected * 2)")
         }
-        embedding = raw.withUnsafeBytes { buf in
-            (0..<expected).map { buf.loadUnaligned(fromByteOffset: $0 * 2, as: Element.self) }
-        }
+        embeddingData = raw
 
         let mlConfiguration = MLModelConfiguration()
         mlConfiguration.computeUnits = computeUnits
@@ -62,6 +64,23 @@ struct Assets {
         guard decodeLanes > 0 else {
             throw VozError.invalidModel("decode step declares no lanes")
         }
+    }
+
+    /// The embedding table, in the mapped file's own memory.
+    ///
+    /// Reading it in place rather than materializing it: the file is 10.5 MB of
+    /// float16 in row-major order, which is what a decode step wants, so a copy
+    /// buys nothing. Building an array of it cost a 5,243,520-iteration loop
+    /// that an unoptimized build (a dependency's default) runs one element at a
+    /// time, and faulted the whole table in from disk when a decode reads only
+    /// the rows it emits. Measured on an M-series Mac, that loop was 620 ms of
+    /// the 780 ms load.
+    ///
+    /// Binding is well formed rather than lucky: a mapping starts on a page
+    /// boundary, and `Data` allocates with more alignment than a two byte
+    /// element needs, so neither backing can land this odd.
+    func withEmbedding<T>(_ body: (UnsafeBufferPointer<Element>) throws -> T) rethrows -> T {
+        try embeddingData.withUnsafeBytes { try body($0.bindMemory(to: Element.self)) }
     }
 }
 #endif

--- a/Sources/Voz/Pipeline.swift
+++ b/Sources/Voz/Pipeline.swift
@@ -222,7 +222,7 @@ final class Pipeline {
 
         while slot.contains(where: { $0 >= 0 }) {
             projections.withUnsafeBufferPointer { source in
-                assets.embedding.withUnsafeBufferPointer { table in
+                assets.withEmbedding { table in
                     for lane in 0..<lanes where slot[lane] >= 0 {
                         (embed.ptr + lane * c.predHidden)
                             .update(from: table.baseAddress! + label[lane] * c.predHidden,


### PR DESCRIPTION
Loading the model converted the 8193 x 640 float16 embedding one element at a time, which is 5,243,520 iterations to produce 10.5 MB whose bytes are already the layout being produced. An optimizing build vectorizes most of that away, but a dependency is built unoptimized by default, and there it was the largest pure-Swift cost in the load. It also faulted the whole table in from disk, while a decode reads only the rows it emits.

The mapped file is kept instead, and `withEmbedding` hands the decode loop the same `UnsafeBufferPointer<Element>` it had before. Binding is well formed rather than lucky: a mapping starts on a page boundary, and `Data` allocates with more alignment than a two byte element needs.

Load time for a model already on disk, M4 Max, median of warm loads:

| build | before | after |
| --- | ---: | ---: |
| unoptimized (how a dependency builds) | 781 ms | **158 ms** |
| optimized | 171 ms | 157 ms |

Transcription is unchanged at 2.25 s for 430 s of audio, and the output is identical: same 1133 words and the same SHA256 over every word and timestamp, before and after.

`mise run test:swift` passes, as do `check:manifest`, `check:docs` and `check:isolation`. `test:node` needs `build:node-native` artifacts I do not have locally, and this change touches no bindings.

Found while profiling a first transcription in an app that takes Voz as a package dependency, where every load paid the full 780 ms.
