### PR TITLE
Run Clear on Core AI if available

### DIFF
--- a/Sources/Clear/Catalog.swift
+++ b/Sources/Clear/Catalog.swift
@@ -1,5 +1,5 @@
 // This model's catalog declaration: coordinates, file names, and which of them
-// each platform ships. The shared behaviour (distribution, resolve, availability)
+// each platform ships. The shared behavior (distribution, resolve, availability)
 // comes from `ModelDeclaration` in the catalog's shared half.
 
 import DesertAnt
@@ -30,6 +30,9 @@ public enum ClearModel: ModelDeclaration {
     /// (`DSP.swift`/`Features.swift`) carries the constants that would otherwise
     /// be a metadata file, so a platform ships exactly one artifact.
     public static let files: [ModelPlatform: [String]] = variant.files
+    /// Core AI export: preferred on iOS 27 and macOS 27, with `files` as the fallback.
+    public static let coreAI = variant.coreAI
+    public static let runtimeFiles: [ModelRuntime: [String]] = variant.runtimeFiles
 
     public static func artifact(for platform: ModelPlatform) -> String {
         variant.artifact(for: platform)

--- a/Sources/Clear/Clear.swift
+++ b/Sources/Clear/Clear.swift
@@ -142,6 +142,10 @@ public final class Clear: @unchecked Sendable {
         /// when nothing was downloaded (a local `modelPath`, explicit assets,
         /// or a self-hosted wasm model).
         public let modelRevision: String?
+        /// Which runtime ran the model: Core AI on iOS 27 and macOS 27 when
+        /// the asset loaded, Core ML otherwise on Apple, LiteRT elsewhere. Nil
+        /// when a wasm host supplied the session.
+        public let modelRuntime: ModelRuntime?
         /// Per-stage breakdown of this pass. See ``Clear/PhaseTimings``.
         public var phaseTimings = PhaseTimings()
         public var realtimeFactor: Double { processingSec > 0 ? durationSec / processingSec : 0 }
@@ -298,6 +302,7 @@ public final class Clear: @unchecked Sendable {
             },
             directory: directory, cacheRoot: cacheRoot) { files, distribution in
             try await .clear(files: files, variant: variant, revision: distribution.revision,
+                             runtime: distribution.runtime(of: files),
                              computeUnits: computeUnits, concurrency: concurrency)
         }
     }
@@ -515,7 +520,7 @@ public final class Clear: @unchecked Sendable {
                       processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
                       measuredTruePeakDBFS: truePeak,
                       modelVariant: assets.variant, modelRevision: assets.revision,
-                      phaseTimings: phases)
+                      modelRuntime: assets.runtime, phaseTimings: phases)
     }
 
     /// Average the channels. Equal weights, which is the standard downmix and

--- a/Sources/Clear/ModelLoading.swift
+++ b/Sources/Clear/ModelLoading.swift
@@ -26,11 +26,16 @@ public struct ModelAssets: Sendable {
     /// `Result`. Nil for a local `modelPath`, explicit assets, or a wasm host
     /// (nothing was downloaded, so no revision applies).
     let revision: String?
+    /// Which runtime opened the artifact, reported on `Result`. Nil when only
+    /// the host knows (a wasm session).
+    let runtime: ModelRuntime?
 
-    init(sessions: [any InferenceSession], variant: ModelVariant? = nil, revision: String? = nil) {
+    init(sessions: [any InferenceSession], variant: ModelVariant? = nil, revision: String? = nil,
+         runtime: ModelRuntime? = nil) {
         self.sessions = sessions
         self.variant = variant
         self.revision = revision
+        self.runtime = runtime
     }
 
     /// Bindings entry point: build from an already-constructed session (e.g. the
@@ -50,20 +55,22 @@ public struct ModelAssets: Sendable {
                 try inferenceSession(modelPath: modelPath, computeUnits: computeUnits, sdk: ClearModel.sdkInfo)
             },
             variant: ModelVariant.inferred(fromPath: modelPath),
-            revision: revision)
+            revision: revision,
+            runtime: ModelRuntime.inferred(fromPath: modelPath))
     }
 
     /// Build from a resolved model directory: one session per worker over this
     /// platform's artifact.
     static func clear(files: StoredModel, variant: ModelVariant, revision: String? = nil,
+                      runtime: ModelRuntime = .platformDefault,
                       computeUnits: ComputeUnits, concurrency: Int) async throws -> ModelAssets {
         var sessions: [any InferenceSession] = []
         for _ in 0..<max(1, concurrency) {
             sessions.append(try await files.inferenceSession(
-                model: variant.artifact,
+                model: variant.artifact(for: runtime),
                 computeUnits: computeUnits, sdk: ClearModel.sdkInfo))
         }
-        return ModelAssets(sessions: sessions, variant: variant, revision: revision)
+        return ModelAssets(sessions: sessions, variant: variant, revision: revision, runtime: runtime)
     }
 }
 

--- a/Sources/Clear/Streaming.swift
+++ b/Sources/Clear/Streaming.swift
@@ -213,7 +213,8 @@ extension Clear {
                       durationSec: Double(totalFrames) / sampleRate,
                       processingSec: elapsedSeconds(since: start), measuredLUFS: measured,
                       measuredTruePeakDBFS: truePeakMeter?.dBFS,
-                      modelVariant: assets.variant, modelRevision: assets.revision)
+                      modelVariant: assets.variant, modelRevision: assets.revision,
+                      modelRuntime: assets.runtime)
     }
 }
 #endif

