### PR TITLE
fix: coalesce concurrent downloads of the same model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,17 @@ jobs:
           key: ios-deriveddata-v2-${{ runner.os }}-${{ github.sha }}
           restore-keys: ios-deriveddata-v2-${{ runner.os }}-
 
-      # No restore-keys here on purpose: test:ios resolves with
-      # -skipPackageUpdates, which trusts whatever state this dir holds. A
-      # stale fallback from an older dependency graph can pin revisions the
-      # cached clones no longer contain ("unable to read tree"), so a graph
-      # change must start from an empty dir and re-clone.
+      # Package.resolved is gitignored, so it cannot key this (hashFiles skips
+      # a missing file and the key silently collapses to Package.swift). test:ios
+      # now resolves without -skipPackageUpdates, so a reused clone dir is
+      # patched to the current graph rather than trusted whole; restore-keys
+      # hand over the previous clone and xcodebuild fetches whatever drifted.
       - name: Cache iOS SPM clones
         uses: actions/cache@v6
         with:
           path: .build/ios-packages
-          key: ios-packages-v2-${{ runner.os }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          key: ios-packages-v3-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ios-packages-v3-${{ runner.os }}-
 
       # build:swift and test:swift build into these scratch paths. Cold, they
       # rebuild every dependency (including swift-syntax via Title's MLX trait

--- a/Sources/ModelStore/DownloadCoordinator.swift
+++ b/Sources/ModelStore/DownloadCoordinator.swift
@@ -1,0 +1,37 @@
+// Coalesces concurrent downloads of the same model into one.
+//
+// `ModelStore` is a value type, recreated per call, so it cannot itself hold
+// "a download is already running for this location". Two callers racing the
+// same model (two test suites in one process, or a server handling two requests
+// that both need a model not yet cached) would each run the full download,
+// writing the same `<location>/.dal-meta/<file>.part` temp and moving it into
+// the same destination. Their writes interleave and the model lands corrupt:
+// the symptom was Core ML failing to open a half-written `weights/weight.bin`.
+//
+// This process-global actor keys an in-flight `Task` by cache location. The
+// first caller starts the download; everyone else on the same location awaits
+// the same task. Different locations still run in parallel, and once a download
+// finishes its entry is dropped so the next miss re-runs. It does not guard
+// against a *second process* racing the same cache dir; that needs a file lock,
+// and no pipeline here runs two processes against one cache.
+
+actor DownloadCoordinator {
+    static let shared = DownloadCoordinator()
+
+    private var inFlight: [String: Task<StoredModel, Error>] = [:]
+
+    func run(location: String, _ body: @Sendable @escaping () async throws -> StoredModel)
+        async throws -> StoredModel
+    {
+        // Join an existing download for this location rather than starting a
+        // second one. A failed task is not cached (the entry is cleared in the
+        // `defer` below), so a later caller retries cleanly.
+        if let existing = inFlight[location] {
+            return try await existing.value
+        }
+        let task = Task { try await body() }
+        inFlight[location] = task
+        defer { inFlight[location] = nil }
+        return try await task.value
+    }
+}

--- a/Sources/ModelStore/ModelStore.swift
+++ b/Sources/ModelStore/ModelStore.swift
@@ -95,6 +95,21 @@ public struct ModelStore: Sendable {
         progress: @Sendable @escaping (DownloadProgress) -> Void = { _ in }
     ) async throws -> StoredModel {
         guard isValid(model) else { throw ModelStoreError.invalidSpec }
+        // Coalesce concurrent downloads of the same location: two callers
+        // racing one model would otherwise write the same `.part` temps and
+        // corrupt the result (see DownloadCoordinator). A caller that joins an
+        // in-flight download shares its outcome; its own `progress` closure is
+        // not driven, which no caller depends on for correctness.
+        return try await DownloadCoordinator.shared.run(location: location(of: model)) {
+            try await self.performDownload(model, progress: progress)
+        }
+    }
+
+    @discardableResult
+    private func performDownload(
+        _ model: ModelSpec,
+        progress: @Sendable @escaping (DownloadProgress) -> Void
+    ) async throws -> StoredModel {
         try fs.makeDirectory(location(of: model))
         if isDownloaded(model) {
             if let bytes = try? fs.read(manifestPath(model)), let m = Manifest.parse(bytes) {

--- a/mise-tasks/test/ios
+++ b/mise-tasks/test/ios
@@ -31,8 +31,13 @@ if [[ -n "${CI:-}" ]]; then
     ci_flags=(
         -derivedDataPath .build/ios-deriveddata
         -clonedSourcePackagesDirPath .build/ios-packages
-        -skipPackageUpdates
     )
+    # No -skipPackageUpdates: it trusts the cached clone dir as-is, but the
+    # cache key hashes Package.resolved, which is gitignored here, so the key
+    # is really just Package.swift and never sees the graph re-resolve to a
+    # revision the cached clones lack ("unable to read tree"). Letting
+    # xcodebuild resolve normally reuses matching clones and fetches whatever
+    # drifted, the same way the DerivedData cache is patched incrementally.
 fi
 
 # Run the bundles in parallel. This package has 21 test targets, so the run is


### PR DESCRIPTION
The Apple job intermittently failed shapes tests with Core ML Code=71, "could not open weights/weight.bin". The artifact on the Hub is intact; this was a download race.

Swift Testing runs suites concurrently, so ShapesModelTests and ShapesBindingTests both build a Shapes() against a cold cache and both run the full download into the same cache location, writing the same .dal-meta/<file>.part temps and moving them over each other. weight.bin lands half-written. Apple hits it because there is no models-macOS CI cache (only Linux and Windows), so that job always downloads cold; the per-suite .serialized traits do nothing here because these are two different suites.

A process-global DownloadCoordinator actor keys an in-flight Task by cache location: the first caller downloads, concurrent callers on the same location await the same task, different locations still run in parallel. Verified by wiping the shapes and clear caches and running both models' suites together in release, which reproduced the corruption before and is clean after.

Scope: process-local. Two separate processes against one cache dir would still need a file lock, but no pipeline here runs that. Separately, adding a models-macOS cache would stop the Apple job downloading cold every run; left as a follow-up since coalescing makes it correct regardless.
