### PR TITLE
Taglines: refresh to the current headlines

### DIFF
--- a/docs/models/align.md
+++ b/docs/models/align.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Align
 
-Timestamps that land on the word.
+Accurate word timestamps for any transcript.
 
 Word-timestamp refinement for Apple's SpeechAnalyzer pipeline.
 

--- a/docs/models/clips.md
+++ b/docs/models/clips.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Clips
 
-Video and audio highlights in seconds.
+Create short videos and highlight clips.
 
 Short clips and highlights from talking video and audio: podcasts, interviews, meetings. On-device.
 

--- a/docs/models/ear.md
+++ b/docs/models/ear.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Ear
 
-Name the language from thirty seconds of audio.
+Detect spoken language from 30 seconds audio.
 
 On-device spoken language identification across 99 languages.
 

--- a/docs/models/emo.md
+++ b/docs/models/emo.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Emo
 
-Faster than you can type.
+Suggest emoji faster than you can type.
 
 Multilingual on-device emoji suggestion.
 

--- a/docs/models/gist.md
+++ b/docs/models/gist.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Gist
 
-Know what any text is about.
+Generate topics and tags for posts and articles.
 
 Multilingual on-device content topic tagging across a 36-topic taxonomy.
 

--- a/docs/models/redact.md
+++ b/docs/models/redact.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Redact
 
-Personal data, gone before it moves.
+Filter PII on the device.
 
 Multilingual on-device PII detection and redaction.
 

--- a/docs/models/title.md
+++ b/docs/models/title.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Title
 
-Titles and descriptions in a split second.
+Suggest a title and description for any text.
 
 On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text.
 

--- a/docs/models/tongue.md
+++ b/docs/models/tongue.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Tongue
 
-Name the language from three words.
+Detect language based on 3 words.
 
 On-device language identification for short text across 84 languages.
 

--- a/docs/models/uhm.md
+++ b/docs/models/uhm.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Uhm
 
-An hour of audio in 12 seconds.
+Find and remove every filler word.
 
 On-device filler-word detection: frame-precise "uh"/"um"/"hmm" spans.
 

--- a/docs/models/voz.md
+++ b/docs/models/voz.md
@@ -1,7 +1,7 @@
 <!-- model:start -->
 # Voz
 
