### PR TITLE
docs(tongue): simplify the model page

### DIFF
--- a/docs/models/tongue.md
+++ b/docs/models/tongue.md
@@ -94,54 +94,25 @@ const tongue = await Tongue.load({ from: "/models/tongue" });
 
 | File | Format | Size | Contents |
 |---|---|---:|---|
-| `tongue_int8.bin` | Raw int8 + fp32 | 2.01 MiB | The shipped artifact: int8 embedding table, fp32 linear head and bias. Byte-identical to what the live demo runs. |
-| `tongue_int4.bin` | Raw int4 + fp32 | 1.01 MiB | Half-size alternative for tight bundles. Same architecture, 4-bit embedding. Costs roughly 0.4pp on short text (see Sizes). |
-| `tongue.onnx` | ONNX (fp32, opset 17) | 8.4 MB | Portable graph for onnxruntime / onnxruntime-web. Verified against the PyTorch reference. |
-| `tongue.pt` | PyTorch checkpoint (fp32) | 8.4 MB | Full-precision weights for retraining or other runtimes. |
-| `tongue_meta.json` | JSON | tiny | Label order, bucket count, embedding dimension, n-gram orders, int8 scale, and the per-script routing tables a runtime needs. |
+| `tongue_int8.bin` | Raw int8 + fp32 | 2.01 MiB | The shipped artifact. Byte-identical to what the live demo runs. |
+| `tongue_int4.bin` | Raw int4 + fp32 | 1.01 MiB | Half-size alternative for tight bundles. Costs roughly 0.4pp on short text, see Sizes. |
+| `tongue.onnx` | ONNX (fp32, opset 17) | 8.4 MB | Portable graph for onnxruntime / onnxruntime-web. |
+| `tongue_meta.json` | JSON | tiny | Runtime tables: label order, hashing constants, script routing. |
 | `labels.json` | JSON | tiny | The 59 model labels plus the script-decided languages, with English and native names. |
-| `config.json` | JSON | tiny | Training configuration and per-language validation accuracy. |
 
