### PR TITLE
docs(emo): simplify the model page

### DIFF
--- a/docs/models/emo.md
+++ b/docs/models/emo.md
@@ -102,10 +102,10 @@ let offline = Emo(directory: myModelDirectory)   // adopted as-is, nothing downl
 
 | File | Format | Size | Contents |
 |---|---|---:|---|
-| `emo.tflite` | LiteRT / TFLite (int8) | ~10.2 MB | Fixed-window n-gram + masked semantic inputs, softmax `probabilities` output; runs on Android, Linux, Node, and the web (bundled by default in the Kotlin SDK; downloaded on demand by the JavaScript SDK) |
-| `emo.mlmodelc` | Compiled Core ML | ~4.6 MB | Mixed 4-/8-bit-palettized transformer, ready to load on Apple platforms (used by the Swift SDK) |
-| `emo_tokenizer.bin` | Pruned unigram tokenizer | ~0.75 MB | 48k SentencePiece pieces + scores; token ids = semantic-table rows |
-| `emo_meta.json` | JSON | tiny | emoji labels + n-gram hashing / fixed-window config the runtime needs |
+| `emo.tflite` | LiteRT / TFLite (int8) | ~10.2 MB | Runs on Android, Linux, Node, and the web (bundled by default in the Kotlin SDK; downloaded on demand by the JavaScript SDK) |
+| `emo.mlmodelc` | Compiled Core ML | ~4.6 MB | Ready to load on Apple platforms (used by the Swift SDK) |
+| `emo_tokenizer.bin` | Unigram tokenizer | ~0.75 MB | Tokenizer the runtime needs |
+| `emo_meta.json` | JSON | tiny | Emoji labels and runtime config |
 
 Older revisions (tags `v0.6.0` and earlier) carry `Emo.mlmodelc` and `emo.safetensors` for SDK versions that predate the unified cross-platform migration.
 

--- a/docs/models/emo.md
+++ b/docs/models/emo.md
@@ -127,15 +127,6 @@ Indonesian, Thai, Vietnamese, Ukrainian, Swedish, Danish, Czech.
 - Emoji semantics are imprecise; near-ties at the top of the ranking are expected.
 - Per-language quality varies; lower-resource languages in the set are somewhat weaker.
 
-## Built on
-
-- [`minishlab/potion-multilingual-128M`](https://huggingface.co/minishlab/potion-multilingual-128M) (MIT): semantic embedding stream (PCA-reduced, vocab-pruned derivative) + tokenizer lineage.
-- [`BAAI/bge-m3`](https://huggingface.co/BAAI/bge-m3) (MIT): teacher the static embedding was distilled from.
-- [Model2Vec](https://github.com/MinishLab/model2vec) (MIT): static-embedding distillation method.
-- Unicode CLDR emoji annotations: multilingual keyword grounding in the training data.
-
-See [`THIRD_PARTY_NOTICES.md`](https://huggingface.co/desert-ant-labs/emo/blob/v0.7.0/THIRD_PARTY_NOTICES.md).
-
 ## License
 
 [Desert Ant Labs Source-Available License](https://license.desertant.com/1.0). Free for


### PR DESCRIPTION
The provenance section is removed. The website mirrors this page through `npm run docs:sync`.