### PR TITLE
fix: many-channel and multi-gigabyte audio decode on Apple

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -139,7 +139,8 @@ let models: [ModelPackage] = [
     ),
     .init(
         name: "Uhm",
-        dependencies: ["AudioIO", "AudioDSP"]
+        dependencies: ["AudioIO", "AudioDSP"],
+        testDependencies: ["AudioIO"]
     ),
     .init(
         name: "Ear",
@@ -485,7 +486,7 @@ let testTargets: [Target] = [
             resources: [.copy("Resources/testmodel.tflite")]
         ),
         .testTarget(name: "AudioDSPTests", dependencies: ["AudioDSP"]),
-        .testTarget(name: "AudioIOTests", dependencies: ["AudioIO"]),
+        .testTarget(name: "AudioIOTests", dependencies: ["AudioIO", "TestSupport"]),
         .testTarget(name: "FFIBufferTests", dependencies: ["FFIBuffer"]),
 ]
 

--- a/Sources/AudioIO/AppleAudioIO.swift
+++ b/Sources/AudioIO/AppleAudioIO.swift
@@ -39,41 +39,91 @@ extension AudioIO {
         do {
             let file = try AVAudioFile(forReading: url)
             let inFormat = file.processingFormat
-            // nil means "whatever the file has"; the converter downmixes when
-            // asked for fewer channels than the source carries.
-            let outChannels = AVAudioChannelCount(requested ?? Int(inFormat.channelCount))
+            let inChannels = Int(inFormat.channelCount)
+            // nil means "whatever the file has". The converter is only trusted
+            // to change channel count for mono/stereo material: beyond stereo
+            // AVAudioConverter has no downmix matrix and silently keeps channel
+            // 0 (a 14-channel field recording decoded to just its first mic),
+            // so a many-channel mixdown converts at the source layout and
+            // averages below, the same mixdown the portable path uses.
+            let outChannels = requested ?? inChannels
+            let mixdownAfter = outChannels == 1 && inChannels > 2
+            let convChannels = AVAudioChannelCount(mixdownAfter ? inChannels : outChannels)
+            // The channels-count initializer returns nil beyond stereo; many-
+            // channel formats need an explicit layout. Prefer the file's own,
+            // fall back to "N discrete channels in order".
+            let outFormat: AVAudioFormat?
+            if convChannels <= 2 {
+                outFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                          sampleRate: sampleRate, channels: convChannels,
+                                          interleaved: false)
+            } else if let layout = inFormat.channelLayout
+                ?? AVAudioChannelLayout(layoutTag: kAudioChannelLayoutTag_DiscreteInOrder | UInt32(convChannels)) {
+                outFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                          sampleRate: sampleRate, interleaved: false,
+                                          channelLayout: layout)
+            } else {
+                outFormat = nil
+            }
             guard
-                outChannels > 0,
-                let outFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                              sampleRate: sampleRate, channels: outChannels,
-                                              interleaved: false),
-                let converter = AVAudioConverter(from: inFormat, to: outFormat),
-                file.length > 0,
-                let inBuffer = AVAudioPCMBuffer(pcmFormat: inFormat,
-                                                frameCapacity: AVAudioFrameCount(file.length))
+                convChannels > 0, outChannels > 0, file.length > 0,
+                let outFormat,
+                let converter = AVAudioConverter(from: inFormat, to: outFormat)
             else { throw AudioIOError.decodeFailed("cannot build converter") }
 
