### PR TITLE
docs(emo): simplify the model page

### DIFF
--- a/docs/models/emo.md
+++ b/docs/models/emo.md
@@ -106,29 +106,8 @@ let offline = Emo(directory: myModelDirectory)   // adopted as-is, nothing downl
 | `emo.mlmodelc` | Compiled Core ML | ~4.6 MB | Mixed 4-/8-bit-palettized transformer, ready to load on Apple platforms (used by the Swift SDK) |
 | `emo_tokenizer.bin` | Pruned unigram tokenizer | ~0.75 MB | 48k SentencePiece pieces + scores; token ids = semantic-table rows |
 | `emo_meta.json` | JSON | tiny | emoji labels + n-gram hashing / fixed-window config the runtime needs |
-| `emo.pt` | PyTorch checkpoint | ~48 MB | Full-precision weights + semantic table + tokenizer (for retraining / other runtimes) |
 
 Older revisions (tags `v0.6.0` and earlier) carry `Emo.mlmodelc` and `emo.safetensors` for SDK versions that predate the unified cross-platform migration.
-
-## Architecture
-
-A compact two-stream classifier - no large encoder, just a tiny transformer over the semantic tokens:
-
-- **Lexical stream**: script-aware character/word n-grams (Latin, Han·Kana, Hangul
-  jamo, Devanagari clusters, SE-Asian, …) hashed into a fixed multi-hash signed
-  embedding table. Its size is independent of the number of languages.
-- **Semantic stream**: a frozen multilingual static embedding (Model2Vec
-  [`potion-multilingual-128M`](https://huggingface.co/minishlab/potion-multilingual-128M),
-  distilled from BAAI `bge-m3`), PCA-reduced to 128 dims and **vocab-pruned to the
-  48k tokens** that matter for the 22 target languages. Gives cross-lingual
-  generalization and handles out-of-vocabulary words. The matching ~0.75 MB unigram
-  tokenizer ships alongside (`emo_tokenizer.bin`).
-- **Semantic pooling**: a small 2-layer transformer encoder runs over the semantic
-  token sequence, then an attention pool - order-aware, so it composes phrases and
-  idioms instead of averaging tokens.
-- **Head**: a small MLP fusing the two streams into a softmax over a **curated vocabulary of ~800 everyday emojis** (the emojis that actually come up most across the
-  training phrases). Trained with n-gram dropout so the head relies on the semantic
-  stream, which is what makes it generalize across languages.
 
 ## Inputs and outputs
 


### PR DESCRIPTION
The Files table lists what the SDK downloads, and the architecture section is removed. The website mirrors this page through `npm run docs:sync`.