--- a/Sources/Clear/Variant.swift
+++ b/Sources/Clear/Variant.swift
@@ -32,14 +32,29 @@ public enum ModelVariant: String, Sendable, Equatable, CaseIterable, Identifiabl
     public var coreML: String { "\(rawValue).mlmodelc" }
     /// LiteRT export: Android/Linux/Windows, and LiteRT.js on the web.
     public var tflite: String { "\(rawValue).tflite" }
+    /// Core AI export (a directory on the Hub): iOS 27 and macOS 27.
+    public var coreAI: String { "\(rawValue).aimodel" }
 
     /// The runnable artifact for `platform`.
     public func artifact(for platform: ModelPlatform) -> String {
         platform == .apple ? coreML : tflite
     }
 
+    /// The runnable artifact for `runtime`.
+    public func artifact(for runtime: ModelRuntime) -> String {
+        switch runtime {
+        case .coreML: coreML
+        case .coreAI: coreAI
+        case .liteRT: tflite
+        }
+    }
+
+    /// Repo-relative entries for the Core AI runtime, preferred on iOS 27 and
+    /// macOS 27; `files` stands in below that or when the asset is absent.
+    public var runtimeFiles: [ModelRuntime: [String]] { [.coreAI: [coreAI + "/"]] }
+
     /// The artifact for the platform being built for.
-    public var artifact: String { artifact(for: .current) }
+    public var artifact: String { artifact(for: ModelPlatform.current) }
 
     /// Repo-relative entries each platform needs for this variant. Clear has no
     /// sidecars (the DSP front end carries what would be a metadata file), so a
@@ -63,7 +78,7 @@ public enum ModelVariant: String, Sendable, Equatable, CaseIterable, Identifiabl
     /// `v0.2.0`, a branch, or a commit hash) instead of the SDK's pinned one.
     /// Each revision caches separately, so switching never clobbers another.
     public func distribution(revision: String) -> ModelDistribution {
-        ModelDistribution(repo: ClearModel.repo, revision: revision, files: files)
+        ModelDistribution(repo: ClearModel.repo, revision: revision, files: files, runtimeFiles: runtimeFiles)
     }
 
     /// The variant an artifact path belongs to, by its file name