-            try file.read(into: inBuffer)
-            let capacity = AVAudioFrameCount(Double(inBuffer.frameLength) * (sampleRate / inFormat.sampleRate) + 4096)
-            guard let outBuffer = AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: capacity) else {
-                throw AudioIOError.decodeFailed("cannot build output buffer")
+            // Chunked, not whole-file: converting a multi-GB file in one call
+            // needs input, intermediate and output buffers sized to the whole
+            // file at once, and AVFoundation's internal byte counts are 32-bit
+            // (a 2.2 GB 14-channel wav died with std::overflow_error). A fixed
+            // chunk keeps every buffer small no matter the file.
+            let chunkFrames: AVAudioFrameCount = 1 << 19  // ~0.5M frames per read
+            let outCapacity = AVAudioFrameCount(Double(chunkFrames) * max(1, sampleRate / inFormat.sampleRate) + 4096)
+            guard let inBuffer = AVAudioPCMBuffer(pcmFormat: inFormat, frameCapacity: chunkFrames),
+                  let outBuffer = AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: outCapacity)
+            else { throw AudioIOError.decodeFailed("cannot build buffers") }
+
+            var channelsOut = [[Float]](repeating: [], count: Int(convChannels))
+            var drained = false
+            while !drained {
+                inBuffer.frameLength = 0
+                // Reading at EOF throws eofErr rather than returning 0 frames,
+                // so stop by position instead of probing.
+                if file.framePosition < file.length {
+                    try file.read(into: inBuffer, frameCount: chunkFrames)
+                }
+                let last = inBuffer.frameLength == 0
+                // `nonisolated(unsafe)` for the same reason as `@preconcurrency`
+                // above: the block runs synchronously inside `convert`, on this
+                // thread, so there is no concurrency for the flag to be unsafe
+                // across.
+                nonisolated(unsafe) var fed = false
+                var error: NSError?
+                let status = converter.convert(to: outBuffer, error: &error) { _, outStatus in
+                    if fed || last { outStatus.pointee = last ? .endOfStream : .noDataNow; return nil }
+                    fed = true; outStatus.pointee = .haveData; return inBuffer
+                }
+                if let error { throw error }
+                if status == .endOfStream { drained = true }
+                if let data = outBuffer.floatChannelData {
+                    let frames = Int(outBuffer.frameLength)
+                    // Non-interleaved, so each channel is its own contiguous buffer.
+                    for c in 0..<Int(convChannels) {
+                        channelsOut[c].append(contentsOf: UnsafeBufferPointer(start: data[c], count: frames))
+                    }
+                }
+                outBuffer.frameLength = 0
             }
