### PR TITLE
docs(shapes): simplify the model page

### DIFF
--- a/docs/models/shapes.md
+++ b/docs/models/shapes.md
@@ -103,8 +103,6 @@ The weights are fetched from the Hub on first use and cached. See
 | `shapes.mlmodelc` | Compiled Core ML | ~0.2 MB | 4-bit-palettized classifier, ready to load on Apple platforms (used by the Swift SDK) |
 | `shapes_meta.json` | JSON | tiny | classes, preprocessing constants, model dims, and snap gates |
 | `shapes.safetensors` | safetensors | ~0.2 MB | packed portable weights (reference) |
-| `model.pt` | PyTorch checkpoint | ~1.5 MB | trained weights (for export / fine-tuning) |
-| `config.json` | JSON | tiny | class list, preprocessing constants, and per-class snap gates |
 
 Older revisions (tag `v0.1.0`) carry `shapes.onnx` for SDK versions that predate the LiteRT migration.
 
@@ -112,9 +110,8 @@ Older revisions (tag `v0.1.0`) carry `shapes.onnx` for SDK versions that predate
 
 Two stages, *the network proposes, geometry verifies*:
 
-1. **Classify**: the stroke is resampled and fed to a compact sequence classifier
-   (Conv1d stem → small Transformer encoder → masked mean-pool → MLP), which
-   predicts the shape type (or `none` to reject scribbles).
+1. **Classify**: the stroke is resampled and fed to a compact sequence classifier,
+   which predicts the shape type (or `none` to reject scribbles).
 2. **Fit + snap**: a classical geometric fitter produces clean vector parameters
    (min-area box, moment/PCA ellipse, max-area triangle, …), then regularizes them
    (snap to axes, circles, squares, and 15° rotation increments). A fit-residual

--- a/docs/models/shapes.md
+++ b/docs/models/shapes.md
@@ -106,17 +106,6 @@ The weights are fetched from the Hub on first use and cached. See
 
 Older revisions (tag `v0.1.0`) carry `shapes.onnx` for SDK versions that predate the LiteRT migration.
 
-## How it works
-
-Two stages, *the network proposes, geometry verifies*:
-
-1. **Classify**: the stroke is resampled and fed to a compact sequence classifier,
-   which predicts the shape type (or `none` to reject scribbles).
-2. **Fit + snap**: a classical geometric fitter produces clean vector parameters
-   (min-area box, moment/PCA ellipse, max-area triangle, …), then regularizes them
-   (snap to axes, circles, squares, and 15° rotation increments). A fit-residual
-   gate vetoes poor fits so non-shapes stay rejected.
-
 ## Inputs and outputs
 
 - **Input:** an ordered list of stroke points in canvas coordinates. Single stroke.


### PR DESCRIPTION
The Files table lists what the SDKs use. The website mirrors this page through `npm run docs:sync`.