### PR TITLE
Taglines: sharper Voz, Title, Uhm

### DIFF
--- a/docs/models/title.md
+++ b/docs/models/title.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Title
 
-Names what you just wrote.
+Titles and descriptions in a split second.
 
 On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text.
 

--- a/docs/models/uhm.md
+++ b/docs/models/uhm.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Uhm
 
-An hour of audio in twelve seconds.
+An hour of audio in 12 seconds.
 
 On-device filler-word detection: frame-precise "uh"/"um"/"hmm" spans.
 

--- a/docs/models/voz.md
+++ b/docs/models/voz.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Voz
 
-Every word, with the time it was said.
+Lightning-fast transcriptions, precisely timed.
 
 On-device speech recognition: transcripts with word-level timestamps, 25 languages.
 

--- a/manifest.json
+++ b/manifest.json
@@ -469,7 +469,7 @@
     {
       "id": "title",
       "name": "Title",
-      "tagline": "Names what you just wrote.",
+      "tagline": "Titles and descriptions in a split second.",
       "summary": "On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text.",
       "category": "Titles and descriptions",
       "lifecycle": "stable",
@@ -585,7 +585,7 @@
     {
       "id": "uhm",
       "name": "Uhm",
-      "tagline": "An hour of audio in twelve seconds.",
+      "tagline": "An hour of audio in 12 seconds.",
       "summary": "On-device filler-word detection: frame-precise \"uh\"/\"um\"/\"hmm\" spans.",
       "category": "Filler-word detection",
       "lifecycle": "stable",
@@ -627,7 +627,7 @@
     {
       "id": "voz",
       "name": "Voz",
-      "tagline": "Every word, with the time it was said.",
+      "tagline": "Lightning-fast transcriptions, precisely timed.",
       "summary": "On-device speech recognition: transcripts with word-level timestamps, 25 languages.",
       "category": "Speech recognition",
       "lifecycle": "stable",


### PR DESCRIPTION
Update model taglines:

- **Voz**: "Every word, with the time it was said." -> **"Lightning-fast transcriptions, precisely timed."**
- **Title**: "Names what you just wrote." -> **"Titles and descriptions in a split second."**
- **Uhm**: "twelve seconds" -> **"12 seconds"** (compact-unit convention).

Docs regenerated from the manifest (`mise run docs:render`).