-            // `nonisolated(unsafe)` for the same reason as `@preconcurrency` above:
-            // the block that flips this runs synchronously inside `convert`, on this
-            // thread, so there is no concurrency for the flag to be unsafe across.
-            nonisolated(unsafe) var fed = false
-            var error: NSError?
-            converter.convert(to: outBuffer, error: &error) { _, status in
-                if fed { status.pointee = .endOfStream; return nil }
-                fed = true; status.pointee = .haveData; return inBuffer
+
+            guard mixdownAfter else { return channelsOut }
+            // Average the source channels into mono, matching Resample.mixdownMono.
+            let frames = channelsOut[0].count
+            var mono = [Float](repeating: 0, count: frames)
+            let inv = 1 / Float(channelsOut.count)
+            for channel in channelsOut {
+                for i in 0..<min(frames, channel.count) { mono[i] += channel[i] }
             }
-            if let error { throw error }
-            guard let data = outBuffer.floatChannelData else { return [] }
-            let frames = Int(outBuffer.frameLength)
-            // Non-interleaved, so each channel is its own contiguous buffer.
-            return (0..<Int(outChannels)).map {
-                Array(UnsafeBufferPointer(start: data[$0], count: frames))
-            }
+            for i in 0..<frames { mono[i] *= inv }
+            return [mono]
         } catch let e as AudioIOError {
             throw e
         } catch {

--- a/Tests/AudioIOTests/AudioIOTests.swift
+++ b/Tests/AudioIOTests/AudioIOTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import TestSupport
 @testable import AudioIO
 
 struct AudioIOTests {
@@ -128,4 +129,67 @@ struct AudioIOTests {
         #expect(mono.count == 100)
         #expect(mono.allSatisfy { abs($0) < 1e-3 })
     }
+
+    // !os(WASI) like every decode test above: on wasm, decode delegates to the
+    // JS host (__DalAudioHost.decode), which the bare test harness never
+    // installs. Not CoreML-gated: the portable path mixes down too, and Linux
+    // should keep proving it.
+    #if !os(WASI)
+    @Test func fourteenChannelMixdown() async throws {
+        // A real 14-channel field capture found two bugs in the Apple decode
+        // path: beyond stereo AVAudioConverter has no downmix matrix and
+        // silently returned channel 0 as the "mixdown", and the whole-file
+        // single-buffer convert died with std::overflow_error once the file
+        // was large enough (2.2 GB) to overflow AVFoundation's 32-bit byte
+        // counts. The size half cannot be reproduced at fixture scale and is
+        // fixed by chunking; this guards the correctness half. Channel c
+        // carries a constant c/14, so the mono mixdown must be the average of
+        // 0/14...13/14 = 6.5/14, not channel 0's flat zero.
+        let sr = 16000
+        let channels = 14
+        var interleaved = [Float](repeating: 0, count: sr * channels)
+        for f in 0..<sr { for c in 0..<channels { interleaved[f * channels + c] = Float(c) / 14 } }
+        let wav = WAV.encode(interleaved, sampleRate: sr, channels: channels)
+        let mono = try await AudioIO.decode(bytes: wav, sampleRate: Double(sr))
+        #expect(mono.count == sr)
+        let expected = Float(6.5) / 14
+        #expect(mono.dropFirst(100).dropLast(100).allSatisfy { abs($0 - expected) < 2e-2 })
+    }
+    #endif
+
+
+
+    #if canImport(AVFoundation)
+    @Test(.longRunning) func multiGigabyteDecodeDoesNotOverflow() async throws {
+        // The crash half of the 14-channel story (the mixdown half is above):
+        // decoding a 2.2 GB capture died with std::overflow_error because the
+        // whole-file convert allocated input buffers for every frame at once,
+        // and frames x channels x 4 bytes crossed AVFoundation's 32-bit byte
+        // counts. The threshold is real (about 2.15 GB of 16-bit source), so a
+        // dense fixture cannot carry it; a sparse file of implicit zeros can,
+        // at no disk cost. Apple-gated: the portable path reads whole files
+        // into memory by design and never had the 32-bit limit.
+        let channels = 14, sr = 48000
+        let frames = 78_000_000  // x 14ch x 4B float32 = 4.37 GB > UInt32.max
+        let dataSize = frames * channels * 2
+        var hdr = [UInt8]()
+        func u16(_ v: Int) { hdr.append(UInt8(v & 0xFF)); hdr.append(UInt8((v >> 8) & 0xFF)) }
+        func u32(_ v: Int) { for s in 0..<4 { hdr.append(UInt8((v >> (8 * s)) & 0xFF)) } }
+        hdr.append(contentsOf: "RIFF".utf8); u32(36 + dataSize); hdr.append(contentsOf: "WAVE".utf8)
+        hdr.append(contentsOf: "fmt ".utf8); u32(16); u16(1); u16(channels); u32(sr)
+        u32(sr * channels * 2); u16(channels * 2); u16(16)
+        hdr.append(contentsOf: "data".utf8); u32(dataSize)
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dal-sparse-14ch-\(UUID().uuidString).wav").path
+        FileManager.default.createFile(atPath: path, contents: Data(hdr))
+        let fh = FileHandle(forWritingAtPath: path)!
+        try fh.truncate(atOffset: UInt64(44 + dataSize))
+        try fh.close()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let mono = try await AudioIO.decode(path: path, sampleRate: 16000)
+        // 78M frames at 48 kHz resampled to 16 kHz: one third, unmixed length.
+        #expect(mono.count == frames / 3)
+        #expect(mono.prefix(1000).allSatisfy { $0 == 0 })
+    }
+    #endif
 }

--- a/Tests/ClearTests/StreamingTests.swift
+++ b/Tests/ClearTests/StreamingTests.swift
@@ -139,14 +139,14 @@ struct ClearStreamingTests {
     /// The acceptance criterion for the whole exercise: doubling the input must
     /// not double the peak.
     ///
-    /// Disabled on CI: `footprintMB()` reads the whole process's memory, and
-    /// Swift Testing runs suites concurrently, so another suite allocating
-    /// during the 240 s window inflates the peak (a run showed 323 MB against a
-    /// 33 MB baseline, 10x what any windowing regression would cause). The
-    /// measurement is only sound with the process to itself; run it locally
-    /// with `swift test --filter peakDoesNotGrowWithDuration`.
-    @Test(.modelBacked, .disabled(if: ProcessInfo.processInfo.environment["CI"] != nil,
-        "whole-process memory reading is unreliable under parallel suites"))
+    /// `.longRunning` (minutes of audio), and doubly unfit for the every-commit
+    /// matrix: `footprintMB()` reads the whole process's memory, and Swift
+    /// Testing runs suites concurrently, so another suite allocating during
+    /// the 240 s window inflates the peak (a run showed 323 MB against a 33 MB
+    /// baseline, 10x what any windowing regression would cause). A long-tests
+    /// lane runs a filtered process, which also gives this the process to
+    /// itself.
+    @Test(.modelBacked, .longRunning)
     func peakDoesNotGrowWithDuration() async throws {
         let clear = try await enhancer()
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/TestSupport/LongRunningTrait.swift
+++ b/Tests/TestSupport/LongRunningTrait.swift
@@ -1,0 +1,15 @@
+#if !os(WASI)
+import Foundation
+import Testing
+
+public extension Trait where Self == ConditionTrait {
+    /// Tests that are too slow (or too resource-hungry) for every commit: they
+    /// run when a job opts in, the same shape as `.hubIntegration`. The normal
+    /// CI matrix never sets the variable; a scheduled or manual lane does.
+    static var longRunning: Self {
+        .enabled(
+            if: ProcessInfo.processInfo.environment["DAL_LONG_TESTS"] == "1",
+            "set DAL_LONG_TESTS=1 to run long-running tests")
+    }
+}
+#endif

--- a/Tests/UhmTests/ManyChannelTests.swift
+++ b/Tests/UhmTests/ManyChannelTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import AudioIO
+import TestSupport
+@testable import Uhm
+
+/// A real 14-channel field-recorder capture crashed `analyze(audioPath:)`
+/// (std::overflow_error out of the whole-file convert) and, decoded, carried
+/// only channel 0. Both fixed in AudioIO's Apple backend (chunked convert,
+/// explicit many-channel mixdown); this pins the contract at Uhm's level: a
+/// many-channel file is analyzable audio like any other, not a crash.
+#if canImport(CoreML)
+@Suite(.serialized, .modelBacked)
+struct ManyChannelTests {
+    @Test func analyzesFourteenChannelAudio() async throws {
+        // One second of near-silence across 14 channels: decode must survive
+        // the layout, and near-silence must yield zero fillers rather than an
+        // error or a truncated duration.
+        let sr = 16000
+        let channels = 14
+        var interleaved = [Float](repeating: 0, count: sr * channels)
+        for f in 0..<sr {
+            for c in 0..<channels {
+                interleaved[f * channels + c] = 0.001 * Float(f % 7)
+            }
+        }
+        let wav = WAV.encode(interleaved, sampleRate: sr, channels: channels)
+        let result = try await Uhm().analyze(bytes: wav)
+        #expect(abs(result.audioDuration - 1.0) < 0.05,
+                "14 channels of 1 s decoded to \(result.audioDuration) s")
+        #expect(result.fillers.isEmpty, "near-silence has no fillers")
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #145

A real 14-channel 2.2 GB field-recorder capture crashed Uhm's analyze. Root-causing it found two independent bugs in AudioIO's Apple decode backend; the portable path had neither.

Silent data loss: beyond stereo, AVAudioConverter has no downmix matrix and silently returns channel 0 as the mono "mixdown", so a many-channel recording was analyzed as its first mic only. Decode now converts at the source layout and averages the channels, matching what Resample.mixdownMono does on the portable path.

The crash: the whole-file single-buffer convert allocated input, intermediate and output for the entire file at once, and frames x channels x 4 bytes crossed AVFoundation's 32-bit byte counts at about 2.15 GB of 16-bit source, dying with an uncaught std::overflow_error. Decode now converts in ~0.5M-frame chunks, making buffer sizes independent of file length. The original 2.2 GB capture decodes in ~3 s.

Tests, each verified to fail (or crash) against the pre-fix code: fourteenChannelMixdown pins the channel average; multiGigabyteDecodeDoesNotOverflow reproduces the exact overflow via a sparse 2.2 GB file of implicit zeros (no dense fixture can carry the threshold, a sparse one costs no disk); UhmTests/ManyChannelTests pins the SDK-level contract.

New .longRunning trait (opt-in via DAL_LONG_TESTS=1, same shape as .hubIntegration) keeps the sparse test out of the every-commit matrix, reported as skipped rather than vanishing. Clear's peakDoesNotGrowWithDuration migrates to it from its ad-hoc disabled-on-CI, a strict upgrade since a filtered long-tests process also isolates its whole-process memory reading. No CI lane sets DAL_LONG_TESTS yet; a scheduled lane is a follow-up.