-Lightning-fast transcriptions, precisely timed.
+Transcribe 10 minutes in 2 seconds.
 
 On-device speech recognition: transcripts with word-level timestamps, 25 languages.
 

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
     {
       "id": "align",
       "name": "Align",
-      "tagline": "Timestamps that land on the word.",
+      "tagline": "Accurate word timestamps for any transcript.",
       "summary": "Word-timestamp refinement for Apple's SpeechAnalyzer pipeline.",
       "category": "Word timestamps",
       "lifecycle": "stable",
@@ -86,7 +86,7 @@
     {
       "id": "clips",
       "name": "Clips",
-      "tagline": "Video and audio highlights in seconds.",
+      "tagline": "Create short videos and highlight clips.",
       "summary": "Short clips and highlights from talking video and audio: podcasts, interviews, meetings. On-device.",
       "category": "Clip selection",
       "lifecycle": "stable",
@@ -122,7 +122,7 @@
     {
       "id": "ear",
       "name": "Ear",
-      "tagline": "Name the language from thirty seconds of audio.",
+      "tagline": "Detect spoken language from 30 seconds audio.",
       "summary": "On-device spoken language identification across 99 languages.",
       "category": "Language identification",
       "lifecycle": "stable",
@@ -166,7 +166,7 @@
     {
       "id": "emo",
       "name": "Emo",
-      "tagline": "Faster than you can type.",
+      "tagline": "Suggest emoji faster than you can type.",
       "summary": "Multilingual on-device emoji suggestion.",
       "category": "Emoji suggestions",
       "lifecycle": "stable",
@@ -206,7 +206,7 @@
     {
       "id": "eye",
       "name": "Eye",
-      "tagline": "Forty shots. One keeper.",
+      "tagline": "Tag and rank images.",
       "summary": "On-device frame scoring: which shot to keep from a burst or a clip.",
       "category": "Image and video scoring",
       "lifecycle": "closed-beta",
@@ -241,7 +241,7 @@
     {
       "id": "face",
       "name": "Face",
-      "tagline": "People search, no server.",
+      "tagline": "Find people in photos, private on the device.",
       "summary": "On-device face matching across a photo library or through a video.",
       "category": "Face matching",
       "lifecycle": "closed-beta",
@@ -276,7 +276,7 @@
     {
       "id": "gist",
       "name": "Gist",
-      "tagline": "Know what any text is about.",
+      "tagline": "Generate topics and tags for posts and articles.",
       "summary": "Multilingual on-device content topic tagging across a 36-topic taxonomy.",
       "category": "Content topic tagging",
       "lifecycle": "stable",
@@ -319,7 +319,7 @@
     {
       "id": "moderator",
       "name": "Moderator",
-      "tagline": "Flag nudity before upload.",
+      "tagline": "Flag nudity before upload or display.",
       "summary": "On-device NSFW image detection, trained only on licensed and synthetic data.",
       "category": "Content moderation",
       "lifecycle": "closed-beta",
@@ -354,7 +354,7 @@
     {
       "id": "redact",
       "name": "Redact",
-      "tagline": "Personal data, gone before it moves.",
+      "tagline": "Filter PII on the device.",
       "summary": "Multilingual on-device PII detection and redaction.",
       "category": "PII redaction",
       "lifecycle": "stable",
@@ -394,7 +394,7 @@
     {
       "id": "schemer",
       "name": "Schemer",
-      "tagline": "Typed JSON, no validation layer.",
+      "tagline": "Extract typed JSON from any text.",
       "summary": "On-device structured extraction into a caller-supplied JSON schema.",
       "category": "Structured extraction",
       "lifecycle": "closed-beta",
@@ -469,7 +469,7 @@
     {
       "id": "title",
       "name": "Title",
-      "tagline": "Titles and descriptions in a split second.",
+      "tagline": "Suggest a title and description for any text.",
       "summary": "On-device titles and descriptions: a short factual title and a one- to two-sentence description for any passage of text.",
       "category": "Titles and descriptions",
       "lifecycle": "stable",
@@ -505,7 +505,7 @@
     {
       "id": "tongue",
       "name": "Tongue",
-      "tagline": "Name the language from three words.",
+      "tagline": "Detect language based on 3 words.",
       "summary": "On-device language identification for short text across 84 languages.",
       "category": "Language identification",
       "lifecycle": "stable",
@@ -585,7 +585,7 @@
     {
       "id": "uhm",
       "name": "Uhm",
-      "tagline": "An hour of audio in 12 seconds.",
+      "tagline": "Find and remove every filler word.",
       "summary": "On-device filler-word detection: frame-precise \"uh\"/\"um\"/\"hmm\" spans.",
       "category": "Filler-word detection",
       "lifecycle": "stable",
@@ -627,7 +627,7 @@
     {
       "id": "voz",
       "name": "Voz",
-      "tagline": "Lightning-fast transcriptions, precisely timed.",
+      "tagline": "Transcribe 10 minutes in 2 seconds.",
       "summary": "On-device speech recognition: transcripts with word-level timestamps, 25 languages.",
       "category": "Speech recognition",
       "lifecycle": "stable",
@@ -710,7 +710,7 @@
     {
       "id": "who",
       "name": "Who",
-      "tagline": "An interview, ready to cut.",
+      "tagline": "Label who said what in audio and video.",
       "summary": "On-device speaker labeling: per-person turns with timestamps.",
       "category": "Speaker diarization",
       "lifecycle": "closed-beta",


### PR DESCRIPTION
Update 15 model taglines to their current headline wording; the per-model pages regenerate from the manifest (`mise run docs:render`). `clear`, `shapes`, and `toxic` already matched.

| model | before | after |
|---|---|---|
| align | Timestamps that land on the word. | **Accurate word timestamps for any transcript.** |
| clips | Video and audio highlights in seconds. | **Create short videos and highlight clips.** |
| ear | Name the language from thirty seconds of audio. | **Detect spoken language from 30 seconds audio.** |
| emo | Faster than you can type. | **Suggest emoji faster than you can type.** |
| eye | Forty shots. One keeper. | **Tag and rank images.** |
| face | People search, no server. | **Find people in photos, private on the device.** |
| gist | Know what any text is about. | **Generate topics and tags for posts and articles.** |
| moderator | Flag nudity before upload. | **Flag nudity before upload or display.** |
| redact | Personal data, gone before it moves. | **Filter PII on the device.** |
| schemer | Typed JSON, no validation layer. | **Extract typed JSON from any text.** |
| title | Titles and descriptions in a split second. | **Suggest a title and description for any text.** |
| tongue | Name the language from three words. | **Detect language based on 3 words.** |
| uhm | An hour of audio in 12 seconds. | **Find and remove every filler word.** |
| voz | Lightning-fast transcriptions, precisely timed. | **Transcribe 10 minutes in 2 seconds.** |
| who | An interview, ready to cut. | **Label who said what in audio and video.** |

## Verification
- `mise run check:manifest` — 18 models, 12 built here
- `mise run check:docs` — README.md and the model pages are current