--- a/Sources/Inference/CoreAISession.swift
+++ b/Sources/Inference/CoreAISession.swift
@@ -1,0 +1,180 @@
+#if canImport(CoreAI)
+import Accelerate
+import CoreAI
+import Foundation
+
+/// Core AI inference backend (iOS 27, macOS 27): a `.aimodel` asset behind the shared ``InferenceSession`` API.
+@available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, watchOS 27.0, *)
+final class CoreAISession: InferenceSession, @unchecked Sendable {
+    private let function: InferenceFunction
+    private let descriptor: InferenceFunctionDescriptor
+    private let lock = NSLock()
+    private var arrays: [String: NDArray] = [:]
+
+    init(modelPath: String, computeUnits: ComputeUnits = .all) throws {
+        let url = URL(fileURLWithPath: modelPath)
+        let options = CoreAISession.options(for: computeUnits)
+        // Specialization is async-only; the session factory is synchronous.
+        let model = try CoreAISession.blocking { try await AIModel(contentsOf: url, options: options) }
+        guard let name = model.functionNames.first,
+              let function = try model.loadFunction(named: name),
+              let descriptor = model.functionDescriptor(for: name) else {
+            throw InferenceError.sessionUnavailable("'\(modelPath)' exposes no inference function")
+        }
+        self.function = function
+        self.descriptor = descriptor
+    }
+
+    static func options(for units: ComputeUnits) -> SpecializationOptions {
+        switch units {
+        case .all: return .default
+        case .cpuAndNeuralEngine: return SpecializationOptions(preferredComputeUnitKind: .neuralEngine)
+        case .cpuOnly: return .cpuOnly
+        }
+    }
+
+    func inputWidth(_ name: String) -> Int? {
+        guard case .ndArray(let array)? = descriptor.inputDescriptor(of: name),
+              let last = array.shape.last, last > 0 else { return nil }
+        return last
+    }
+
+    func run(inputs: [String: Tensor], outputs: [String], deviceId: String?) async throws -> [Tensor] {
+        var produced = try await function.run(inputs: try bind(inputs))
+        return try outputs.map { name in
+            guard let value = produced.remove(name), let array = value.ndArray else {
+                throw InferenceError.runFailed("the model returned no '\(name)'")
+            }
+            return try tensor(from: array)
+        }
+    }
+
+    /// Reuses the input arrays: the runtime binds a buffer on first use, and a fresh one per call costs more than the model.
+    private func bind(_ inputs: [String: Tensor]) throws -> [String: NDArray] {
+        lock.lock(); defer { lock.unlock() }
+        for (name, tensor) in inputs {
+            guard case .ndArray(let declared)? = descriptor.inputDescriptor(of: name) else {
+                throw InferenceError.invalidTensor("the model has no tensor input '\(name)'")
+            }
+            if arrays[name]?.shape != tensor.shape {
+                arrays[name] = NDArray(shape: tensor.shape, scalarType: declared.scalarType)
+            }
+            try write(tensor, into: &arrays[name]!, scalarType: declared.scalarType)
+        }
+        return arrays
+    }
+
+    private func write(_ tensor: Tensor, into array: inout NDArray, scalarType: NDArray.ScalarType) throws {
+        switch (tensor.element, scalarType) {
+        case (.float32, .float16):
+            array.mutableRawView().withUnsafeMutableBytes { dst, shape, strides in
+                let rowLength = shape[shape.count - 1]
+                tensor.bytes.withUnsafeBytes { raw in
+                    let src = raw.baseAddress!.assumingMemoryBound(to: Float.self)
+                    forEachRow(shape: shape, strides: strides) { row, offset in
+                        var s = vImage_Buffer(data: .init(mutating: src + row * rowLength), height: 1,
+                                              width: vImagePixelCount(rowLength), rowBytes: rowLength * 4)
+                        var d = vImage_Buffer(data: dst + offset * 2, height: 1,
+                                              width: vImagePixelCount(rowLength), rowBytes: rowLength * 2)
+                        vImageConvert_PlanarFtoPlanar16F(&s, &d, 0)
+                    }
+                }
+            }
+        case (.float32, .float32), (.int32, .int32):
+            array.mutableRawView().withUnsafeMutableBytes { dst, shape, strides in
+                let rowLength = shape[shape.count - 1]
+                tensor.bytes.withUnsafeBytes { raw in
+                    forEachRow(shape: shape, strides: strides) { row, offset in
+                        (dst + offset * 4).copyMemory(from: raw.baseAddress! + row * rowLength * 4,
+                                                      byteCount: rowLength * 4)
+                    }
+                }
+            }
+        default:
+            throw InferenceError.invalidTensor(
+                "the model wants \(scalarType) where the caller passed \(tensor.element.rawValue)")
+        }
+    }
+
+    /// Visits every innermost row in row-major order with its element offset under `strides`.
+    private func forEachRow(shape: Span<Int>, strides: Span<Int>, _ body: (Int, Int) -> Void) {
+        let dims = Array(0..<shape.count).map { shape[$0] }
+        let steps = Array(0..<strides.count).map { strides[$0] }
+        guard let rowLength = dims.last, rowLength > 0 else { return }
+        let rows = dims.reduce(1, *) / rowLength
+        var index = [Int](repeating: 0, count: dims.count - 1)
+        for row in 0..<rows {
+            var offset = 0
+            for d in 0..<index.count { offset += index[d] * steps[d] }
+            body(row, offset)
+            var d = index.count - 1
+            while d >= 0 {
+                index[d] += 1
+                if index[d] < dims[d] { break }
+                index[d] = 0
+                d -= 1
+            }
+        }
+    }
+
+    private func tensor(from array: NDArray) throws -> Tensor {
+        let shape = array.shape
+        switch array.scalarType {
+        case .float16:
+            let halves: [Float16] = array.view(as: Float16.self).withUnsafePointer { base, shape, strides in
+                gather(base, shape: shape, strides: strides)
+            }
+            var floats = [Float](repeating: 0, count: halves.count)
+            halves.withUnsafeBytes { src in
+                floats.withUnsafeMutableBytes { dst in
+                    var s = vImage_Buffer(data: .init(mutating: src.baseAddress!), height: 1,
+                                          width: vImagePixelCount(halves.count), rowBytes: halves.count * 2)
+                    var d = vImage_Buffer(data: dst.baseAddress!, height: 1,
+                                          width: vImagePixelCount(halves.count), rowBytes: halves.count * 4)
+                    vImageConvert_Planar16FtoPlanarF(&s, &d, 0)
+                }
+            }
+            return Tensor(float32: floats, shape: shape)
+        case .float32:
+            let floats: [Float] = array.view(as: Float.self).withUnsafePointer { base, shape, strides in
+                gather(base, shape: shape, strides: strides)
+            }
+            return Tensor(float32: floats, shape: shape)
+        case .int32:
+            let ints: [Int32] = array.view(as: Int32.self).withUnsafePointer { base, shape, strides in
+                gather(base, shape: shape, strides: strides)
+            }
+            return Tensor(int32: ints, shape: shape)
+        default:
+            throw InferenceError.runFailed("unsupported output scalar type \(array.scalarType)")
+        }
+    }
+
+    /// Row-major copy that honors the runtime's strides, which pad the innermost row on the ANE.
+    private func gather<T>(_ base: UnsafePointer<T>, shape: Span<Int>, strides: Span<Int>) -> [T] {
+        let count = Array(0..<shape.count).map { shape[$0] }.reduce(1, *)
+        let rowLength = shape.count > 0 ? shape[shape.count - 1] : 0
+        return [T](unsafeUninitializedCapacity: count) { buffer, filled in
+            forEachRow(shape: shape, strides: strides) { row, offset in
+                (buffer.baseAddress! + row * rowLength).update(from: base + offset, count: rowLength)
+            }
+            filled = count
+        }
+    }
+
+    private static func blocking<T: Sendable>(_ body: @escaping @Sendable () async throws -> T) throws -> T {
+        let done = DispatchSemaphore(value: 0)
+        let box = ResultBox<T>()
+        Task.detached(priority: .userInitiated) {
+            do { box.result = .success(try await body()) } catch { box.result = .failure(error) }
+            done.signal()
+        }
+        done.wait()
+        return try box.result!.get()
+    }
+
+    private final class ResultBox<T>: @unchecked Sendable {
+        var result: Result<T, Error>?
+    }
+}
+#endif

