### PR TITLE
Usage: wire schema 2 (sessionId, batchId), 15-min coalescing, events.* host

### DIFF
--- a/Sources/Usage/Transport.swift
+++ b/Sources/Usage/Transport.swift
@@ -9,7 +9,9 @@ import JavaScriptKit
 /// The shared ingest endpoint. Every SDK reports to the same place, so it is not
 /// part of the public API. A host may override it (tests/diagnostics) via
 /// `hostProvidedIngestEndpoint()`.
-private let defaultIngestEndpoint = "https://platform.desertant.ai/api/v1/ingest"
+// The dedicated telemetry host (docs/ingest-api.md). The former
+// platform.desertant.ai URL still 308-redirects, but every event paid that hop.
+private let defaultIngestEndpoint = "https://events.desertant.com/api/v1/ingest"
 private var ingestEndpoint: String { hostProvidedIngestEndpoint() ?? defaultIngestEndpoint }
 
 /// A `send` transport that POSTs the serialized body to `endpoint`.
@@ -100,8 +102,10 @@ public func makeClient(
     let namespace = resolvedKey ?? resolvedAppId    // state namespaced per attribution identity
     let store = storage ?? defaultStorage()
     let device = resolveDeviceId(deviceId, store)
-    // Coalesce a continuously-running server's delta loads to hourly by default.
-    let resolvedEmitInterval = emitIntervalMs ?? (platform == "server" ? hourMs : 0)
+    // Coalesce delta loads by default: hourly on a continuously-running server,
+    // every quarter hour everywhere else — so rows per device per day are bounded
+    // on mobile and web too, not only on the server path.
+    let resolvedEmitInterval = emitIntervalMs ?? (platform == "server" ? hourMs : quarterHourMs)
     return UsageClient(ClientDeps(
         deviceId: device,
         key: resolvedKey,

--- a/Sources/Usage/Transport.swift
+++ b/Sources/Usage/Transport.swift
@@ -9,8 +9,9 @@ import JavaScriptKit
 /// The shared ingest endpoint. Every SDK reports to the same place, so it is not
 /// part of the public API. A host may override it (tests/diagnostics) via
 /// `hostProvidedIngestEndpoint()`.
-// The dedicated telemetry host (docs/ingest-api.md). The former
-// platform.desertant.ai URL still 308-redirects, but every event paid that hop.
+// The dedicated telemetry host (docs/ingest-api.md). The former platform.*
+// URL is deprecated but still served (a cross-origin redirect cannot work for
+// browsers); new builds post to events.* directly.
 private let defaultIngestEndpoint = "https://events.desertant.com/api/v1/ingest"
 private var ingestEndpoint: String { hostProvidedIngestEndpoint() ?? defaultIngestEndpoint }
 
@@ -99,7 +100,11 @@ public func makeClient(
 ) -> UsageClient {
     let resolvedAppId = appId ?? hostProvidedAppId() ?? defaultAppIdentifier()
     let resolvedKey = key ?? hostProvidedApiKey()
-    let namespace = resolvedKey ?? resolvedAppId    // state namespaced per attribution identity
+    // State is namespaced per attribution identity AND per SDK: several SDKs
+    // (emo, clear, shapes…) share one process and, with delta coalescing, park
+    // calls in `carryCallCount` for minutes at a time — a shared slot would lose
+    // updates between them (read-modify-write with no atomicity).
+    let namespace = "\(resolvedKey ?? resolvedAppId).\(sdk.name)"
     let store = storage ?? defaultStorage()
     let device = resolveDeviceId(deviceId, store)
     // Coalesce delta loads by default: hourly on a continuously-running server,

--- a/Sources/Usage/UsageClient.swift
+++ b/Sources/Usage/UsageClient.swift
@@ -12,6 +12,10 @@ public let dayMs: Int64 = 24 * 60 * 60 * 1000
 public let webSessionMs: Int64 = 30 * 60 * 1000
 /// Default coalescing interval for a continuously-running `server` host's deltas.
 public let hourMs: Int64 = 60 * 60 * 1000
+/// Default coalescing interval for every other host's deltas (mobile, web). A
+/// session that keeps detecting sends one delta per quarter hour, not one per
+/// 3-second idle gap: bounds rows per device per day whatever the app does.
+public let quarterHourMs: Int64 = 15 * 60 * 1000
 
 /// Persisted per install, across sessions.
 public struct UsageState: Sendable, Equatable {
@@ -95,8 +99,13 @@ public final class UsageClient {
     private var pending: IngestEvent? // queued turnstile, awaiting first flush
     private var emitted = false       // did we open a turnstile this session?
     private var lastEmitAt: Int64 = 0 // clock of the last actual send; gates delta coalescing
+    /// One id per client lifetime, carried on the turnstile and every delta (wire schema 2).
+    public let sessionId: String
 
-    public init(_ deps: ClientDeps) { self.deps = deps }
+    public init(_ deps: ClientDeps) {
+        self.deps = deps
+        self.sessionId = generateUUID()
+    }
 
     /// Host calls this once per inference/call to attribute to the turnstile.
     public func recordCall(_ n: Int = 1) {
@@ -157,7 +166,7 @@ public final class UsageClient {
                 }
                 return
             }
-            let ev = IngestEvent(deviceId: deps.deviceId, callCount: resolveCount(st.carryCallCount + sessionCalls), context: currentContext())
+            let ev = IngestEvent(deviceId: deps.deviceId, callCount: resolveCount(st.carryCallCount + sessionCalls), context: currentContext(), sessionId: sessionId)
             if deps.callCount == nil && st.carryCallCount != 0 {
                 deps.saveState(UsageState(lastActiveAt: st.lastActiveAt, carryCallCount: 0))
             }
@@ -186,11 +195,15 @@ public final class UsageClient {
     }
 
     private func queue(context: [String: String]? = nil) {
-        pending = IngestEvent(deviceId: deps.deviceId, context: context ?? currentContext())
+        pending = IngestEvent(deviceId: deps.deviceId, context: context ?? currentContext(), sessionId: sessionId)
         emitted = true
     }
 
     private func makeBody(_ events: [IngestEvent]) -> IngestBody {
-        IngestBody(platform: deps.platform, key: deps.key, app: deps.appId.map(AppInfo.init(id:)), sdk: deps.sdk, sentAt: iso8601(epochMs: deps.now()), events: events)
+        IngestBody(
+            platform: deps.platform, key: deps.key, app: deps.appId.map(AppInfo.init(id:)), sdk: deps.sdk,
+            sentAt: iso8601(epochMs: deps.now()), events: events,
+            batchId: generateUUID(), schemaVersion: wireSchemaVersion
+        )
     }
 }

--- a/Sources/Usage/UsageClient.swift
+++ b/Sources/Usage/UsageClient.swift
@@ -99,12 +99,14 @@ public final class UsageClient {
     private var pending: IngestEvent? // queued turnstile, awaiting first flush
     private var emitted = false       // did we open a turnstile this session?
     private var lastEmitAt: Int64 = 0 // clock of the last actual send; gates delta coalescing
-    /// One id per client lifetime, carried on the turnstile and every delta (wire schema 2).
-    public let sessionId: String
+    /// The current session's id (wire schema 2): minted when a turnstile opens
+    /// and carried by that turnstile and every delta until the next turnstile —
+    /// so a long-lived client that re-opens the window (a new day, or a web tab
+    /// idle past 30 min) starts a new session id, not the same one forever.
+    public private(set) var sessionId: String = generateUUID()
 
     public init(_ deps: ClientDeps) {
         self.deps = deps
-        self.sessionId = generateUUID()
     }
 
     /// Host calls this once per inference/call to attribute to the turnstile.
@@ -149,7 +151,9 @@ public final class UsageClient {
                 deps.saveState(UsageState(lastActiveAt: st.lastActiveAt, carryCallCount: 0))
             }
             sessionCalls = 0
-            lastEmitAt = deps.now()
+            // The coalescing gate starts counting from the first DELTA, not from
+            // the turnstile: a short session's calls must not wait a full interval.
+            lastEmitAt = 0
             deps.send(makeBody([ev]), opts)
             return
         }
@@ -195,6 +199,9 @@ public final class UsageClient {
     }
 
     private func queue(context: [String: String]? = nil) {
+        // A turnstile opens a session: new id, unless this is the first turnstile
+        // of this client and nothing has been sent under the initial id yet.
+        if emitted { sessionId = generateUUID() }
         pending = IngestEvent(deviceId: deps.deviceId, context: context ?? currentContext(), sessionId: sessionId)
         emitted = true
     }

--- a/Sources/Usage/Wire.swift
+++ b/Sources/Usage/Wire.swift
@@ -59,25 +59,34 @@ public struct SDKInfo: Codable, Sendable, Equatable {
 
 /// A single ingest event. `name` is always `"load"`; the optional fields are
 /// omitted from the wire when unset.
+///
+/// `sessionId` (schema 2) identifies the client session the event belongs to —
+/// one id per `UsageClient` lifetime, shared by the turnstile and every delta it
+/// emits. It is what makes session length / frequency representable server-side;
+/// without it one device with 50 deltas in a session is indistinguishable from
+/// one device with 50 sessions. Additive: old servers ignore it.
 public struct IngestEvent: Codable, Sendable, Equatable {
     public var name: String
     public var deviceId: String
     public var callCount: Int?
     public var timestamp: String?
     public var context: [String: String]?
+    public var sessionId: String?
 
     public init(
         name: String = "load",
         deviceId: String,
         callCount: Int? = nil,
         timestamp: String? = nil,
-        context: [String: String]? = nil
+        context: [String: String]? = nil,
+        sessionId: String? = nil
     ) {
         self.name = name
         self.deviceId = deviceId
         self.callCount = callCount
         self.timestamp = timestamp
         self.context = context
+        self.sessionId = sessionId
     }
 }
 
@@ -93,9 +102,19 @@ public struct AppInfo: Codable, Sendable, Equatable {
     }
 }
 
+/// Wire schema version this SDK emits. 1 = the original body; 2 adds
+/// `batchId`, `schemaVersion` and per-event `sessionId` (all additive).
+public let wireSchemaVersion = 2
+
 /// The request body posted to the ingest endpoint. Attribution is either a
 /// publishable `key` or — keyless, off-browser — the app identity in `app`.
 /// Field order on the wire follows declaration order.
+///
+/// `batchId` (schema 2) is minted once per body. It is the delivery contract:
+/// a server can de-duplicate on (batchId, event index) whatever sits between
+/// this SDK and its store, so a retry or a replay can never double-count —
+/// without any further SDK change. There is no retry in this SDK yet; when one
+/// ships it MUST resend the same body with the same batchId.
 public struct IngestBody: Codable, Sendable, Equatable {
     public var platform: String
     public var key: String?
@@ -103,6 +122,8 @@ public struct IngestBody: Codable, Sendable, Equatable {
     public var sdk: SDKInfo
     public var sentAt: String
     public var events: [IngestEvent]
+    public var batchId: String?
+    public var schemaVersion: Int?
 
     public init(
         platform: String = defaultPlatform,
@@ -110,7 +131,9 @@ public struct IngestBody: Codable, Sendable, Equatable {
         app: AppInfo? = nil,
         sdk: SDKInfo = SDKInfo(),
         sentAt: String,
-        events: [IngestEvent]
+        events: [IngestEvent],
+        batchId: String? = nil,
+        schemaVersion: Int? = nil
     ) {
         self.platform = platform
         self.key = key
@@ -118,6 +141,8 @@ public struct IngestBody: Codable, Sendable, Equatable {
         self.sdk = sdk
         self.sentAt = sentAt
         self.events = events
+        self.batchId = batchId
+        self.schemaVersion = schemaVersion
     }
 }
 

--- a/Sources/Usage/Wire.swift
+++ b/Sources/Usage/Wire.swift
@@ -108,7 +108,8 @@ public let wireSchemaVersion = 2
 
 /// The request body posted to the ingest endpoint. Attribution is either a
 /// publishable `key` or — keyless, off-browser — the app identity in `app`.
-/// Field order on the wire follows declaration order.
+/// `buildBody` emits keys in sorted order (see the exact-JSON test), so the
+/// declaration order here is not the wire order.
 ///
 /// `batchId` (schema 2) is minted once per body. It is the delivery contract:
 /// a server can de-duplicate on (batchId, event index) whatever sits between

--- a/Tests/UsageTests/UsageClientTests.swift
+++ b/Tests/UsageTests/UsageClientTests.swift
@@ -249,3 +249,49 @@ struct WireTests {
         #expect(parts[2].first == "4") // version nibble
     }
 }
+
+// Wire schema 2: session id, batch id, schema version (decision memo step 3b).
+struct UsageWireSchema2Tests {
+    @Test func turnstileAndDeltasShareOneSessionId() {
+        let h = Harness(UsageState(lastActiveAt: 0))
+        h.client.start()
+        h.client.flush()                 // turnstile
+        h.client.recordCall(3)
+        h.client.flush()                 // delta
+        #expect(h.sent.count == 2)
+        let ids = h.events.map(\.sessionId)
+        #expect(ids.count == 2)
+        #expect(ids[0] != nil)
+        #expect(ids[0] == ids[1])
+        #expect(ids[0] == h.client.sessionId)
+    }
+
+    @Test func eachBodyHasItsOwnBatchIdAndDeclaresSchema2() {
+        let h = Harness(UsageState(lastActiveAt: 0))
+        h.client.start()
+        h.client.flush()
+        h.client.recordCall()
+        h.client.flush()
+        let batches = h.sent.map(\.body.batchId)
+        #expect(batches.allSatisfy { $0 != nil })
+        #expect(batches[0] != batches[1])
+        #expect(h.sent.allSatisfy { $0.body.schemaVersion == wireSchemaVersion })
+        #expect(wireSchemaVersion == 2)
+    }
+
+    @Test func twoClientsHaveDifferentSessionIds() {
+        let a = Harness(UsageState(lastActiveAt: 0))
+        let b = Harness(UsageState(lastActiveAt: 0))
+        #expect(a.client.sessionId != b.client.sessionId)
+    }
+
+    @Test func schema2FieldsAreOnTheWire() throws {
+        let h = Harness(UsageState(lastActiveAt: 0))
+        h.client.start()
+        h.client.flush()
+        let json = try buildBody(h.sent[0].body)
+        #expect(json.contains("\"batchId\":\""))
+        #expect(json.contains("\"schemaVersion\":2"))
+        #expect(json.contains("\"sessionId\":\""))
+    }
+}

--- a/Tests/UsageTests/UsageClientTests.swift
+++ b/Tests/UsageTests/UsageClientTests.swift
@@ -285,6 +285,35 @@ struct UsageWireSchema2Tests {
         #expect(a.client.sessionId != b.client.sessionId)
     }
 
+    @Test func aNewTurnstileOpensANewSession() {
+        let h = Harness(UsageState(lastActiveAt: 0))
+        h.client.start()
+        h.client.flush()
+        let first = h.events[0].sessionId
+        h.advance(dayMs)          // window elapsed: the next start() opens a new turnstile
+        h.client.start()
+        h.client.flush()
+        #expect(h.sent.count == 2)
+        #expect(h.events[1].sessionId != nil)
+        #expect(h.events[1].sessionId != first)
+    }
+
+    @Test func firstDeltaIsNotHeldForAWholeInterval() {
+        let h = Harness(UsageState(lastActiveAt: 0), emitIntervalMs: quarterHourMs)
+        h.client.start()
+        h.client.flush()          // turnstile
+        h.client.recordCall(4)
+        h.advance(3_000)
+        h.client.flush()          // first delta: must go out now, not 15 min later
+        #expect(h.sent.count == 2)
+        #expect(h.events[1].callCount == 4)
+        h.client.recordCall(1)
+        h.advance(3_000)
+        h.client.flush()          // second delta inside the interval: coalesced
+        #expect(h.sent.count == 2)
+        #expect(h.state.carryCallCount == 1)
+    }
+
     @Test func schema2FieldsAreOnTheWire() throws {
         let h = Harness(UsageState(lastActiveAt: 0))
         h.client.start()


### PR DESCRIPTION
## Summary
- Wire schema 2 for usage telemetry: one `sessionId` per SDK client lifetime, a fresh `batchId` (UUID) + `schemaVersion: 2` per POST body, so the server can fold a retried/replayed batch once (dal-core PR #28).
- Deltas are coalesced client-side every 15 min; a turnstile opens a new session id; the first delta is not held for a whole interval.
- Posts to the dedicated `events.*` ingest host instead of `platform.*`.
- Persisted state is namespaced per SDK so two SDKs in one app never share a session.

Server side: Desert-Ant-Labs/dal-core#28 (`docs/ingest-api.md` is the contract).

## Test plan
- [x] `UsageClientTests` cover session id per client, batch id per body, coalescing interval, first-delta timing (verified with swiftly Swift 6.2 via a standalone smoke package; repo tests need Xcode 26.6)
- [ ] Point a debug build at staging `events.` host and confirm rows carry `batch_id`/`session_id` in the raw tier
