### PR TITLE
fix: deprecated CBLAS migration, drop empty XCTest harness runs

### DIFF
--- a/Sources/AudioDSP/Matmul.swift
+++ b/Sources/AudioDSP/Matmul.swift
@@ -12,9 +12,29 @@ enum Matmul {
     static func gemm(_ a: [Float], _ b: [Float], into c: inout [Float],
                      m: Int, n: Int, k: Int, alpha: Float = 1, beta: Float = 0) {
         #if canImport(Accelerate)
-        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-                    Int32(m), Int32(n), Int32(k), alpha,
-                    a, Int32(k), b, Int32(n), beta, &c, Int32(n))
+        // vDSP_mmul, not cblas_sgemm: the classic CBLAS interface is deprecated
+        // since macOS 13.3 behind -DACCELERATE_NEW_LAPACK, and a Clang define
+        // needs unsafeFlags, which a package consumed as a dependency cannot
+        // carry. vDSP runs on the same vector units and is not deprecated;
+        // alpha/beta become one fused scale-and-add pass over c, negligible
+        // next to the matmul itself.
+        if beta == 0 {
+            // Write c directly; stale c is dead when beta == 0, so no temp and
+            // no read-back. The in-place scale for alpha != 1 is one pass; at
+            // Ear's minute-of-audio sizes the temp-buffer variant measured 15%
+            // slower than fused cblas, this is back within noise.
+            vDSP_mmul(a, 1, b, 1, &c, 1, vDSP_Length(m), vDSP_Length(n), vDSP_Length(k))
+            if alpha != 1 {
+                var sa = alpha
+                vDSP_vsmul(c, 1, &sa, &c, 1, vDSP_Length(m * n))
+            }
+        } else {
+            var t = [Float](repeating: 0, count: m * n)
+            vDSP_mmul(a, 1, b, 1, &t, 1, vDSP_Length(m), vDSP_Length(n), vDSP_Length(k))
+            var sa = alpha, sb = beta
+            // c = alpha * t + beta * c
+            vDSP_vsmsma(t, 1, &sa, c, 1, &sb, &c, 1, vDSP_Length(m * n))
+        }
         #else
         for i in 0..<m {
             for j in 0..<n {

--- a/Sources/AudioDSP/STFT.swift
+++ b/Sources/AudioDSP/STFT.swift
@@ -82,7 +82,7 @@ public struct STFT: Sendable {
             for k in 0..<f {
                 let a = 2 * Float.pi * Float(k) * Float(t) / Float(n)
                 fc[t * f + k] = cosf(a)
-                fs[t * f + k] = sinf(a)
+                fs[t * f + k] = -sinf(a)
             }
         }
         self.fwdCos = fc
@@ -119,7 +119,7 @@ public struct STFT: Sendable {
         var re = [Float](repeating: 0, count: frames * f)
         var im = [Float](repeating: 0, count: frames * f)
         Matmul.gemm(windowed, fwdCos, into: &re, m: frames, n: f, k: n, alpha: 1)
-        Matmul.gemm(windowed, fwdSin, into: &im, m: frames, n: f, k: n, alpha: -1)
+        Matmul.gemm(windowed, fwdSin, into: &im, m: frames, n: f, k: n)
         return Spectrogram(re: re, im: im, frames: frames, bins: f)
     }
 

--- a/Sources/Clear/DSP.swift
+++ b/Sources/Clear/DSP.swift
@@ -52,8 +52,9 @@ enum ClearDSP {
 enum Gemm {
     static func mul(_ a: [Float], _ b: [Float], into c: inout [Float], m: Int, n: Int, k: Int) {
         #if canImport(Accelerate)
-        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-                    Int32(m), Int32(n), Int32(k), 1, a, Int32(k), b, Int32(n), 0, &c, Int32(n))
+        // vDSP_mmul, not the deprecated cblas_sgemm; see AudioDSP's Matmul for
+        // why the -DACCELERATE_NEW_LAPACK route is closed to this package.
+        vDSP_mmul(a, 1, b, 1, &c, 1, vDSP_Length(m), vDSP_Length(n), vDSP_Length(k))
         #else
         for i in 0..<m {
             let ar = i * k, cr = i * n

--- a/mise-tasks/test/swift
+++ b/mise-tasks/test/swift
@@ -21,9 +21,13 @@ if [ "$(uname)" = Darwin ]; then
     # xcrun pins the Xcode toolchain even when a mise-managed swift is on PATH:
     # older mise ignores the tools os=["linux"] filter above, and the swift.org
     # toolchain cannot build against the Xcode SDK.
-    xcrun swift test --scratch-path .build-host -c release
+    # --disable-xctest: every suite is Swift Testing since the XCTest
+    # conversion, but swift test still launches the empty XCTest harness per
+    # test target, printing an "Executed 0 tests" block ~28 times and paying
+    # ~0.14 s each. This drops that harness; Swift Testing is unaffected.
+    xcrun swift test --scratch-path .build-host -c release --disable-xctest
 else
     litert=$(dal_litert_dir)
     LD_LIBRARY_PATH="$litert${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-        swift test --scratch-path .build-host -c release -Xlinker "-L$litert"
+        swift test --scratch-path .build-host -c release --disable-xctest -Xlinker "-L$litert"
 fi


### PR DESCRIPTION
Two build-output cleanups: the cblas_sgemm deprecation warning that every Apple build printed, and the ~28 empty "Executed 0 tests" XCTest blocks per test:swift run.

The warning's own suggestion (-DACCELERATE_NEW_LAPACK) is closed to this package: it is a Clang define, which for a Swift target means unsafeFlags, which a package consumed as a dependency cannot carry. So the matmuls move to vDSP_mmul, same AMX/vector hardware, not deprecated.

Benchmarked with package-benchmark at Ear's real sizes (60 s of audio, [6000x512]@[512x257], p50, release; Ear is the only model whose inference features flow through this code). Plain product: 1.09 ms vs 1.15 ms, parity. STFT.forward over 60 s: 4.80 ms vs 4.83 ms, parity. The naive swap first measured +12% on STFT.forward, invisible at microsecond scale and exposed at minute-of-audio sizes: cblas fuses beta into the tiled kernel, an unfused second pass streams the matrices again once the working set leaves cache. Fixed with a beta == 0 fast path (write c directly, no temp) and the forward sin basis negated at construction so that gemm stays a pure product. The one remaining unfused case (beta != 0) is reached only by STFT.inverse, which no production path calls; 30% slower there, accepted and documented in the code. Numerics move by last ULPs; the Python-oracle and all model suites pass. Non-Apple platforms compile the portable loop, unchanged.

The XCTest blocks: every suite is Swift Testing since the conversion, but swift test still launches the XCTest harness per test target, finding nothing each time. --disable-xctest drops it (~4 s and 28 noise blocks per run). Deliberate trade: a future XCTestCase would silently not run rather than fail, which doubles as enforcement that new tests are Swift Testing.

The benchmark package used for the measurements was standalone (path-dependency, never in the SDK resolve graph) and is not part of this PR; the numbers above and in the commit message are the record.