-There is no tokenizer file. tongue hashes raw character n-grams, so nothing has
-to be shipped or version-matched alongside the weights.
-
-## Architecture
-
-Two stages. No encoder, no learned tokenizer, no per-language models.
-
-- **Script router (zero parameters).** A [UAX #24](https://www.unicode.org/reports/tr24/)
-  script table decides any text whose script belongs to one language outright,
-  Hangul to Korean, Greek to Greek, Thai to Thai, and narrows multi-language
-  scripts (Cyrillic, Arabic, Devanagari, Bengali) to their candidate sets before
-  the model runs. Presence beats dominance, so a Latin brand name embedded in
-  Greek text does not derail the route.
-- **Lexical model.** FNV-1a-hashed character n-grams (orders 1-5, marked with
-  word boundaries) over Unicode scalars, summed through an int8 `EmbeddingBag`
-  into a linear head, decoded with a per-script masked softmax. The hash table
-  *is* the feature space, so model size does not grow with the language count.
-- **Prior correction.** The training corpus caps large languages and under-fills
-  thin ones, so the head absorbs a label prior. A fixed `-tau*log(prior)` shift
-  (tau = 0.75) is folded into the exported bias, which costs nothing at runtime
-  and keeps confusion pairs from collapsing onto the better-resourced side.
-- **Calibrated abstention.** Reliability is keyed off input length and the margin
-  between the top two candidates, not raw softmax confidence, which is
-  overconfident on very short text. Below the threshold the model reports a
-  tentative answer or a tie instead of committing.
+There is no tokenizer file, so nothing has to be shipped or version-matched
+alongside the weights.
 
 ## Inputs and outputs
 
-**Input:** a short UTF-8 string. The runtime normalizes it (NFC, lowercase, URLs
-/ mentions / digits stripped, 512-character cap), hashes n-grams, and consults
-the router before the graph.
+**Input:** a short UTF-8 string, up to 512 characters.
 **Output:** ranked ISO 639-1/639-3 codes with probabilities, plus a reliability
 signal (`confident` / `likely` / `tentative`). Script-decided inputs return a
 single confident answer.
 
 The ONNX graph carries **only the head**: `values` (int64 hashed bucket ids) and
-`offsets` (int64 per-sample starts) in, `logits` out. The normalizer, hasher and
-router are reimplemented natively per platform and verified against golden
-vectors: they must run before the model is consulted, and on inputs the model
-never sees. `tongue_meta.json` documents both tables.
+`offsets` (int64 per-sample starts) in, `logits` out. Normalization, hashing and
+script routing run in the host before the graph; `tongue_meta.json` documents them.
 
 ## Coverage
 
@@ -164,13 +135,10 @@ not on principle.
 | Held-out single words | 0.759 | 0.752 |
 | Held-out sentences | 0.971 | 0.970 |
 
-int4 uses one scale per embedding dimension with the scale clipped at the 99th
-percentile: plain max-scaling spends most of the 16 levels on a handful of
-outliers and costs 3.8pp instead of 0.4pp. The loss lands almost entirely on
-one- and two-word input, where there are fewer n-grams for quantisation error
-to cancel across; full sentences are unaffected within measurement noise. Since
-short text is what this model is for, int8 stays the default and int4 is the
-option when a megabyte matters more than the last half point.
+The int4 loss lands almost entirely on one- and two-word input; full sentences
+are unaffected within measurement noise. Since short text is what this model is
+for, int8 stays the default and int4 is the option when a megabyte matters more
+than the last half point.
 
 ## Failure modes (read before deploying)
 
@@ -209,13 +177,13 @@ frequent words of a language appear in everyone's training data, so any
 detector's single-word accuracy partly measures memorized vocabulary. Read the
 word-pair and sentence numbers as the generalization signal.
 
-## Measured quality (the shipped artifact, not the checkpoint)
+## Measured quality
 
 Every number below is measured on the shipped int8 weights, on three
 public benchmarks, with other detectors run on the identical rows and language
 subsets. Higher is better.
 
-### FLORES-200, a benchmark none of these detectors trained on
+### FLORES-200
 
 Sentences from FLORES-200 truncated to their first 2, 3 and 5 words. Accuracy
 over the 20 languages the three detectors share.
@@ -236,7 +204,7 @@ same collection lingua trains on. Accuracy over the languages we share.
 | **tongue** | **2 MB** | **0.746** | **0.909** | **0.988** |
 | lingua | 293 MB | 0.752 | 0.915 | 0.985 |
 
-### eld, an independent benchmark, held out from training
+### eld, an independent benchmark
 
 Accuracy over the languages tongue supports (53,035 single-word rows,
 53,613 word pairs, 53,141 sentences, 9,066 tweets).
@@ -250,32 +218,9 @@ single 293 MB compiled extension with its language models embedded.
 | HeLI-OTS | 51 MB | 0.986 | 0.683 | 0.843 | 0.967 |
 | Apple | system | 0.997 | 0.641 | 0.719 | 0.748 |
 
-## How these numbers were made
+## Latency
 
-- **Benchmarks are eval-only.** FLORES-200, WiLI-2018 and the eld benchmark are
-  never trained on. Leipzig/Wortschatz corpora are excluded from training in
-  every form, because a competing detector's published test set is drawn from
-  them.
-- **Evaluation splits are leakage-controlled.** The training corpus is split
-  along the Tatoeba translation-link graph, so a sentence and its translations
-  cannot straddle train and validation.
-- **Numbers are re-measured on the exported bytes**, not extrapolated from the
-  training checkpoint, and the pure-JavaScript runtime is verified against the
-  Python reference on golden vectors (currently 119/119 identical, worst
-  probability delta 1.1e-16).
-- **Latency** is measured per single detection in JavaScript on an Apple-silicon
-  laptop: 0.013 ms for one word, 0.028 ms for a short sentence, 0.10 ms at 193
-  characters (p99 0.24 ms). On-device budgets on phone-class hardware will be
-  higher; the design target is under 1 ms.
-
-## Training data
-
-Built exclusively from commercially clean components: Tatoeba (CC BY 2.0 FR),
-Common Voice sentence collections (CC0), Wikidata Lexemes (CC0), Hunspell
-dictionaries (permissive per-dictionary) and five Universal Dependencies
-treebanks (CC BY 4.0). Share-alike sources are excluded by policy and by build
-check: no Wikipedia or Europarl text enters training. Attributions and dataset
-citations are in [`THIRD_PARTY_NOTICES.md`](https://huggingface.co/desert-ant-labs/tongue/blob/v1.0.0/THIRD_PARTY_NOTICES.md).
+Measured per single detection in JavaScript on an Apple-silicon laptop: 0.013 ms for one word, 0.028 ms for a short sentence, 0.10 ms at 193 characters (p99 0.24 ms). On-device budgets on phone-class hardware will be higher; the design target is under 1 ms.
 
 ## License
 


### PR DESCRIPTION
The Files table lists what ships, and the methodology sections are reduced to results and latency. The website mirrors this page through `npm run docs:sync`.