--- a/Sources/Inference/SessionFactory.swift
+++ b/Sources/Inference/SessionFactory.swift
@@ -15,6 +15,14 @@ public func inferenceSession(modelPath: String, computeUnits: ComputeUnits = .al
                              functionName: String? = nil,
                              sdk: SDKInfo = SDKInfo()) throws -> any InferenceSession {
     #if canImport(CoreML)
+    if modelPath.hasSuffix(".aimodel") {
+        #if canImport(CoreAI)
+        if #available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            return tracked(try CoreAISession(modelPath: modelPath, computeUnits: computeUnits), sdk: sdk)
+        }
+        #endif
+        throw InferenceError.sessionUnavailable("Core AI assets need iOS 27 / macOS 27")
+    }
     return tracked(try CoreMLSession(modelPath: modelPath, computeUnits: computeUnits,
                                      functionName: functionName), sdk: sdk)
     #elseif canImport(CLiteRt)

--- a/Sources/ModelCatalog/LoadedModel.swift
+++ b/Sources/ModelCatalog/LoadedModel.swift
@@ -27,6 +27,7 @@
 //         }
 //     }
 
+import Foundation
 import ModelStore
 import PlatformSupport
 
@@ -98,10 +99,8 @@ public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
         // fraction (halved), [0.5, 1] is preparing/build. `download` and `load`
         // decode it back, so the Double API keeps its old meaning.
         loader = LazyLoader { progress in
-            let files = try await distribution.resolve(
-                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction * 0.5) }
-            progress(0.5)
-            return try await build(files)
+            try await Self.load(distribution, directory: directory, cacheRoot: cacheRoot,
+                                progress: progress) { files, _ in try await build(files) }
         }
         availability = { distribution.isAvailable(cacheDirectory: directory, cacheRoot: cacheRoot) }
     }
@@ -119,13 +118,40 @@ public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
         build: @escaping @Sendable (StoredModel, ModelDistribution) async throws -> Runtime
     ) {
         loader = LazyLoader { progress in
-            let distribution = try await resolve()
-            let files = try await distribution.resolve(
-                cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction * 0.5) }
-            progress(0.5)
-            return try await build(files, distribution)
+            try await Self.load(try await resolve(), directory: directory, cacheRoot: cacheRoot,
+                                progress: progress, build: build)
         }
         availability = isAvailable
+    }
+
+    /// Resolve and build, on the platform default runtime when the alternate one is not on the
+    /// Hub at this revision, not in `directory`, or fails to load. A failure is remembered for
+    /// the process, so the next load goes straight to the default.
+    private static func load(
+        _ distribution: ModelDistribution, directory: String?, cacheRoot: String?,
+        progress: @Sendable @escaping (Double) -> Void,
+        build: @Sendable (StoredModel, ModelDistribution) async throws -> Runtime
+    ) async throws -> Runtime {
+        var chosen = distribution
+        if distribution.hasFallback {
+            if RuntimeFallbacks.shared.failed(distribution, directory: directory) {
+                chosen = distribution.platformDefault
+            } else {
+                do {
+                    let files = try await distribution.resolve(
+                        cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction * 0.5) }
+                    progress(0.5)
+                    return try await build(files, distribution)
+                } catch {
+                    RuntimeFallbacks.shared.record(distribution, directory: directory)
+                    chosen = distribution.platformDefault
+                }
+            }
+        }
+        let files = try await chosen.resolve(
+            cacheDirectory: directory, cacheRoot: cacheRoot) { progress($0.fraction * 0.5) }
+        progress(0.5)
+        return try await build(files, chosen)
     }
 
     /// Wrap a runtime the caller already has the inputs for (the cross-language
@@ -162,4 +188,23 @@ public final class LoadedModel<Runtime: Sendable>: @unchecked Sendable {
 
     /// The runtime, loading it on first use.
     public func value() async throws -> Runtime { try await loader.value() }
+}
+
+/// Alternate-runtime loads that failed in this process, keyed by repo, revision, and directory.
+private final class RuntimeFallbacks: @unchecked Sendable {
+    static let shared = RuntimeFallbacks()
+    private let lock = NSLock()
+    private var keys: Set<String> = []
+
+    private func key(_ distribution: ModelDistribution, directory: String?) -> String {
+        "\(distribution.repo)@\(distribution.revision)@\(directory ?? "")"
+    }
+
+    func failed(_ distribution: ModelDistribution, directory: String?) -> Bool {
+        lock.withLock { keys.contains(key(distribution, directory: directory)) }
+    }
+
+    func record(_ distribution: ModelDistribution, directory: String?) {
+        lock.withLock { _ = keys.insert(key(distribution, directory: directory)) }
+    }
 }

--- a/Sources/ModelCatalog/ModelDeclaration.swift
+++ b/Sources/ModelCatalog/ModelDeclaration.swift
@@ -32,13 +32,16 @@ public protocol ModelDeclaration: Sendable {
     /// Repo-relative entries each platform needs. Directory artifacts (e.g. a
     /// Core ML `.mlmodelc`) end in `/`. A platform absent here is unsupported.
     static var files: [ModelPlatform: [String]] { get }
+    /// Repo-relative entries for a runtime other than the platform default (Core
+    /// AI on Apple). Empty for a model that ships one artifact per platform.
+    static var runtimeFiles: [ModelRuntime: [String]] { get }
 
     /// The oldest OS this model's ARTIFACT runs on. Defaults to the package floor, so a model
-    /// whose artifact imposes nothing extra says nothing. Override when the artifact does —
+    /// whose artifact imposes nothing extra says nothing. Override when the artifact does,
     /// and `ModelCatalogTests` checks the value against the compiled package rather than
     /// trusting it.
     static var osFloor: OSFloor { get }
-    /// The runnable artifact for `platform` — the file the inference session is
+    /// The runnable artifact for `platform`: the file the inference session is
     /// built from, as opposed to the sidecars around it.
     static func artifact(for platform: ModelPlatform) -> String
 }
@@ -50,6 +53,8 @@ public extension ModelDeclaration {
 
     static var osFloor: OSFloor { .packageFloor }
 
+    static var runtimeFiles: [ModelRuntime: [String]] { [:] }
+
     /// This SDK's usage identity, attached to every emitted telemetry body's
     /// `sdk` field so usage attributes to this model rather than to the core it
     /// is built on. Derived, so a model cannot forget to pass one (which silently
@@ -59,11 +64,11 @@ public extension ModelDeclaration {
     /// This model's Hub declaration: repo, pinned revision, per-platform files.
     /// The single value an SDK needs to download, adopt, or verify its model.
     static var distribution: ModelDistribution {
-        ModelDistribution(repo: repo, revision: revision, files: files)
+        ModelDistribution(repo: repo, revision: revision, files: files, runtimeFiles: runtimeFiles)
     }
 
     /// The runnable artifact on the platform being built for.
-    static var artifact: String { artifact(for: .current) }
+    static var artifact: String { artifact(for: ModelPlatform.current) }
 
     /// Whether this model ships anything for `platform`.
     static func supports(_ platform: ModelPlatform) -> Bool { files[platform] != nil }
@@ -86,7 +91,7 @@ public extension ModelDeclaration {
 
 /// The oldest OS each Apple platform needs to run a model's artifact.
 ///
-/// Data, not a comment. A model's OS requirement comes from the artifact it ships — a Core ML
+/// Data, not a comment. A model's OS requirement comes from the artifact it ships: a Core ML
 /// package records `specificationVersion` and an availability map, and refusing to load below
 /// it is the runtime's behaviour whatever the SDK claims. Declaring it here means the catalog
 /// can be checked against the artifact instead of against somebody's memory.
@@ -95,7 +100,7 @@ public extension ModelDeclaration {
 /// cannot be computed from a value, so a model that must not COMPILE below some version still
 /// annotates its own declarations. What this gives is the other three things:
 /// a runtime refusal with a legible reason, a catalog test that every model states a floor,
-/// and one place to read when writing the README — instead of three that drift apart, which is
+/// and one place to read when writing the README, instead of three that drift apart, which is
 /// how the manifest came to declare iOS 16 while the README promised iOS 18.
 public struct OSFloor: Sendable, Equatable {
     public let iOS: Int

--- a/Sources/ModelStore/ModelDistribution.swift
+++ b/Sources/ModelStore/ModelDistribution.swift
@@ -21,26 +21,76 @@ public enum ModelPlatform: String, Sendable, Hashable, CaseIterable {
     }
 }
 
+/// Which inference runtime opens a model's artifact.
+public enum ModelRuntime: String, Sendable, Hashable, CaseIterable {
+    case coreML = "coreml"
+    case coreAI = "coreai"
+    case liteRT = "litert"
+
+    /// What this platform's `files` list is for: Core ML on Apple, LiteRT elsewhere.
+    public static var platformDefault: ModelRuntime {
+        ModelPlatform.current == .apple ? .coreML : .liteRT
+    }
+
+    /// The runtime this device should run: Core AI where the OS ships it, else the platform default.
+    public static var current: ModelRuntime {
+        #if canImport(CoreAI)
+        if #available(macOS 27.0, iOS 27.0, tvOS 27.0, visionOS 27.0, watchOS 27.0, *) { return .coreAI }
+        #endif
+        return platformDefault
+    }
+
+    /// The runtime an artifact path is for, by its extension, or nil for an unknown one.
+    public static func inferred(fromPath path: String) -> ModelRuntime? {
+        let name = path.split(separator: "/").last.map(String.init) ?? path
+        if name.hasSuffix(".aimodel") { return .coreAI }
+        if name.hasSuffix(".mlmodelc") || name.hasSuffix(".mlpackage") { return .coreML }
+        if name.hasSuffix(".tflite") { return .liteRT }
+        return nil
+    }
+}
+
 /// A model's Hub declaration: the complete file list for each platform.
 ///
 /// Each platform owns its own list, so artifacts and sidecars may differ
 /// entirely. Core selects the current platform's list and handles download,
 /// verification, caching, and local-directory validation. Turning a resolved
 /// `StoredModel` into runtime assets is the model package's concern.
+///
+/// `runtimeFiles` lists a platform's alternate runtime, Core AI on Apple. It is
+/// preferred where ``ModelRuntime/current`` names it, and `files` stands in when
+/// it is missing or fails to load.
 public struct ModelDistribution: Sendable, Equatable {
     public let repo: String
     public let revision: String
     /// Repo entries per platform. Directory entries end in `/`.
     public let files: [ModelPlatform: [String]]
+    /// Repo entries for a runtime other than the platform's default.
+    public let runtimeFiles: [ModelRuntime: [String]]
 
-    public init(repo: String, revision: String, files: [ModelPlatform: [String]]) {
+    public init(repo: String, revision: String, files: [ModelPlatform: [String]],
+                runtimeFiles: [ModelRuntime: [String]] = [:]) {
         self.repo = repo
         self.revision = revision
         self.files = files
+        self.runtimeFiles = runtimeFiles
+    }
+
+    /// The runtime this device opens: the current one when this model ships files for it.
+    public var currentRuntime: ModelRuntime {
+        runtimeFiles[.current] != nil ? .current : .platformDefault
     }
 
     /// The current platform's file list, or `nil` if unsupported.
-    public var currentFiles: [String]? { files[.current] }
+    public var currentFiles: [String]? { runtimeFiles[.current] ?? files[.current] }
+
+    /// Whether the current runtime is an alternate the platform default can stand in for.
+    public var hasFallback: Bool { currentRuntime != .platformDefault && files[.current] != nil }
+
+    /// The same slice of the repo on the platform's default runtime.
+    public var platformDefault: ModelDistribution {
+        ModelDistribution(repo: repo, revision: revision, files: files)
+    }
 
     /// Download and verify the current platform's file list, returning the
     /// cached model directory. A no-op (no network) once cached.
@@ -90,11 +140,11 @@ public struct ModelDistribution: Sendable, Equatable {
     /// order). `exact` never touches the network.
     public func resolving(_ requirement: RevisionRequirement, cacheRoot: String? = nil) async -> ModelDistribution {
         if let revision = requirement.exactRevision {
-            return ModelDistribution(repo: repo, revision: revision, files: files)
+            return ModelDistribution(repo: repo, revision: revision, files: files, runtimeFiles: runtimeFiles)
         }
         guard let store = try? ModelStore.platformDefault(cacheRoot: cacheRoot) else { return self }
         let revision = await store.resolveRevision(requirement, repo: repo)
-        return ModelDistribution(repo: repo, revision: revision, files: files)
+        return ModelDistribution(repo: repo, revision: revision, files: files, runtimeFiles: runtimeFiles)
     }
 
     /// The downloaded revisions of this repo satisfying `requirement` (offline;
@@ -116,13 +166,32 @@ public struct ModelDistribution: Sendable, Equatable {
         progress: @Sendable @escaping (DownloadProgress) -> Void = { _ in }
     ) async throws -> StoredModel {
         if let placed = userPlacedFiles(cacheDirectory) { return placed }
-        return try await install(cacheDirectory: cacheDirectory, cacheRoot: cacheRoot, progress: progress)
+        guard hasFallback else {
+            return try await install(cacheDirectory: cacheDirectory, cacheRoot: cacheRoot, progress: progress)
+        }
+        // The alternate runtime's files are preferred, and the platform default's stand in when
+        // they are not in `cacheDirectory` or not in the repo at this revision.
+        if let placed = platformDefault.userPlacedFiles(cacheDirectory) { return placed }
+        do {
+            return try await install(cacheDirectory: cacheDirectory, cacheRoot: cacheRoot, progress: progress)
+        } catch {
+            return try await platformDefault.install(cacheDirectory: cacheDirectory, cacheRoot: cacheRoot,
+                                                     progress: progress)
+        }
+    }
+
+    /// The runtime `files` (from ``resolve``) will open: the alternate when its entries are all
+    /// there, else the platform default.
+    public func runtime(of files: StoredModel) -> ModelRuntime {
+        guard hasFallback, let alternate = runtimeFiles[.current] else { return currentRuntime }
+        return (try? files.requireFiles(alternate)) != nil ? .current : .platformDefault
     }
 
     /// Whether the model is available offline for `cacheDirectory`: files you
     /// placed there, or our verified cache. An interrupted download is not.
     public func isAvailable(cacheDirectory: String? = nil, cacheRoot: String? = nil) -> Bool {
         userPlacedFiles(cacheDirectory) != nil || isInstalled(cacheDirectory: cacheDirectory, cacheRoot: cacheRoot)
+            || (hasFallback && platformDefault.isAvailable(cacheDirectory: cacheDirectory, cacheRoot: cacheRoot))
     }
 
     /// Files present in `cacheDirectory` that you provided (no in-progress

--- a/Tests/ClearTests/ClearRuntimeTests.swift
+++ b/Tests/ClearTests/ClearRuntimeTests.swift
@@ -1,0 +1,85 @@
+// Which runtime opens the model, and what happens when the preferred one cannot.
+import Foundation
+import Testing
+import TestSupport
+@testable import Clear
+import DesertAnt
+
+#if !os(WASI)
+@Suite(.serialized, .modelBacked) struct ClearRuntimeTests {
+    @Test func theVariantDeclaresACoreAIArtifactBesideCoreML() {
+        let studio = ModelVariant.clearStudio
+        #expect(studio.coreAI == "clear-studio.aimodel")
+        #expect(studio.artifact(for: .coreAI) == "clear-studio.aimodel")
+        #expect(studio.artifact(for: .coreML) == studio.coreML)
+        #expect(studio.runtimeFiles == [.coreAI: ["clear-studio.aimodel/"]])
+        #expect(ClearModel.runtimeFiles == studio.runtimeFiles)
+        #expect(ClearModel.distribution.runtimeFiles == studio.runtimeFiles)
+        // The platform list is untouched, so nothing below iOS 27 changes.
+        #expect(ClearModel.files[.apple] == [studio.coreML + "/"])
+    }
+
+    /// A Core AI asset that will not load must not fail the enhance: the Core ML
+    /// artifact beside it takes over, and the result says which one ran.
+    @Test func fallsBackToCoreMLWhenTheCoreAIAssetCannotLoad() async throws {
+        let directory = try await populated()
+        let broken = directory.appendingPathComponent(ClearModel.coreAI)
+        try FileManager.default.createDirectory(at: broken, withIntermediateDirectories: true)
+        try Data("not an asset".utf8).write(to: broken.appendingPathComponent("main.mlirb"))
+
+        let clear = Clear(directory: directory.path)
+        #expect(clear.isDownloaded())
+        let result = try await clear.enhance(samples: noisyTone(), sampleRate: 48_000)
+        #expect(result.modelRuntime == ModelRuntime.platformDefault)
+        #expect(result.modelVariant == .clearStudio)
+    }
+
+    /// With the real asset in place, iOS 27 and macOS 27 run Core AI, and its
+    /// output agrees with Core ML's on the same audio. Needs a local asset:
+    /// `DAL_CLEAR_COREAI_ASSET=/path/to/clear-studio.aimodel`.
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["DAL_CLEAR_COREAI_ASSET"] != nil))
+    func runsCoreAIWhereTheOSHasIt() async throws {
+        let asset = ProcessInfo.processInfo.environment["DAL_CLEAR_COREAI_ASSET"]!
+        let directory = try await populated()
+        try FileManager.default.copyItem(
+            atPath: asset, toPath: directory.appendingPathComponent(ClearModel.coreAI).path)
+
+        let input = noisyTone()
+        let result = try await Clear(directory: directory.path).enhance(samples: input, sampleRate: 48_000)
+        #expect(result.modelRuntime == ModelRuntime.current)
+        guard result.modelRuntime == .coreAI else { return }
+
+        let files = try await ModelFixture.files(ClearModel.self)
+        let coreML = try Clear(modelPath: files.path(ClearModel.artifact))
+        let reference = try await coreML.enhance(samples: input, sampleRate: 48_000)
+        #expect(reference.modelRuntime == .coreML)
+        let snr = snrDB(reference: reference.samples, actual: result.samples)
+        #expect(snr > 20, "Core AI output is \(snr) dB from Core ML's")
+    }
+
+    private func populated() async throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clear-runtime-\(UUID().uuidString)")
+        try await ModelFixture.populate(ClearModel.self, into: directory)
+        return directory
+    }
+
+    private func noisyTone(seconds: Double = 3) -> [Float] {
+        var state: UInt32 = 12345
+        return (0..<Int(48_000 * seconds)).map { i in
+            state = state &* 1_664_525 &+ 1_013_904_223
+            let noise = Float(state >> 8) / Float(1 << 24) - 0.5
+            return 0.3 * sin(2 * .pi * 220 * Float(i) / 48_000) + 0.05 * noise
+        }
+    }
+
+    private func snrDB(reference: [Float], actual: [Float]) -> Double {
+        var signal = 0.0, noise = 0.0
+        for (r, a) in zip(reference, actual) {
+            signal += Double(r) * Double(r)
+            noise += Double(r - a) * Double(r - a)
+        }
+        return noise == 0 ? .infinity : 10 * log10(signal / noise)
+    }
+}
+#endif

--- a/Tests/ClearTests/ClearTests.swift
+++ b/Tests/ClearTests/ClearTests.swift
@@ -130,13 +130,13 @@ struct ClearTests {
     @Test func resultSamplesIsTheFirstChannel() {
         let stereo = Clear.Result(channels: [[1, 2], [3, 4]], sampleRate: 48_000,
                                   durationSec: 0, processingSec: 0, measuredLUFS: nil,
-                                  measuredTruePeakDBFS: nil, modelVariant: nil, modelRevision: nil)
+                                  measuredTruePeakDBFS: nil, modelVariant: nil, modelRevision: nil, modelRuntime: nil)
         #expect(stereo.channelCount == 2)
         #expect(stereo.samples == [1, 2])
 
         let empty = Clear.Result(channels: [], sampleRate: 48_000,
                                  durationSec: 0, processingSec: 0, measuredLUFS: nil,
-                                 measuredTruePeakDBFS: nil, modelVariant: nil, modelRevision: nil)
+                                 measuredTruePeakDBFS: nil, modelVariant: nil, modelRevision: nil, modelRuntime: nil)
         #expect(empty.samples == [])
         #expect(empty.channelCount == 0)
     }

--- a/Tests/ModelStoreTests/ModelRuntimeTests.swift
+++ b/Tests/ModelStoreTests/ModelRuntimeTests.swift
@@ -1,0 +1,40 @@
+#if !os(WASI)
+import Testing
+@testable import ModelStore
+
+struct ModelRuntimeTests {
+    @Test func aDistributionWithoutAlternateFilesRunsThePlatformDefault() {
+        let d = ModelDistribution(repo: "r", revision: "v1", files: [.current: ["m.mlmodelc/"]])
+        #expect(d.currentRuntime == .platformDefault)
+        #expect(d.currentFiles == ["m.mlmodelc/"])
+        #expect(!d.hasFallback)
+        #expect(d.platformDefault == d)
+    }
+
+    @Test func alternateFilesArePreferredOnlyWhereTheRuntimeIsCurrent() async {
+        let d = ModelDistribution(repo: "r", revision: "v1", files: [.current: ["m.mlmodelc/"]],
+                                  runtimeFiles: [.coreAI: ["m.aimodel/"]])
+        if ModelRuntime.current == .coreAI {
+            #expect(d.currentRuntime == .coreAI)
+            #expect(d.currentFiles == ["m.aimodel/"])
+            #expect(d.hasFallback)
+            #expect(d.platformDefault.currentFiles == ["m.mlmodelc/"])
+            #expect(!d.platformDefault.hasFallback)
+        } else {
+            #expect(d.currentRuntime == .platformDefault)
+            #expect(d.currentFiles == ["m.mlmodelc/"])
+            #expect(!d.hasFallback)
+        }
+        let pinned = await d.resolving(.exact("v2"))
+        #expect(pinned.revision == "v2")
+        #expect(pinned.runtimeFiles == d.runtimeFiles)
+    }
+
+    @Test func theRuntimeFollowsTheArtifactExtension() {
+        #expect(ModelRuntime.inferred(fromPath: "/cache/clear-studio.aimodel") == .coreAI)
+        #expect(ModelRuntime.inferred(fromPath: "clear-studio.mlmodelc") == .coreML)
+        #expect(ModelRuntime.inferred(fromPath: "clear-studio.tflite") == .liteRT)
+        #expect(ModelRuntime.inferred(fromPath: "weights.bin") == nil)
+    }
+}
+#endif

--- a/manifest.json
+++ b/manifest.json
@@ -66,13 +66,14 @@
         "revision": "v0.3.0",
         "license": "desert-ant-labs-source-available-1.0"
       },
-      "runtime": ["coreml", "litert"],
+      "runtime": ["coreml", "coreai", "litert"],
       "variants": [
         { "id": "clear-studio", "default": true, "note": "Aggressive denoise and dereverb." },
         { "id": "clear-natural", "default": false, "note": "Lighter touch, keeps more of the room." }
       ],
       "hub": {
-        "tags": ["audio", "speech", "speech-enhancement", "speech-denoising", "noise-suppression", "dereverberation", "podcast", "on-device", "core-ml", "onnx", "ios", "android", "deepfilternet"],
+        "tags": ["audio", "speech", "speech-enhancement", "speech-denoising", "noise-suppression", "dereverberation", "podcast", "on-device", "core-ml",
+        "core-ai", "onnx", "ios", "android", "deepfilternet"],
         "pipelineTag": "audio-to-audio",
         "libraryName": null
       },

--- a/mise-tasks/check/manifest
+++ b/mise-tasks/check/manifest
@@ -29,7 +29,7 @@ const VISIBILITY = ["public", "internal"];
 const STATUS = ["live", "planned", "none"];
 const PLATFORMS = ["apple", "android", "linux", "windows", "web", "node"];
 const SOURCE = ["hub", "bundled", "none"];
-const RUNTIME = ["coreml", "litert", "mlx", "pure"];
+const RUNTIME = ["coreml", "coreai", "litert", "mlx", "pure"];
 const BASIS = ["derived", "declared", "inherited"];
 
 eq("manifest.json", manifest.schemaVersion, 1, "schemaVersion");


### PR DESCRIPTION
Core AI is Apple's inference framework on iOS 27 and macOS 27. This adds it as a backend beside Core ML. On those systems Clear loads the Core AI build of its model. Older systems keep the Core ML build.

## What changes for a caller

Nothing. `Clear()` picks the runtime for the device, the same way it already picks the artifact for the platform. `Result.modelRuntime` reports which runtime ran, for callers that log or benchmark.

## How the choice is made

A model declares its Core AI files alongside its per-platform ones:

```swift
public var runtimeFiles: [ModelRuntime: [String]] { [.coreAI: ["clear-studio.aimodel/"]] }
```

`ModelRuntime.current` names Core AI on iOS 27 and macOS 27 and the platform default below that. The device downloads one artifact, not both.

Core ML stands in when Core AI cannot be used. That happens in two places. At resolve time, when the asset is absent from the model directory or from the repo at the pinned revision. At load time, when the asset resolved but its session would not build. A load that falls back is remembered for the process, so the next one goes straight to Core ML.

## The session

`CoreAISession` sits behind the existing `InferenceSession` protocol. Inputs are converted to the model's declared precision with vImage, matching `CoreMLSession`. Outputs honor the runtime's strides, which pad the innermost row on the Neural Engine.

Input arrays are allocated once per shape and rewritten in place. The runtime binds a buffer on first use, and allocating a fresh one per call cost three times the model time on an iPhone 17 Pro.

Compute units map onto Core AI's specialization options. `.all` is the default and `.cpuOnly` is CPU only. `.cpuAndNeuralEngine` expresses a Neural Engine preference rather than an exclusion, because the allow-list initializer is not public.

## Measurements

Clear's enhance path on a five minute clip, iPhone 17 Pro, iOS 27.0, release build. The same five arms ran in four different orders, because arms run in sequence and position moves the result by as much as 20%.

| Runtime | Weights | Realtime, median of four orders |
|---|---|---:|
| Core AI | fp16 | 413x |
| Core ML | 6-bit palettized | 366x |
| Core ML | fp16 | 354x |

Accuracy against an fp32 reference rendered on the same device: 46.6 dB for the fp16 arms, 30.7 dB for the palettized one. The three fp16 arms agree to the decimal, which puts that figure on the device's fp16 arithmetic and not on either runtime.

First load on the Neural Engine costs 3.1s for Core ML and 8.4s for Core AI, once per install. Every load after that is under 40ms.

## When to merge this

The Core AI assets are published on the Hub at `v0.4.0`, and the SDK pins `v0.3.0`. Until the pin moves, an iOS 27 device looks for the Core AI files at v0.3.0, does not find them, and falls back to Core ML. Correct, but it costs one wasted lookup per cold load.

The pin should move once the Core AI toolchain leaves beta. Its asset format has changed between beta releases, so the published assets will be rebuilt against the released toolchain first.

## Tests

`ModelRuntimeTests` covers the selection and the file lists. `ClearRuntimeTests` covers the declaration, the fallback against a deliberately broken asset, and a Core AI run scored against Core ML on the same audio when a local asset is supplied through `DAL_CLEAR_COREAI_ASSET`. The existing Clear suites pass unchanged.
